### PR TITLE
fix(robots): point sitemap links to /sitemap/[0-2].xml

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -12,6 +12,10 @@ export default function robots(): MetadataRoute.Robots {
         '/_next/',
       ],
     },
-    sitemap: `${baseUrl}/sitemap.xml`,
+    sitemap: [
+      `${baseUrl}/sitemap/0.xml`,
+      `${baseUrl}/sitemap/1.xml`,
+      `${baseUrl}/sitemap/2.xml`,
+    ],
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -21,8 +21,8 @@ export function generateSitemaps() {
   return [{ id: 0 }, { id: 1 }, { id: 2 }];
 }
 
-export default async function sitemap({ id }: { id: number }): Promise<MetadataRoute.Sitemap> {
-  switch (id) {
+export default async function sitemap({ id }: { id: number | string }): Promise<MetadataRoute.Sitemap> {
+  switch (Number(id)) {
     case 0:
       return generateHomeParksSitemap();
     case 1:

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -21,7 +21,8 @@ export function generateSitemaps() {
   return [{ id: 0 }, { id: 1 }, { id: 2 }];
 }
 
-export default async function sitemap({ id }: { id: number | string }): Promise<MetadataRoute.Sitemap> {
+export default async function sitemap(props: { id: Promise<string> }): Promise<MetadataRoute.Sitemap> {
+  const id = await props.id;
   switch (Number(id)) {
     case 0:
       return generateHomeParksSitemap();


### PR DESCRIPTION
generateSitemaps() does NOT generate a /sitemap.xml index — Next.js only builds /sitemap/0.xml, /sitemap/1.xml, /sitemap/2.xml. Referencing the non-existent /sitemap.xml in robots.txt made Google find no sitemaps at all.

https://claude.ai/code/session_01J4oJMTNbLUgvz3qtyEWwnx