### PR TITLE
Improve ride slug matching

### DIFF
--- a/app/parks/[continent]/[country]/[park]/page.tsx
+++ b/app/parks/[continent]/[country]/[park]/page.tsx
@@ -8,7 +8,7 @@ import { PageBreadcrumbs } from '@/components/layout/page-breadcrumbs';
 import { WaitTimeBadge } from '@/components/wait-time-badge';
 import { fetchParkDetails, getCountryFlag, isStaticFileRequest } from '@/lib/api';
 import { formatPercentage } from '@/lib/date-utils';
-import { formatSlugToTitle, toSlug } from '@/lib/utils';
+import { formatSlugToTitle } from '@/lib/utils';
 
 interface ParkPageProps {
   params: Promise<{
@@ -64,7 +64,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
       area.rides.map((ride) => ({
         ...ride,
         themeAreaName: area.name,
-        hierarchicalUrl: ride.hierarchicalUrl || `${data.hierarchicalUrl}/${toSlug(ride.name)}`,
+        hierarchicalUrl: ride.hierarchicalUrl,
       }))
     );
 
@@ -157,9 +157,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
                       {area.rides.map((ride) => (
                         <Link
                           key={ride.id}
-                          href={
-                            ride.hierarchicalUrl || `${data.hierarchicalUrl}/${toSlug(ride.name)}`
-                          }
+                          href={ride.hierarchicalUrl}
                           className="block transition-colors hover:bg-muted rounded-lg p-3"
                         >
                           <div className="flex items-center justify-between">

--- a/app/parks/[continent]/[country]/[park]/page.tsx
+++ b/app/parks/[continent]/[country]/[park]/page.tsx
@@ -8,7 +8,7 @@ import { PageBreadcrumbs } from '@/components/layout/page-breadcrumbs';
 import { WaitTimeBadge } from '@/components/wait-time-badge';
 import { fetchParkDetails, getCountryFlag, isStaticFileRequest } from '@/lib/api';
 import { formatPercentage } from '@/lib/date-utils';
-import { formatSlugToTitle } from '@/lib/utils';
+import { formatSlugToTitle, toSlug } from '@/lib/utils';
 
 interface ParkPageProps {
   params: Promise<{
@@ -64,10 +64,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
       area.rides.map((ride) => ({
         ...ride,
         themeAreaName: area.name,
-        hierarchicalUrl: `${data.hierarchicalUrl}/${ride.name
-          .toLowerCase()
-          .replace(/[^a-z0-9\s-]/g, '')
-          .replace(/\s+/g, '-')}`,
+        hierarchicalUrl: ride.hierarchicalUrl || `${data.hierarchicalUrl}/${toSlug(ride.name)}`,
       }))
     );
 
@@ -160,10 +157,9 @@ export default async function ParkPage({ params }: ParkPageProps) {
                       {area.rides.map((ride) => (
                         <Link
                           key={ride.id}
-                          href={`${data.hierarchicalUrl}/${ride.name
-                            .toLowerCase()
-                            .replace(/[^a-z0-9\s-]/g, '')
-                            .replace(/\s+/g, '-')}`}
+                          href={
+                            ride.hierarchicalUrl || `${data.hierarchicalUrl}/${toSlug(ride.name)}`
+                          }
                           className="block transition-colors hover:bg-muted rounded-lg p-3"
                         >
                           <div className="flex items-center justify-between">

--- a/app/parks/[continent]/[country]/page.tsx
+++ b/app/parks/[continent]/[country]/page.tsx
@@ -12,7 +12,7 @@ import {
   isStaticFileRequest,
 } from '@/lib/api';
 import { formatNumber, formatPercentage } from '@/lib/date-utils';
-import { formatSlugToTitle } from '@/lib/utils';
+import { formatSlugToTitle, toSlug } from '@/lib/utils';
 
 interface CountryPageProps {
   params: Promise<{
@@ -72,10 +72,7 @@ export default async function CountryPage({ params }: CountryPageProps) {
           ...ride,
           parkName: park.name,
           parkId: park.id,
-          hierarchicalUrl: `${park.hierarchicalUrl}/${ride.name
-            .toLowerCase()
-            .replace(/[^a-z0-9\s-]/g, '')
-            .replace(/\s+/g, '-')}`,
+          hierarchicalUrl: ride.hierarchicalUrl || `${park.hierarchicalUrl}/${toSlug(ride.name)}`,
         }))
       )
     );

--- a/app/parks/[continent]/[country]/page.tsx
+++ b/app/parks/[continent]/[country]/page.tsx
@@ -12,7 +12,7 @@ import {
   isStaticFileRequest,
 } from '@/lib/api';
 import { formatNumber, formatPercentage } from '@/lib/date-utils';
-import { formatSlugToTitle, toSlug } from '@/lib/utils';
+import { formatSlugToTitle } from '@/lib/utils';
 
 interface CountryPageProps {
   params: Promise<{
@@ -72,7 +72,7 @@ export default async function CountryPage({ params }: CountryPageProps) {
           ...ride,
           parkName: park.name,
           parkId: park.id,
-          hierarchicalUrl: ride.hierarchicalUrl || `${park.hierarchicalUrl}/${toSlug(ride.name)}`,
+          hierarchicalUrl: ride.hierarchicalUrl,
         }))
       )
     );

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -181,6 +181,7 @@ export interface ContinentApiData {
           isOpen: boolean;
           lastUpdated: string;
         };
+        hierarchicalUrl: string;
       }>;
     }>;
     operatingStatus: {
@@ -266,6 +267,7 @@ export interface CountryApiData {
           isOpen: boolean;
           lastUpdated: string;
         };
+        hierarchicalUrl: string;
       }>;
     }>;
     operatingStatus: {
@@ -350,6 +352,7 @@ export interface ParkApiData {
         isOpen: boolean;
         lastUpdated: string;
       };
+      hierarchicalUrl: string;
     }>;
   }>;
   operatingStatus: {


### PR DESCRIPTION
## Summary
- use API-provided slug for park ride links when available
- map ride slugs to IDs through park data if the direct API call fails

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_685cf505f58c8325925b752b7c2fda26