### PR TITLE
fix(footer): enable wrapping and fix horizontal scroll on mobile

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -343,12 +343,12 @@ export async function Footer({ locale }: FooterProps) {
           <p className="text-muted-foreground/80 text-sm">{t('disclaimer')}</p>
         </div>
 
-        <div className="text-muted-foreground flex flex-col items-center justify-between text-sm md:flex-row">
+        <div className="text-muted-foreground flex flex-col items-center justify-between gap-6 text-sm md:flex-row">
           <div className="flex flex-col items-center text-center md:text-left">
             <p>{t('copyright', { year: currentYear })}</p>
             <BuildInfo />
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-center gap-2 md:justify-end">
             <Link
               href="/howto"
               prefetch={false}


### PR DESCRIPTION
## Summary
- Fix footer links wrapping on mobile devices
- Eliminate horizontal scrolling caused by footer content
- Improve footer layout on tablet and desktop screens

## Changes
- Added `flex-wrap` to footer links container for proper text wrapping
- Added `gap-6` to outer footer container for better spacing
- Added responsive alignment: `justify-center` on mobile, `justify-end` on desktop

## Test Plan
- [x] Test footer on mobile (320px - 640px) — links should wrap
- [x] Test footer on tablet (641px - 1024px) — proper alignment
- [x] Test footer on desktop (1025px+) — right-aligned links
- [x] No horizontal scrolling should occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)