### PR TITLE
Normalize cuisine types and fix Dutch translation

### DIFF
--- a/components/seo/structured-data.tsx
+++ b/components/seo/structured-data.tsx
@@ -39,6 +39,16 @@ function JsonLd<T extends Thing>({ data }: StructuredDataProps<T>) {
 
 const SITE_URL = 'https://park.fan';
 
+/** Normalizes raw API cuisineType values to proper display names. */
+function normalizeCuisineType(cuisineType: string | null): string | undefined {
+  if (!cuisineType) return undefined;
+  const map: Record<string, string> = {
+    cafe: 'Café',
+    fondu: 'Fondue',
+  };
+  return map[cuisineType.toLowerCase()] ?? cuisineType;
+}
+
 export function OrganizationStructuredData({ description }: { description?: string }) {
   const data: WithContext<Organization> = {
     '@context': 'https://schema.org',
@@ -150,7 +160,7 @@ export function ParkStructuredData({
         ? park.restaurants.map((restaurant) => ({
             '@type': 'FoodEstablishment' as const,
             name: stripNewPrefix(restaurant.name),
-            servesCuisine: restaurant.cuisineType || undefined,
+            servesCuisine: normalizeCuisineType(restaurant.cuisineType),
           }))
         : []),
     ],

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -522,7 +522,7 @@
       "china": "China",
       "canada": "Canada",
       "mexico": "Mexico",
-      "hong-kong": "Hong Kong",
+      "hong-kong": "Hongkong",
       "south-korea": "Zuid-Korea",
       "australia": "Australië",
       "brazil": "Brazilië"


### PR DESCRIPTION
## Summary
This PR improves data consistency by normalizing cuisine type values in structured data and corrects a Dutch translation.

## Key Changes
- Added `normalizeCuisineType()` function to normalize raw API cuisine type values to proper display names
  - Maps lowercase values like "cafe" → "Café" and "fondu" → "Fondue"
  - Falls back to original value if no mapping exists
- Updated `ParkStructuredData` to use the new normalization function for restaurant `servesCuisine` field
- Fixed Dutch translation: "Hong Kong" → "Hongkong" in `messages/nl.json`

## Implementation Details
The normalization function handles null/undefined values gracefully and uses a case-insensitive lookup to ensure consistent formatting of cuisine types in JSON-LD structured data, improving SEO and data quality.

https://claude.ai/code/session_01CJVDRqHNXJnN9BoqrWWJ8g