### PR TITLE
Refactor hero section layout for better centering and responsiveness

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -166,7 +166,7 @@ export default async function HomePage({ params }: HomePageProps) {
                 />
               </div>
               {/* Title + Description only (search rendered separately below) */}
-              <div className="min-w-0 lg:max-w-2xl text-center lg:text-left">
+              <div className="min-w-0 lg:max-w-2xl text-center">
                 <HeroWithNearby searchPlaceholder={tHome('hero.searchPlaceholder')} hideSearch />
               </div>
             </div>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -147,7 +147,7 @@ export default async function HomePage({ params }: HomePageProps) {
         <div className="relative container mx-auto">
           <div className="flex flex-col">
             {/* Row 1: Logo left + Title/Description right */}
-            <div className="flex flex-col items-center lg:mb-16 lg:flex-row-reverse lg:items-center lg:justify-center">
+            <div className="flex flex-col items-center lg:mb-16 lg:flex-row lg:items-center lg:justify-center">
               {/* Logo – light/dark variants */}
               <div className="relative h-36 w-36 shrink-0 lg:h-72 lg:w-72">
                 <Image

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -149,7 +149,7 @@ export default async function HomePage({ params }: HomePageProps) {
             {/* Row 1: Logo left + Title/Description right */}
             <div className="flex flex-col items-center lg:mb-16 lg:flex-row lg:items-center lg:justify-center">
               {/* Logo – light/dark variants */}
-              <div className="relative h-36 w-36 shrink-0 lg:h-72 lg:w-72 xl:-mr-28">
+              <div className="relative h-36 w-36 shrink-0 lg:h-72 lg:w-72">
                 <Image
                   src="/logo-big.svg"
                   alt="park.fan"

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -147,7 +147,7 @@ export default async function HomePage({ params }: HomePageProps) {
         <div className="relative container mx-auto">
           <div className="flex flex-col">
             {/* Row 1: Logo left + Title/Description right */}
-            <div className="flex flex-col items-center lg:mb-16 lg:flex-row lg:items-center lg:justify-center">
+            <div className="flex flex-col items-center lg:mb-16 lg:flex-row-reverse lg:items-center lg:justify-center">
               {/* Logo – light/dark variants */}
               <div className="relative h-36 w-36 shrink-0 lg:h-72 lg:w-72">
                 <Image
@@ -166,7 +166,7 @@ export default async function HomePage({ params }: HomePageProps) {
                 />
               </div>
               {/* Title + Description only (search rendered separately below) */}
-              <div className="min-w-0 lg:max-w-2xl text-center">
+              <div className="min-w-0 lg:max-w-2xl text-center lg:text-left">
                 <HeroWithNearby searchPlaceholder={tHome('hero.searchPlaceholder')} hideSearch />
               </div>
             </div>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -149,7 +149,7 @@ export default async function HomePage({ params }: HomePageProps) {
             {/* Row 1: Logo left + Title/Description right */}
             <div className="flex flex-col items-center lg:mb-16 lg:flex-row lg:items-center lg:justify-center">
               {/* Logo – light/dark variants */}
-              <div className="relative h-36 w-36 shrink-0 lg:h-72 lg:w-72">
+              <div className="relative h-36 w-36 shrink-0 lg:h-72 lg:w-72 xl:-mr-28">
                 <Image
                   src="/logo-big.svg"
                   alt="park.fan"

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -144,12 +144,12 @@ export default async function HomePage({ params }: HomePageProps) {
       {/* Hero Section – static default; when user is in a park (nearby), shows "Willkommen im [Park]" + park info */}
       <section className="relative -mt-16 overflow-hidden px-4 pt-16 pb-16 sm:pb-20 md:pt-28 md:pb-24 lg:flex lg:min-h-dvh lg:flex-col lg:justify-center lg:pt-16 lg:pb-24">
         <HeroBackground imageSrc={randomHeroImage} />
-        <div className="relative container mx-auto xl:ml-28">
+        <div className="relative container mx-auto">
           <div className="flex flex-col">
             {/* Row 1: Logo left + Title/Description right */}
-            <div className="flex flex-col items-center lg:mb-16 lg:flex-row lg:items-center">
+            <div className="flex flex-col items-center lg:mb-16 lg:flex-row lg:items-center lg:justify-center">
               {/* Logo – light/dark variants */}
-              <div className="relative h-36 w-36 shrink-0 lg:h-72 lg:w-72 xl:-mr-28">
+              <div className="relative h-36 w-36 shrink-0 lg:h-72 lg:w-72">
                 <Image
                   src="/logo-big.svg"
                   alt="park.fan"
@@ -166,7 +166,7 @@ export default async function HomePage({ params }: HomePageProps) {
                 />
               </div>
               {/* Title + Description only (search rendered separately below) */}
-              <div className="min-w-0 flex-1 text-center">
+              <div className="min-w-0 lg:max-w-2xl text-center">
                 <HeroWithNearby searchPlaceholder={tHome('hero.searchPlaceholder')} hideSearch />
               </div>
             </div>


### PR DESCRIPTION
## Summary
Adjusted the hero section layout to improve visual centering and remove unnecessary horizontal offsets that were causing alignment issues on larger screens.

## Key Changes
- Removed `xl:ml-28` margin from the main container to eliminate the left offset on extra-large screens
- Removed `xl:-mr-28` negative margin from the logo to prevent it from overlapping with content
- Added `lg:justify-center` to the flex row to ensure proper horizontal centering on large screens
- Changed the title/description container from `flex-1` to use `lg:max-w-2xl` for better width control and centering behavior

## Implementation Details
These changes work together to create a more balanced, centered hero section:
- The container no longer shifts left on XL screens, providing consistent alignment
- The logo no longer uses negative margins to compensate for container offsets
- The flex row now explicitly centers its children horizontally on large screens
- The title/description area has a defined maximum width instead of expanding to fill available space, allowing it to center properly within the layout

https://claude.ai/code/session_01EAGiAN1jqxkz98LHobyz6q