### PR TITLE
Add search with autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A modern, responsive Next.js 15 dashboard for real-time theme park statistics an
 - **Interactive Charts** - Visualize wait times and park data
 - **Mobile Optimized** - Perfect experience on all devices
 - **Localized Formatting** - Dates, times, and numbers in your local format
+- **Search with Autocomplete** - Quickly find parks and rides
 
 ## 🚀 Tech Stack
 

--- a/app/api/search/parks/route.ts
+++ b/app/api/search/parks/route.ts
@@ -11,8 +11,9 @@ export async function GET(request: Request) {
   }
 
   try {
+    const fields = 'id,name,country,hierarchicalUrl';
     const resp = await fetch(
-      `${API_BASE_URL}/parks?search=${encodeURIComponent(query)}&limit=${limit}`,
+      `${API_BASE_URL}/parks?search=${encodeURIComponent(query)}&limit=${limit}&fields=${fields}`,
       {
         headers: API_HEADERS,
       }

--- a/app/api/search/parks/route.ts
+++ b/app/api/search/parks/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { API_BASE_URL, API_HEADERS } from '@/lib/config';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('search') ?? '';
+  const limit = searchParams.get('limit') ?? '5';
+
+  if (!query) {
+    return NextResponse.json({ data: [] });
+  }
+
+  try {
+    const resp = await fetch(
+      `${API_BASE_URL}/parks?search=${encodeURIComponent(query)}&limit=${limit}`,
+      {
+        headers: API_HEADERS,
+      }
+    );
+
+    if (!resp.ok) {
+      throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+    }
+
+    const data = await resp.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('Error searching parks:', err);
+    return NextResponse.json({ data: [] }, { status: 500 });
+  }
+}

--- a/app/api/search/rides/route.ts
+++ b/app/api/search/rides/route.ts
@@ -11,8 +11,9 @@ export async function GET(request: Request) {
   }
 
   try {
+    const fields = 'id,name,hierarchicalUrl,park.name,park.country';
     const resp = await fetch(
-      `${API_BASE_URL}/rides?search=${encodeURIComponent(query)}&limit=${limit}`,
+      `${API_BASE_URL}/rides?search=${encodeURIComponent(query)}&limit=${limit}&fields=${fields}`,
       {
         headers: API_HEADERS,
       }

--- a/app/api/search/rides/route.ts
+++ b/app/api/search/rides/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { API_BASE_URL, API_HEADERS } from '@/lib/config';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('search') ?? '';
+  const limit = searchParams.get('limit') ?? '5';
+
+  if (!query) {
+    return NextResponse.json({ data: [] });
+  }
+
+  try {
+    const resp = await fetch(
+      `${API_BASE_URL}/rides?search=${encodeURIComponent(query)}&limit=${limit}`,
+      {
+        headers: API_HEADERS,
+      }
+    );
+
+    if (!resp.ok) {
+      throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+    }
+
+    const data = await resp.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('Error searching rides:', err);
+    return NextResponse.json({ data: [] }, { status: 500 });
+  }
+}

--- a/components/interactive/search-autocomplete.tsx
+++ b/components/interactive/search-autocomplete.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Search } from 'lucide-react';
-import { searchParks, searchRides } from '../../lib/api';
+import { searchParks, searchRides, getCountryFlag } from '../../lib/api';
 import { SearchParkResult, SearchRideResult } from '../../lib/park-types';
 import { cn } from '../../lib/utils';
 
@@ -133,13 +133,14 @@ export function SearchAutocomplete() {
                   href={park.hierarchicalUrl}
                   tabIndex={-1}
                   className={cn(
-                    'block px-2 py-1 rounded-md hover:bg-muted',
+                    'block px-2 py-1 rounded-md hover:bg-muted flex items-center gap-2',
                     activeIndex === idx && 'bg-accent text-accent-foreground'
                   )}
                   onMouseEnter={() => setActiveIndex(idx)}
                   onClick={() => setOpen(false)}
                 >
-                  {park.name}
+                  <span className="text-lg">{getCountryFlag(park.country)}</span>
+                  <span className="truncate">{park.name}</span>
                 </Link>
               ))}
             </div>
