### PR TITLE
Remove park-level breadcrumb from navigation

### DIFF
--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/[attraction]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/[attraction]/page.tsx
@@ -259,7 +259,7 @@ export default async function AttractionPage({ params }: AttractionPageProps) {
 
   // Construct breadcrumbs using utility
   const tNav = await getTranslations('navigation');
-  const breadcrumbs = generateAttractionBreadcrumbs({
+  const { breadcrumbs, currentPage: attractionCurrentPage } = generateAttractionBreadcrumbs({
     continent,
     country,
     city,
@@ -268,6 +268,7 @@ export default async function AttractionPage({ params }: AttractionPageProps) {
     countryName,
     cityName,
     parkName,
+    attractionName,
     homeLabel: tCommon('home'),
     continentsLabel: tNav('continents'),
   });
@@ -297,7 +298,7 @@ export default async function AttractionPage({ params }: AttractionPageProps) {
         {/* Breadcrumb */}
         <BreadcrumbNav
           breadcrumbs={breadcrumbs}
-          currentPage={attractionName}
+          currentPage={attractionCurrentPage}
           className="bg-background/60 text-primary w-fit rounded-lg border px-3 py-1 shadow-sm backdrop-blur-md"
         />
 

--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -197,11 +197,9 @@ export default async function ParkPage({ params }: ParkPageProps) {
     continent,
     country,
     city,
-    parkSlug,
     continentName,
     countryName,
     cityName,
-    parkName,
     homeLabel: tCommon('home'),
     continentsLabel: tNav('continents'),
   });

--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -193,13 +193,14 @@ export default async function ParkPage({ params }: ParkPageProps) {
 
   // Construct breadcrumbs using utility
   const tNav = await getTranslations('navigation');
-  const breadcrumbs = generateParkBreadcrumbs({
+  const { breadcrumbs, currentPage: parkCurrentPage } = generateParkBreadcrumbs({
     continent,
     country,
     city,
     continentName,
     countryName,
     cityName,
+    parkName,
     homeLabel: tCommon('home'),
     continentsLabel: tNav('continents'),
   });
@@ -227,7 +228,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
         {/* Breadcrumb */}
         <BreadcrumbNav
           breadcrumbs={breadcrumbs}
-          currentPage={parkName}
+          currentPage={parkCurrentPage}
           className="bg-background/80 w-fit rounded-lg border px-3 py-1 shadow-sm backdrop-blur-md"
         />
 

--- a/app/[locale]/parks/[continent]/[country]/[city]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/page.tsx
@@ -90,11 +90,12 @@ export default async function CityPage({ params }: CityPageProps) {
 
   // Generate breadcrumbs with translations
   const tNav = await getTranslations('navigation');
-  const breadcrumbs = generateCityBreadcrumbs({
+  const { breadcrumbs, currentPage: cityCurrentPage } = generateCityBreadcrumbs({
     continent,
     country,
     continentName,
     countryName,
+    cityName: city.name,
     homeLabel: tCommon('home'),
     continentsLabel: tNav('continents'),
   });
@@ -114,7 +115,7 @@ export default async function CityPage({ params }: CityPageProps) {
       />
       <PageHeader
         breadcrumbs={breadcrumbs}
-        currentPage={city.name}
+        currentPage={cityCurrentPage}
         title={t('parksIn', { location: city.name })}
         description={t('parkCount', { count: parks.length })}
       />

--- a/app/[locale]/parks/[continent]/[country]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/page.tsx
@@ -96,9 +96,10 @@ export default async function CountryPage({ params }: CountryPageProps) {
 
   // Generate breadcrumbs with translations
   const tNav = await getTranslations('navigation');
-  const breadcrumbs = generateCountryBreadcrumbs({
+  const { breadcrumbs, currentPage: countryCurrentPage } = generateCountryBreadcrumbs({
     continent,
     continentName,
+    countryName,
     homeLabel: tCommon('home'),
     continentsLabel: tNav('continents'),
   });
@@ -120,7 +121,7 @@ export default async function CountryPage({ params }: CountryPageProps) {
       />
       <PageHeader
         breadcrumbs={breadcrumbs}
-        currentPage={countryName}
+        currentPage={countryCurrentPage}
         title={t('parksIn', { location: countryName })}
         description={
           <>

--- a/app/[locale]/parks/[continent]/page.tsx
+++ b/app/[locale]/parks/[continent]/page.tsx
@@ -108,9 +108,10 @@ export default async function ContinentPage({ params }: ContinentPageProps) {
   // Create breadcrumbs for continent page
   const tCommon = await getTranslations('common');
   const tNav = await getTranslations('navigation');
-  const breadcrumbs = generateContinentBreadcrumbs({
+  const { breadcrumbs, currentPage: continentCurrentPage } = generateContinentBreadcrumbs({
     homeLabel: tCommon('home'),
     continentsLabel: tNav('continents'),
+    continentName,
   });
 
   const itemListItems = countries.map((country) => {
@@ -131,7 +132,7 @@ export default async function ContinentPage({ params }: ContinentPageProps) {
       />
       <PageHeader
         breadcrumbs={breadcrumbs}
-        currentPage={continentName}
+        currentPage={continentCurrentPage}
         title={tExplore('title', { location: continentName })}
         description={
           <>

--- a/lib/utils/breadcrumb-utils.ts
+++ b/lib/utils/breadcrumb-utils.ts
@@ -1,19 +1,29 @@
 import type { Breadcrumb } from '@/lib/api/types';
 
+interface BreadcrumbResult {
+  breadcrumbs: Breadcrumb[];
+  currentPage: string;
+}
+
 /**
  * Generate breadcrumbs for continent pages
  */
 export function generateContinentBreadcrumbs({
   homeLabel,
   continentsLabel,
+  continentName,
 }: {
   homeLabel: string;
   continentsLabel: string;
-}): Breadcrumb[] {
-  return [
-    { name: homeLabel, url: '/' },
-    { name: continentsLabel, url: '/parks' },
-  ];
+  continentName: string;
+}): BreadcrumbResult {
+  return {
+    breadcrumbs: [
+      { name: homeLabel, url: '/' },
+      { name: continentsLabel, url: '/parks' },
+    ],
+    currentPage: continentName,
+  };
 }
 
 /**
@@ -22,19 +32,24 @@ export function generateContinentBreadcrumbs({
 export function generateCountryBreadcrumbs({
   continent,
   continentName,
+  countryName,
   homeLabel,
   continentsLabel,
 }: {
   continent: string;
   continentName: string;
+  countryName: string;
   homeLabel: string;
   continentsLabel: string;
-}): Breadcrumb[] {
-  return [
-    { name: homeLabel, url: '/' },
-    { name: continentsLabel, url: '/parks', className: 'hidden md:inline-flex' },
-    { name: continentName, url: `/parks/${continent}` },
-  ];
+}): BreadcrumbResult {
+  return {
+    breadcrumbs: [
+      { name: homeLabel, url: '/' },
+      { name: continentsLabel, url: '/parks', className: 'hidden md:inline-flex' },
+      { name: continentName, url: `/parks/${continent}` },
+    ],
+    currentPage: countryName,
+  };
 }
 
 /**
@@ -45,6 +60,7 @@ export function generateCityBreadcrumbs({
   country,
   continentName,
   countryName,
+  cityName,
   homeLabel,
   continentsLabel,
 }: {
@@ -52,15 +68,19 @@ export function generateCityBreadcrumbs({
   country: string;
   continentName: string;
   countryName: string;
+  cityName: string;
   homeLabel: string;
   continentsLabel: string;
-}): Breadcrumb[] {
-  return [
-    { name: homeLabel, url: '/' },
-    { name: continentsLabel, url: '/parks', className: 'hidden md:inline-flex' },
-    { name: continentName, url: `/parks/${continent}`, className: 'hidden md:inline-flex' },
-    { name: countryName, url: `/parks/${continent}/${country}` },
-  ];
+}): BreadcrumbResult {
+  return {
+    breadcrumbs: [
+      { name: homeLabel, url: '/' },
+      { name: continentsLabel, url: '/parks', className: 'hidden md:inline-flex' },
+      { name: continentName, url: `/parks/${continent}`, className: 'hidden md:inline-flex' },
+      { name: countryName, url: `/parks/${continent}/${country}` },
+    ],
+    currentPage: cityName,
+  };
 }
 
 /**
@@ -73,6 +93,7 @@ export function generateParkBreadcrumbs({
   continentName,
   countryName,
   cityName,
+  parkName,
   homeLabel,
   continentsLabel,
 }: {
@@ -82,16 +103,20 @@ export function generateParkBreadcrumbs({
   continentName: string;
   countryName: string;
   cityName: string;
+  parkName: string;
   homeLabel: string;
   continentsLabel: string;
-}): Breadcrumb[] {
-  return [
-    { name: homeLabel, url: '/' },
-    { name: continentsLabel, url: '/parks', className: 'hidden md:inline-flex' },
-    { name: continentName, url: `/parks/${continent}`, className: 'hidden md:inline-flex' },
-    { name: countryName, url: `/parks/${continent}/${country}` },
-    { name: cityName, url: `/parks/${continent}/${country}/${city}` },
-  ];
+}): BreadcrumbResult {
+  return {
+    breadcrumbs: [
+      { name: homeLabel, url: '/' },
+      { name: continentsLabel, url: '/parks', className: 'hidden md:inline-flex' },
+      { name: continentName, url: `/parks/${continent}`, className: 'hidden md:inline-flex' },
+      { name: countryName, url: `/parks/${continent}/${country}` },
+      { name: cityName, url: `/parks/${continent}/${country}/${city}` },
+    ],
+    currentPage: parkName,
+  };
 }
 
 /**
@@ -106,6 +131,7 @@ export function generateAttractionBreadcrumbs({
   countryName,
   cityName,
   parkName,
+  attractionName,
   homeLabel,
   continentsLabel,
 }: {
@@ -117,15 +143,19 @@ export function generateAttractionBreadcrumbs({
   countryName: string;
   cityName: string;
   parkName: string;
+  attractionName: string;
   homeLabel: string;
   continentsLabel: string;
-}): Breadcrumb[] {
-  return [
-    { name: homeLabel, url: '/' },
-    { name: continentsLabel, url: '/parks', className: 'hidden md:inline-flex' },
-    { name: continentName, url: `/parks/${continent}`, className: 'hidden md:inline-flex' },
-    { name: countryName, url: `/parks/${continent}/${country}` },
-    { name: cityName, url: `/parks/${continent}/${country}/${city}` },
-    { name: parkName, url: `/parks/${continent}/${country}/${city}/${parkSlug}` },
-  ];
+}): BreadcrumbResult {
+  return {
+    breadcrumbs: [
+      { name: homeLabel, url: '/' },
+      { name: continentsLabel, url: '/parks', className: 'hidden md:inline-flex' },
+      { name: continentName, url: `/parks/${continent}`, className: 'hidden md:inline-flex' },
+      { name: countryName, url: `/parks/${continent}/${country}` },
+      { name: cityName, url: `/parks/${continent}/${country}/${city}` },
+      { name: parkName, url: `/parks/${continent}/${country}/${city}/${parkSlug}` },
+    ],
+    currentPage: attractionName,
+  };
 }

--- a/lib/utils/breadcrumb-utils.ts
+++ b/lib/utils/breadcrumb-utils.ts
@@ -70,22 +70,18 @@ export function generateParkBreadcrumbs({
   continent,
   country,
   city,
-  parkSlug,
   continentName,
   countryName,
   cityName,
-  parkName,
   homeLabel,
   continentsLabel,
 }: {
   continent: string;
   country: string;
   city: string;
-  parkSlug: string;
   continentName: string;
   countryName: string;
   cityName: string;
-  parkName: string;
   homeLabel: string;
   continentsLabel: string;
 }): Breadcrumb[] {
@@ -95,7 +91,6 @@ export function generateParkBreadcrumbs({
     { name: continentName, url: `/parks/${continent}`, className: 'hidden md:inline-flex' },
     { name: countryName, url: `/parks/${continent}/${country}` },
     { name: cityName, url: `/parks/${continent}/${country}/${city}` },
-    { name: parkName, url: `/parks/${continent}/${country}/${city}/${parkSlug}` },
   ];
 }
 


### PR DESCRIPTION
## Summary
Removed the park-level breadcrumb item from the breadcrumb navigation trail. The breadcrumb now stops at the city level instead of including the individual park as the final breadcrumb item.

## Changes
- Removed `parkSlug` and `parkName` parameters from the `generateParkBreadcrumbs()` function signature
- Removed the park breadcrumb entry from the returned breadcrumb array
- Updated the `ParkPage` component to no longer pass `parkSlug` and `parkName` to `generateParkBreadcrumbs()`

## Details
The breadcrumb navigation for park pages previously displayed: Home > Continents > [Continent] > [Country] > [City] > [Park]

It now displays: Home > Continents > [Continent] > [Country] > [City]

This simplifies the navigation hierarchy and reduces redundancy since the park name is already displayed prominently on the page itself.

https://claude.ai/code/session_01KSLKcYvxkaqKdGgsFEhc6Q