### PR TITLE
Fix header controls alignment on mobile in transparent mode

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -157,9 +157,12 @@ export function Header() {
             <SearchCommand trigger="button" />
           </div>
 
-          {/* Always visible: locale switcher + theme toggle — glass pill on transparent hero */}
+          {/* Always visible: locale switcher + theme toggle — glass pill on transparent hero.
+              On mobile in transparent mode, offset right by the width of the invisible menu button
+              (size-9 = 36px) + gap-2 (8px) = 44px so the pill aligns with the hero card edge.
+              On md+ the menu button is display:none and needs no offset (md:translate-x-0). */}
           <div
-            className={`flex items-center gap-1 rounded-lg transition-all duration-500 ${isTransparent ? 'bg-white/60 px-1 py-0.5 backdrop-blur-md dark:bg-black/40' : ''}`}
+            className={`flex items-center gap-1 rounded-lg transition-all duration-500 ${isTransparent ? 'translate-x-11 md:translate-x-0 bg-white/60 px-1 py-0.5 backdrop-blur-md dark:bg-black/40' : 'translate-x-0'}`}
           >
             <LocaleSwitcher />
             <ThemeToggle />


### PR DESCRIPTION
## Summary
Adjusted the positioning of the locale switcher and theme toggle controls in the header to properly align with the hero card edge on mobile devices when in transparent mode.

## Key Changes
- Added `translate-x-11` class to offset the controls container by 44px on mobile (accounting for the invisible menu button width of 36px + 8px gap)
- Added `md:translate-x-0` to reset the offset on medium screens and above where the menu button is hidden
- Added `translate-x-0` for non-transparent mode to ensure no offset is applied
- Updated the comment to document the mobile alignment logic and responsive behavior

## Implementation Details
The fix addresses a visual alignment issue where the glass pill containing the locale switcher and theme toggle was not properly aligned with the hero card edge on mobile devices in transparent mode. The offset accounts for the space occupied by the invisible menu button (size-9 = 36px) plus the gap between elements (gap-2 = 8px), totaling 44px. On larger screens where the menu button is not displayed, the offset is removed via the `md:translate-x-0` utility class.

https://claude.ai/code/session_0192Gvyht1AmMHFTon4aPyYP