### PR TITLE
Improve hero background gradient with dark mode support

### DIFF
--- a/components/layout/hero-background.tsx
+++ b/components/layout/hero-background.tsx
@@ -60,7 +60,7 @@ export function HeroBackground({ imageSrc }: HeroBackgroundProps) {
   return (
     <div className="absolute inset-0 -z-10 overflow-hidden">
       <RandomHeroImage imageSrc={imageSrc} />
-      <div className="from-background via-background/70 to-muted/50 absolute inset-0 bg-gradient-to-br" />
+      <div className="absolute inset-0 bg-gradient-to-br from-background/50 via-background/20 to-transparent dark:from-background dark:via-background/70 dark:to-muted/50" />
       <div className="from-park-primary/10 absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] via-transparent to-transparent" />
     </div>
   );


### PR DESCRIPTION
## Summary
Enhanced the hero background gradient overlay to provide better visual hierarchy and improved dark mode support with distinct gradient values for light and dark themes.

## Key Changes
- Updated the gradient overlay to use more subtle values in light mode (`from-background/50 via-background/20 to-transparent`) for better image visibility
- Added dark mode-specific gradient values (`dark:from-background dark:via-background/70 dark:to-muted/50`) that maintain the original stronger overlay effect in dark mode
- Reorganized class order for better readability and maintainability

## Implementation Details
The change replaces a single gradient configuration with a responsive design that adapts to the user's color scheme preference. Light mode now uses lower opacity values to preserve the hero image visibility, while dark mode retains stronger opacity to ensure adequate contrast and readability over darker backgrounds.

https://claude.ai/code/session_01XZrtvYRSp7FFEx4xSNWPYy