### PR TITLE
Remove fallback URL construction logic across components

### DIFF
--- a/app/[locale]/parks/[continent]/[country]/[city]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/page.tsx
@@ -75,7 +75,7 @@ export default async function CityPage({ params }: CityPageProps) {
   if (!city || city.parks.length === 0) {
     // Before returning 404, check if the "city" slug is actually a park
     // This handles malformed URLs like /parks/europe/germany/phantasialand
-    // which should be /parks/europe/germany/bruhl/phantasialand
+    // which should be /parks/europe/germany/bruehl/phantasialand
     const redirectUrl = await findCityPageRedirect(continent, country, citySlug);
     if (redirectUrl) {
       permanentRedirect(`/${locale}${redirectUrl}`);

--- a/app/[locale]/search/page.tsx
+++ b/app/[locale]/search/page.tsx
@@ -85,13 +85,6 @@ function SearchResultCard({ result }: { result: SearchResultItem; locale: string
   if (result.url) {
     // Use centralized utility for URL conversion
     href = convertApiUrlToFrontendUrl(result.url);
-  } else if (result.type === 'park') {
-    // Fallback URL construction for parks
-    if (result.slug && result.city && result.country) {
-      href = `/parks/${result.continent?.toLowerCase() || 'europe'}/${result.country.toLowerCase()}/${result.city.toLowerCase().replace(/\s+/g, '-')}/${result.slug}`;
-    } else {
-      href = `/search?q=${result.name}`;
-    }
   } else if (result.parentPark && result.parentPark.url) {
     // Fallback for attractions/shows/restaurants without explicit URL
     const parkUrl = convertApiUrlToFrontendUrl(result.parentPark.url);

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -124,7 +124,7 @@ export async function Footer({ locale }: FooterProps) {
                     Europa-Park
                   </Link>
                   <Link
-                    href="/parks/europe/germany/bruhl/phantasialand"
+                    href="/parks/europe/germany/bruehl/phantasialand"
                     prefetch={false}
                     className="text-muted-foreground hover:text-foreground transition-colors"
                     aria-label="Phantasialand - Wait Times"

--- a/components/parks/attraction-card.tsx
+++ b/components/parks/attraction-card.tsx
@@ -89,15 +89,6 @@ function getHref(attraction: ParkAttraction | FavoriteAttraction, parkPath?: str
     }
   }
 
-  // For FavoriteAttraction, try to construct from park data if available
-  if ('park' in attraction && attraction.park) {
-    const favoriteAttraction = attraction as FavoriteAttraction;
-    const park = favoriteAttraction.park;
-    if (park && park.continent && park.country && park.city) {
-      return `/parks/${park.continent}/${park.country}/${park.city}/${park.slug}/${attraction.slug}`;
-    }
-  }
-
   // Fallback: use parkPath (for ParkAttraction on park detail pages)
   if (parkPath) {
     return `${parkPath}/${attraction.slug}` as '/europe/germany/rust/europa-park/blue-fire';

--- a/components/parks/favorites-section.tsx
+++ b/components/parks/favorites-section.tsx
@@ -235,13 +235,6 @@ export function FavoritesSection() {
                         }
                       }
 
-                      // If we don't have a park URL yet, construct from park data
-                      if (!parkUrl && show.park) {
-                        if (show.park.continent && show.park.country && show.park.city) {
-                          parkUrl = `/parks/${show.park.continent}/${show.park.country}/${show.park.city}/${show.park.slug}`;
-                        }
-                      }
-
                       // Build show URL with hash
                       if (parkUrl) {
                         showHref = buildShowUrl(parkUrl);
@@ -295,17 +288,6 @@ export function FavoritesSection() {
                         if (converted !== '#' && converted.startsWith('/parks/')) {
                           parkUrl = converted;
                         }
-                      }
-                    }
-
-                    // If we don't have a park URL yet, construct from park data
-                    if (!parkUrl && restaurant.park) {
-                      if (
-                        restaurant.park.continent &&
-                        restaurant.park.country &&
-                        restaurant.park.city
-                      ) {
-                        parkUrl = `/parks/${restaurant.park.continent}/${restaurant.park.country}/${restaurant.park.city}/${restaurant.park.slug}`;
                       }
                     }
 

--- a/lib/utils/url-utils.ts
+++ b/lib/utils/url-utils.ts
@@ -13,8 +13,8 @@
  * Use this whenever you receive a URL from the API response.
  *
  * Examples:
- * - /v1/parks/europe/germany/bruhl/phantasialand → /parks/europe/germany/bruhl/phantasialand
- * - /v1/parks/europe/germany/bruhl/phantasialand/attractions/taron → /parks/europe/germany/bruhl/phantasialand/taron
+ * - /v1/parks/europe/germany/bruehl/phantasialand → /parks/europe/germany/bruehl/phantasialand
+ * - /v1/parks/europe/germany/bruehl/phantasialand/attractions/taron → /parks/europe/germany/bruehl/phantasialand/taron
  * - /v1/shows/... → /parks/...#shows
  * - /v1/restaurants/... → /parks/...#restaurants
  * - /v1/discovery/... → /parks/...
@@ -174,10 +174,10 @@ export interface AttractionGeoData {
  * buildParkUrl({
  *   continent: 'europe',
  *   country: 'germany',
- *   city: 'bruhl',
+ *   city: 'bruehl',
  *   slug: 'phantasialand'
  * })
- * // Returns: '/parks/europe/germany/bruhl/phantasialand'
+ * // Returns: '/parks/europe/germany/bruehl/phantasialand'
  * ```
  */
 export function buildParkUrl(data: ParkGeoData): string {
@@ -217,11 +217,11 @@ export function buildParkUrl(data: ParkGeoData): string {
  *   park: {
  *     continent: 'europe',
  *     country: 'germany',
- *     city: 'bruhl',
+ *     city: 'bruehl',
  *     slug: 'phantasialand'
  *   }
  * })
- * // Returns: '/parks/europe/germany/bruhl/phantasialand/taron'
+ * // Returns: '/parks/europe/germany/bruehl/phantasialand/taron'
  * ```
  */
 export function buildAttractionUrlFromGeo(data: AttractionGeoData): string {


### PR DESCRIPTION
## Summary
This PR removes redundant fallback URL construction logic from multiple components. The fallback code that manually built URLs from park/attraction data is no longer needed, likely because the API now consistently provides complete URLs.

## Key Changes
- **favorites-section.tsx**: Removed fallback URL construction for both shows and restaurants that attempted to build park URLs from continent/country/city/slug data
- **attraction-card.tsx**: Removed fallback URL construction for FavoriteAttraction that built attraction URLs from park data
- **search/page.tsx**: Removed fallback URL construction for park search results that manually built URLs from slug/city/country data
- **footer.tsx**: Fixed typo in Phantasialand URL (`bruhl` → `bruehl`)

## Implementation Details
All removed code blocks followed the same pattern: checking if a URL wasn't available and attempting to construct one from individual data fields. With these removals, the components now rely on:
- Centralized URL conversion utilities (e.g., `convertApiUrlToFrontendUrl`)
- Direct URL properties from API responses
- Fallback to search or parkPath-based URLs only when necessary

This simplification reduces code duplication and makes URL handling more maintainable by centralizing the logic.

https://claude.ai/code/session_0159SycSf7QvLJvW6254fMkP