@@ -155,14 +156,17 @@ export function SearchAutocomplete() {
                     href={ride.hierarchicalUrl}
                     tabIndex={-1}
                     className={cn(
-                      'block px-2 py-1 rounded-md hover:bg-muted',
+                      'block px-2 py-1 rounded-md hover:bg-muted flex items-center gap-2',
                       activeIndex === globalIndex && 'bg-accent text-accent-foreground'
                     )}
                     onMouseEnter={() => setActiveIndex(globalIndex)}
                     onClick={() => setOpen(false)}
                   >
-                    {ride.name}{' '}
-                    <span className="text-muted-foreground text-xs">({ride.parkName})</span>
+                    <span className="text-lg">{getCountryFlag(ride.country)}</span>
+                    <span className="truncate">
+                      {ride.name}{' '}
+                      <span className="text-muted-foreground text-xs">({ride.parkName})</span>
+                    </span>
                   </Link>
                 );
               })}

--- a/components/interactive/search-autocomplete.tsx
+++ b/components/interactive/search-autocomplete.tsx
@@ -36,7 +36,7 @@ export function SearchAutocomplete() {
   }, [query]);
 
   return (
-    <div className="relative w-64">
+    <div className="relative w-40 sm:w-64 transition-all duration-300 focus-within:w-60 sm:focus-within:w-72">
       <div className="relative">
         <Search className="w-4 h-4 absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
         <input
@@ -50,7 +50,7 @@ export function SearchAutocomplete() {
         />
       </div>
       {open && (parks.length > 0 || rides.length > 0) && (
-        <div className="absolute z-50 mt-1 w-full bg-background border border-border rounded-md shadow-md max-h-60 overflow-y-auto">
+        <div className="absolute z-50 mt-1 w-full bg-card border border-border rounded-md shadow-md max-h-60 overflow-y-auto animate-slide-down">
           {parks.length > 0 && (
             <div className="p-2">
               <p className="text-xs font-semibold text-muted-foreground mb-1">Parks</p>

--- a/components/interactive/search-autocomplete.tsx
+++ b/components/interactive/search-autocomplete.tsx
@@ -17,6 +17,7 @@ export function SearchAutocomplete() {
   const timer = useRef<NodeJS.Timeout | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
 
   useEffect(() => {
@@ -51,8 +52,20 @@ export function SearchAutocomplete() {
     }
   }, [activeIndex]);
 
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setActiveIndex(-1);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
   return (
     <div
+      ref={containerRef}
       className={cn(
         'relative transition-all duration-300 focus-within:w-60 sm:focus-within:w-72',
         query.length === 0 ? 'w-32 sm:w-48' : 'w-40 sm:w-64'
@@ -66,12 +79,14 @@ export function SearchAutocomplete() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onFocus={() => query.length >= 2 && setOpen(true)}
-          onBlur={() => setTimeout(() => setOpen(false), 100)}
           onKeyDown={(e) => {
             if (e.key === 'ArrowDown') {
               e.preventDefault();
               if (!open) setOpen(true);
               setActiveIndex(0);
+            } else if (e.key === 'Escape') {
+              setOpen(false);
+              setActiveIndex(-1);
             }
           }}
           className="w-full pl-7 pr-3 py-2 text-sm rounded-md bg-muted/40 focus:outline-none focus:ring-2 focus:ring-primary"
@@ -122,6 +137,7 @@ export function SearchAutocomplete() {
                     activeIndex === idx && 'bg-accent text-accent-foreground'
                   )}
                   onMouseEnter={() => setActiveIndex(idx)}
+                  onClick={() => setOpen(false)}
                 >
                   {park.name}
                 </Link>
@@ -143,6 +159,7 @@ export function SearchAutocomplete() {
                       activeIndex === globalIndex && 'bg-accent text-accent-foreground'
                     )}
                     onMouseEnter={() => setActiveIndex(globalIndex)}
+                    onClick={() => setOpen(false)}
                   >
                     {ride.name}{' '}
                     <span className="text-muted-foreground text-xs">({ride.parkName})</span>

--- a/components/interactive/search-autocomplete.tsx
+++ b/components/interactive/search-autocomplete.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Search } from 'lucide-react';
 import { searchParks, searchRides } from '../../lib/api';
 import { SearchParkResult, SearchRideResult } from '../../lib/park-types';
+import { cn } from '../../lib/utils';
 
 export function SearchAutocomplete() {
   const [query, setQuery] = useState('');
@@ -36,7 +37,12 @@ export function SearchAutocomplete() {
   }, [query]);
 
   return (
-    <div className="relative w-40 sm:w-64 transition-all duration-300 focus-within:w-60 sm:focus-within:w-72">
+    <div
+      className={cn(
+        'relative transition-all duration-300 focus-within:w-60 sm:focus-within:w-72',
+        query.length === 0 ? 'w-32 sm:w-48' : 'w-40 sm:w-64'
+      )}
+    >
       <div className="relative">
         <Search className="w-4 h-4 absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
         <input
@@ -50,7 +56,7 @@ export function SearchAutocomplete() {
         />
       </div>
       {open && (parks.length > 0 || rides.length > 0) && (
-        <div className="absolute z-50 mt-1 w-full bg-card border border-border rounded-md shadow-md max-h-60 overflow-y-auto animate-slide-down">
+        <div className="absolute z-50 mt-1 w-full bg-background border border-border rounded-md shadow-md max-h-60 overflow-y-auto animate-slide-down">
           {parks.length > 0 && (
             <div className="p-2">
               <p className="text-xs font-semibold text-muted-foreground mb-1">Parks</p>

--- a/components/interactive/search-autocomplete.tsx
+++ b/components/interactive/search-autocomplete.tsx
@@ -107,7 +107,7 @@ export function SearchAutocomplete() {
               }
             }
           }}
-          className="absolute z-50 mt-1 w-full bg-popover border border-border rounded-md shadow-md max-h-60 overflow-y-auto animate-slide-down"
+          className="absolute z-50 mt-1 w-full bg-background border border-border rounded-md shadow-md max-h-60 overflow-y-auto animate-slide-down"
         >
           {parks.length > 0 && (
             <div className="p-2">

--- a/components/interactive/search-autocomplete.tsx
+++ b/components/interactive/search-autocomplete.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import Link from 'next/link';
+import { Search } from 'lucide-react';
+import { searchParks, searchRides } from '../../lib/api';
+import { SearchParkResult, SearchRideResult } from '../../lib/park-types';
+
+export function SearchAutocomplete() {
+  const [query, setQuery] = useState('');
+  const [parks, setParks] = useState<SearchParkResult[]>([]);
+  const [rides, setRides] = useState<SearchRideResult[]>([]);
+  const [open, setOpen] = useState(false);
+  const timer = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (query.length < 2) {
+      setParks([]);
+      setRides([]);
+      return;
+    }
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(async () => {
+      try {
+        const [p, r] = await Promise.all([searchParks(query), searchRides(query)]);
+        setParks(p);
+        setRides(r);
+        setOpen(true);
+      } catch (e) {
+        console.error(e);
+      }
+    }, 300);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [query]);
+
+  return (
+    <div className="relative w-64">
+      <div className="relative">
+        <Search className="w-4 h-4 absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => query.length >= 2 && setOpen(true)}
+          onBlur={() => setTimeout(() => setOpen(false), 100)}
+          className="w-full pl-7 pr-3 py-2 text-sm rounded-md bg-muted/40 focus:outline-none focus:ring-2 focus:ring-primary"
+          placeholder="Search parks or rides"
+        />
+      </div>
+      {open && (parks.length > 0 || rides.length > 0) && (
+        <div className="absolute z-50 mt-1 w-full bg-background border border-border rounded-md shadow-md max-h-60 overflow-y-auto">
+          {parks.length > 0 && (
+            <div className="p-2">
+              <p className="text-xs font-semibold text-muted-foreground mb-1">Parks</p>
+              {parks.map((park) => (
+                <Link
+                  key={`park-${park.id}`}
+                  href={park.hierarchicalUrl}
+                  className="block px-2 py-1 rounded-md hover:bg-muted"
+                >
+                  {park.name}
+                </Link>
+              ))}
+            </div>
+          )}
+          {rides.length > 0 && (
+            <div className="p-2 border-t border-border">
+              <p className="text-xs font-semibold text-muted-foreground mb-1">Rides</p>
+              {rides.map((ride) => (
+                <Link
+                  key={`ride-${ride.id}`}
+                  href={ride.hierarchicalUrl}
+                  className="block px-2 py-1 rounded-md hover:bg-muted"
+                >
+                  {ride.name}{' '}
+                  <span className="text-muted-foreground text-xs">({ride.parkName})</span>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import { Menu, X, BarChart3, MapPin } from 'lucide-react';
 import { ThemeToggle } from '../interactive/theme-toggle';
 import { Button } from '../ui/button';
+import { SearchAutocomplete } from '../interactive/search-autocomplete';
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: BarChart3 },
@@ -59,6 +60,7 @@ export function Navbar() {
           </div>
 
           <div className="hidden sm:ml-6 sm:flex sm:items-center sm:space-x-4">
+            <SearchAutocomplete />
             <ThemeToggle />
           </div>
 
@@ -86,6 +88,9 @@ export function Navbar() {
       {isOpen && (
         <div className="sm:hidden" id="mobile-menu">
           <div className="pt-2 pb-3 space-y-1 bg-background border-t border-border" role="menu">
+            <div className="px-4 pb-3">
+              <SearchAutocomplete />
+            </div>
             {navigation.map((item) => {
               const Icon = item.icon;
               const isActive = pathname === item.href;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -300,6 +300,15 @@ export async function fetchRideDetails(
   }
 }
 
+interface SearchParksApiResponse {
+  data: Array<{
+    id: number;
+    name: string;
+    country: string;
+    hierarchicalUrl: string;
+  }>;
+}
+
 export async function searchParks(query: string, limit = 5): Promise<SearchParkResult[]> {
   try {
     const response = await fetch(
@@ -313,8 +322,8 @@ export async function searchParks(query: string, limit = 5): Promise<SearchParkR
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
 
-    const data = await response.json();
-    return (data.data || []).map((park: any) => ({
+    const data = (await response.json()) as SearchParksApiResponse;
+    return (data.data || []).map((park) => ({
       id: park.id,
       name: park.name,
       country: park.country,
@@ -324,6 +333,15 @@ export async function searchParks(query: string, limit = 5): Promise<SearchParkR
     console.error('Failed to search parks:', error);
     return [];
   }
+}
+
+interface SearchRidesApiResponse {
+  data: Array<{
+    id: number;
+    name: string;
+    park: { name: string } | null;
+    hierarchicalUrl: string;
+  }>;
 }
 
 export async function searchRides(query: string, limit = 5): Promise<SearchRideResult[]> {
@@ -339,11 +357,11 @@ export async function searchRides(query: string, limit = 5): Promise<SearchRideR
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
 
-    const data = await response.json();
-    return (data.data || []).map((ride: any) => ({
+    const data = (await response.json()) as SearchRidesApiResponse;
+    return (data.data || []).map((ride) => ({
       id: ride.id,
       name: ride.name,
-      parkName: ride.park?.name,
+      parkName: ride.park?.name ?? '',
       hierarchicalUrl: ride.hierarchicalUrl,
     }));
   } catch (error) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -7,6 +7,7 @@ import {
   ContinentStats,
 } from './api-types';
 import { API_BASE_URL, API_HEADERS, API_REVALIDATE_CONFIG } from './config';
+import { SearchParkResult, SearchRideResult } from './park-types';
 import { toSlug } from './utils';
 
 export async function fetchStatistics(): Promise<StatisticsData> {
@@ -296,6 +297,58 @@ export async function fetchRideDetails(
   } catch (error) {
     console.error(`Failed to fetch ride details for ${ride}:`, error);
     throw error;
+  }
+}
+
+export async function searchParks(query: string, limit = 5): Promise<SearchParkResult[]> {
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/parks?search=${encodeURIComponent(query)}&limit=${limit}`,
+      {
+        headers: API_HEADERS,
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return (data.data || []).map((park: any) => ({
+      id: park.id,
+      name: park.name,
+      country: park.country,
+      hierarchicalUrl: park.hierarchicalUrl,
+    }));
+  } catch (error) {
+    console.error('Failed to search parks:', error);
+    return [];
+  }
+}
+
+export async function searchRides(query: string, limit = 5): Promise<SearchRideResult[]> {
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/rides?search=${encodeURIComponent(query)}&limit=${limit}`,
+      {
+        headers: API_HEADERS,
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return (data.data || []).map((ride: any) => ({
+      id: ride.id,
+      name: ride.name,
+      parkName: ride.park?.name,
+      hierarchicalUrl: ride.hierarchicalUrl,
+    }));
+  } catch (error) {
+    console.error('Failed to search rides:', error);
+    return [];
   }
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -311,12 +311,14 @@ interface SearchParksApiResponse {
 
 export async function searchParks(query: string, limit = 5): Promise<SearchParkResult[]> {
   try {
-    const response = await fetch(
-      `${API_BASE_URL}/parks?search=${encodeURIComponent(query)}&limit=${limit}`,
-      {
-        headers: API_HEADERS,
-      }
-    );
+    const url =
+      typeof window === 'undefined'
+        ? `${API_BASE_URL}/parks?search=${encodeURIComponent(query)}&limit=${limit}`
+        : `/api/search/parks?search=${encodeURIComponent(query)}&limit=${limit}`;
+
+    const response = await fetch(url, {
+      headers: API_HEADERS,
+    });
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -346,12 +348,14 @@ interface SearchRidesApiResponse {
 
 export async function searchRides(query: string, limit = 5): Promise<SearchRideResult[]> {
   try {
-    const response = await fetch(
-      `${API_BASE_URL}/rides?search=${encodeURIComponent(query)}&limit=${limit}`,
-      {
-        headers: API_HEADERS,
-      }
-    );
+    const url =
+      typeof window === 'undefined'
+        ? `${API_BASE_URL}/rides?search=${encodeURIComponent(query)}&limit=${limit}`
+        : `/api/search/rides?search=${encodeURIComponent(query)}&limit=${limit}`;
+
+    const response = await fetch(url, {
+      headers: API_HEADERS,
+    });
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -311,10 +311,11 @@ interface SearchParksApiResponse {
 
 export async function searchParks(query: string, limit = 5): Promise<SearchParkResult[]> {
   try {
+    const fields = 'id,name,country,hierarchicalUrl';
     const url =
       typeof window === 'undefined'
-        ? `${API_BASE_URL}/parks?search=${encodeURIComponent(query)}&limit=${limit}`
-        : `/api/search/parks?search=${encodeURIComponent(query)}&limit=${limit}`;
+        ? `${API_BASE_URL}/parks?search=${encodeURIComponent(query)}&limit=${limit}&fields=${fields}`
+        : `/api/search/parks?search=${encodeURIComponent(query)}&limit=${limit}&fields=${fields}`;
 
     const response = await fetch(url, {
       headers: API_HEADERS,
@@ -341,17 +342,18 @@ interface SearchRidesApiResponse {
   data: Array<{
     id: number;
     name: string;
-    park: { name: string } | null;
+    park: { name: string; country: string } | null;
     hierarchicalUrl: string;
   }>;
 }
 
 export async function searchRides(query: string, limit = 5): Promise<SearchRideResult[]> {
   try {
+    const fields = 'id,name,hierarchicalUrl,park.name,park.country';
     const url =
       typeof window === 'undefined'
-        ? `${API_BASE_URL}/rides?search=${encodeURIComponent(query)}&limit=${limit}`
-        : `/api/search/rides?search=${encodeURIComponent(query)}&limit=${limit}`;
+        ? `${API_BASE_URL}/rides?search=${encodeURIComponent(query)}&limit=${limit}&fields=${fields}`
+        : `/api/search/rides?search=${encodeURIComponent(query)}&limit=${limit}&fields=${fields}`;
 
     const response = await fetch(url, {
       headers: API_HEADERS,
@@ -366,6 +368,7 @@ export async function searchRides(query: string, limit = 5): Promise<SearchRideR
       id: ride.id,
       name: ride.name,
       parkName: ride.park?.name ?? '',
+      country: ride.park?.country ?? '',
       hierarchicalUrl: ride.hierarchicalUrl,
     }));
   } catch (error) {

--- a/lib/park-types.ts
+++ b/lib/park-types.ts
@@ -39,5 +39,6 @@ export interface SearchRideResult {
   id: number;
   name: string;
   parkName: string;
+  country: string;
   hierarchicalUrl: string;
 }

--- a/lib/park-types.ts
+++ b/lib/park-types.ts
@@ -26,3 +26,18 @@ export interface ParkStatsProps {
   totalRides: number;
   openRides: number;
 }
+
+// Simplified results for search/autocomplete
+export interface SearchParkResult {
+  id: number;
+  name: string;
+  country: string;
+  hierarchicalUrl: string;
+}
+
+export interface SearchRideResult {
+  id: number;
+  name: string;
+  parkName: string;
+  hierarchicalUrl: string;
+}


### PR DESCRIPTION
## Summary
- provide a SearchAutocomplete component
- expose `searchParks` and `searchRides` API helpers
- update type definitions for search results
- integrate search bar in the Navbar for desktop and mobile
- document the new feature

## Testing
- `pnpm format`
- `pnpm lint` *(fails: Command "next" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc3d43e1c832593b1ff0a2d342c8f