### PR TITLE
Adjust park background positioning and height calculation

### DIFF
--- a/components/parks/park-background.tsx
+++ b/components/parks/park-background.tsx
@@ -9,7 +9,7 @@ export function ParkBackground({ imageSrc, alt }: ParkBackgroundProps) {
   if (!imageSrc) return null;
 
   return (
-    <div className="pointer-events-none absolute top-16 right-0 left-0 -z-10 h-[60vh] max-h-[600px] overflow-hidden select-none">
+    <div className="pointer-events-none absolute top-0 right-0 left-0 -z-10 h-[calc(60vh+4rem)] max-h-[664px] overflow-hidden select-none">
       <div className="relative h-full w-full">
         <Image
           src={imageSrc}


### PR DESCRIPTION
## Summary
Updated the park background component's positioning and sizing to extend the background image higher on the page and adjust its maximum height accordingly.

## Key Changes
- Changed `top-16` to `top-0` to position the background from the very top of the container instead of with a 4rem offset
- Updated height calculation from `h-[60vh]` to `h-[calc(60vh+4rem)]` to compensate for the removed top offset and maintain visual coverage
- Increased `max-h` constraint from `600px` to `664px` (600px + 64px/4rem) to match the new height calculation

## Implementation Details
These changes ensure the park background image extends to the top of the page while maintaining the same visual coverage area. The height is now calculated dynamically to account for the removed top padding, preventing any gaps between the background and the page header.

https://claude.ai/code/session_01B7E2fc2GwfBuQH5gRzeJvT