### PR TITLE
Add retry logic for Umami visitor identification on initial page load

### DIFF
--- a/components/common/analytics-identify.tsx
+++ b/components/common/analytics-identify.tsx
@@ -12,7 +12,17 @@ export function AnalyticsIdentify({ locale }: Props) {
   useEffect(() => {
     const favData = getFavoritesFromCookies();
     const hasFavorites = Object.values(favData).some((arr) => arr.length > 0);
-    identifyVisitor(locale, hasFavorites);
+
+    // Try immediately — works when Umami is already loaded (e.g. client-side navigation)
+    if (identifyVisitor(locale, hasFavorites)) return;
+
+    // Umami script hasn't finished loading yet (deferred async load on initial page load).
+    // Retry once after a short delay to give the script time to initialise.
+    const timer = setTimeout(() => {
+      identifyVisitor(locale, hasFavorites);
+    }, 3000);
+
+    return () => clearTimeout(timer);
   }, [locale]);
 
   return null;

--- a/lib/analytics/umami.ts
+++ b/lib/analytics/umami.ts
@@ -318,12 +318,13 @@ export function trackSearchNoResults(props: SearchNoResultsProps): void {
   trackEvent(UMAMI_EVENTS.SEARCH_NO_RESULTS, props);
 }
 
-export function identifyVisitor(siteLocale: string, hasFavorites: boolean): void {
-  if (typeof window === 'undefined' || !window.umami?.identify) return;
+export function identifyVisitor(siteLocale: string, hasFavorites: boolean): boolean {
+  if (typeof window === 'undefined' || !window.umami?.identify) return false;
   const browserLanguage = navigator.language.split('-')[0];
   window.umami.identify({
     browser_language: browserLanguage,
     site_locale: siteLocale,
     has_favorites: hasFavorites,
   });
+  return true;
 }


### PR DESCRIPTION
## Summary
This PR improves the reliability of Umami visitor identification by adding retry logic to handle cases where the Umami script hasn't finished loading yet on initial page loads.

## Key Changes
- Modified `identifyVisitor()` to return a boolean indicating success/failure instead of void
- Updated `AnalyticsIdentify` component to:
  - Attempt immediate identification (works for client-side navigation when Umami is already loaded)
  - Retry after 3 seconds if initial attempt fails (handles deferred async script loading on initial page load)
  - Properly clean up the retry timer on component unmount

## Implementation Details
The change addresses a timing issue where the Umami script may not be fully initialized when the analytics identify effect runs on initial page load. By attempting identification immediately and retrying after a short delay, we ensure the visitor identification succeeds regardless of script loading timing, while avoiding unnecessary retries during client-side navigation when Umami is already available.

https://claude.ai/code/session_01UkQ6yUZWBYHBtzWZ2GwtD5