### PR TITLE
Optimize hero section spacing and logo sizing for mobile

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -125,14 +125,14 @@ export default async function HomePage({ params }: HomePageProps) {
     <div className="flex flex-col">
       <HomepageFAQStructuredData />
       {/* Hero Section – static default; when user is in a park (nearby), shows "Willkommen im [Park]" + park info */}
-      <section className="relative isolate -mt-16 overflow-hidden px-4 pt-16 pb-16 sm:pb-20 md:pt-28 md:pb-24 lg:flex lg:min-h-dvh lg:flex-col lg:justify-center lg:pt-16 lg:pb-24">
+      <section className="relative isolate -mt-16 overflow-hidden px-4 pt-16 pb-4 sm:pb-20 md:pt-28 md:pb-24 lg:flex lg:min-h-dvh lg:flex-col lg:justify-center lg:pt-16 lg:pb-24">
         <HeroBackground imageSrc={randomHeroImage} />
         <div className="relative container mx-auto">
           <div className="flex flex-col">
             {/* Row 1: Logo left + Title/Description right */}
-            <div className="mx-auto flex w-full max-w-5xl flex-col items-center rounded-2xl bg-white/50 px-6 py-8 shadow-2xl backdrop-blur-md lg:mb-16 lg:flex-row lg:items-center lg:px-12 lg:py-10 dark:bg-black/40">
+            <div className="mx-auto flex w-full max-w-5xl flex-col items-center rounded-2xl bg-white/50 px-6 py-4 shadow-2xl backdrop-blur-md sm:py-8 lg:mb-16 lg:flex-row lg:items-center lg:px-12 lg:py-10 dark:bg-black/40">
               {/* Logo – light/dark variant based on theme */}
-              <div className="relative h-36 w-36 shrink-0 lg:h-72 lg:w-72">
+              <div className="relative h-20 w-20 shrink-0 sm:h-36 sm:w-36 lg:h-72 lg:w-72">
                 <Image
                   src="/logo-big.svg"
                   alt="park.fan"

--- a/components/home/hero-with-nearby.tsx
+++ b/components/home/hero-with-nearby.tsx
@@ -62,7 +62,7 @@ function ParkBadges({
   tCommon,
 }: ParkBadgesProps) {
   return (
-    <div className="mx-auto mt-6 mb-8 flex max-w-2xl flex-wrap items-center justify-center gap-2 px-4 py-4 md:gap-3 md:px-6 md:py-5">
+    <div className="mx-auto mt-3 mb-3 flex max-w-2xl flex-wrap items-center justify-center gap-2 px-4 py-2 md:mt-6 md:mb-8 md:gap-3 md:px-6 md:py-5">
       <Badge
         variant="outline"
         className={
@@ -176,7 +176,7 @@ export function HeroWithNearby({
 
     return (
       <>
-        <h1 className="mb-8 text-3xl font-bold tracking-tight sm:text-3xl md:text-4xl lg:text-5xl">
+        <h1 className="mb-3 text-3xl font-bold tracking-tight sm:mb-8 sm:text-3xl md:text-4xl lg:text-5xl">
           {t('heroWelcome', { parkName: stripNewPrefix(park.name) })}
         </h1>
         <p className="text-foreground/85 mx-auto max-w-2xl text-center text-base leading-relaxed md:text-lg">
@@ -222,7 +222,7 @@ export function HeroWithNearby({
 
   return (
     <>
-      <h1 className="mb-8 text-2xl font-bold tracking-tight sm:text-3xl md:text-4xl lg:text-5xl">
+      <h1 className="mb-3 text-2xl font-bold tracking-tight sm:mb-8 sm:text-3xl md:text-4xl lg:text-5xl">
         {t('title')}
       </h1>
       {showNearParkHero ? (
@@ -242,7 +242,7 @@ export function HeroWithNearby({
           />
         </>
       ) : (
-        <p className="text-foreground/80 mx-auto mb-8 max-w-2xl text-center text-base leading-relaxed md:mb-0 md:text-lg">
+        <p className="text-foreground/80 mx-auto mb-3 max-w-2xl text-center text-base leading-relaxed md:mb-0 md:text-lg">
           {tHome('intro')}
         </p>
       )}


### PR DESCRIPTION
## Summary
This PR refines the responsive spacing and sizing of the hero section to improve mobile layout and visual hierarchy. The changes reduce excessive padding on smaller screens while maintaining the original spacing on larger breakpoints.

## Key Changes
- **Hero section padding**: Reduced bottom padding from `pb-16` to `pb-4` on mobile, maintaining `pb-20` and above on small screens and larger
- **Park badges container**: Adjusted vertical margins from `mt-6 mb-8` to `mt-3 mb-3` on mobile, with responsive restoration at `md:` breakpoint
- **Hero title spacing**: Changed bottom margin from `mb-8` to `mb-3` on mobile, with `sm:mb-8` for small screens and up
- **Logo sizing**: Reduced initial size from `h-36 w-36` to `h-20 w-20` on mobile, scaling up to `sm:h-36 sm:w-36` and `lg:h-72 lg:w-72`
- **Hero card padding**: Reduced vertical padding from `py-8` to `py-4` on mobile, with `sm:py-8` for small screens and up
- **Intro paragraph spacing**: Reduced bottom margin from `mb-8` to `mb-3` on mobile

## Implementation Details
All changes follow a mobile-first responsive design approach, using Tailwind CSS breakpoints (`sm:`, `md:`, `lg:`) to progressively enhance spacing and sizing as viewport width increases. This ensures optimal visual presentation across all device sizes while reducing clutter on mobile devices.

https://claude.ai/code/session_01KE3rXdCDXNdWx1WxfTXxXd