### PR TITLE
Add glossary term injection and linking throughout content

### DIFF
--- a/app/[locale]/glossary/[term]/page.tsx
+++ b/app/[locale]/glossary/[term]/page.tsx
@@ -161,7 +161,7 @@ export default async function GlossaryTermPage({ params }: TermPageProps) {
 
       <FavoritesSection />
 
-      <FeaturedParksSection locale={locale} geoData={geoData} />
+      <FeaturedParksSection locale={locale as Locale} geoData={geoData} />
     </>
   );
 }

--- a/app/[locale]/howto/page.tsx
+++ b/app/[locale]/howto/page.tsx
@@ -287,15 +287,23 @@ function DemoBadge({
   color,
   label,
   icon: Icon,
+  termId,
 }: {
   color: string;
   label: string;
   icon?: React.ElementType;
+  termId?: string;
 }) {
   return (
     <Badge className={cn('font-bold tracking-wide text-white uppercase backdrop-blur-md', color)}>
       {Icon && <Icon className="h-3 w-3 text-inherit" />}
-      {label}
+      {termId ? (
+        <GlossaryTermLink termId={termId} className="underline decoration-dashed underline-offset-2 decoration-white/60 cursor-help">
+          {label}
+        </GlossaryTermLink>
+      ) : (
+        label
+      )}
     </Badge>
   );
 }
@@ -1795,6 +1803,7 @@ function ContentDE() {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: User,
                 label: 'Single Rider',
+                termId: 'single-rider',
                 desc: 'Einzelfahrer-Schlange. Oft deutlich kürzer als die reguläre Schlange, aber du kannst nicht mit Begleitern fahren.',
               },
               {
@@ -1802,23 +1811,26 @@ function ContentDE() {
                   'bg-status-down/65 border-status-down/80 dark:bg-status-down/25 dark:border-status-down/40',
                 icon: Zap,
                 label: 'Lightning Lane',
+                termId: 'lightning-lane',
                 desc: 'Kostenpflichtiger Express-Pass (z. B. bei Disney). Zeigt den aktuellen Preis und die Rückkehrzeit.',
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: 'Rückkehrzeit',
+                termId: 'virtual-queue',
                 desc: 'Kostenlose virtuelle Schlange – du holst dir einen Zeitslot und kehrst zur angezeigten Uhrzeit zurück.',
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: 'Boarding Group',
+                termId: 'boarding-group',
                 desc: 'Virtuelle Warteschlange mit Gruppenummer. Beliebt bei sehr gefragten neuen Attraktionen.',
               },
-            ].map(({ color, icon, label, desc }) => (
+            ].map(({ color, icon, label, termId, desc }) => (
               <div key={label} className="flex items-start gap-3">
-                <DemoBadge color={color} label={label} icon={icon} />
+                <DemoBadge color={color} label={label} icon={icon} termId={termId} />
                 <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
@@ -2927,6 +2939,7 @@ function ContentENSections() {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: User,
                 label: 'Single Rider',
+                termId: 'single-rider',
                 desc: "Often much shorter than regular queue – but you can't ride with your group.",
               },
               {
@@ -2934,23 +2947,26 @@ function ContentENSections() {
                   'bg-status-down/65 border-status-down/80 dark:bg-status-down/25 dark:border-status-down/40',
                 icon: Zap,
                 label: 'Lightning Lane',
+                termId: 'lightning-lane',
                 desc: 'Paid express pass (e.g. at Disney). Shows current price and return time.',
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: 'Return Time',
+                termId: 'virtual-queue',
                 desc: 'Free virtual queue – reserve a time slot and return later.',
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: 'Boarding Group',
+                termId: 'boarding-group',
                 desc: 'Virtual queue with group number – popular for highly demanded new rides.',
               },
-            ].map(({ color, icon, label, desc }) => (
+            ].map(({ color, icon, label, termId, desc }) => (
               <div key={label} className="flex items-start gap-3">
-                <DemoBadge color={color} label={label} icon={icon} />
+                <DemoBadge color={color} label={label} icon={icon} termId={termId} />
                 <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
@@ -3725,6 +3741,7 @@ function ContentESSections() {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: User,
                 label: 'Fila Individual',
+                termId: 'single-rider',
                 desc: 'A menudo mucho más corta que la fila normal – pero no puedes ir con tu grupo.',
               },
               {
@@ -3732,23 +3749,26 @@ function ContentESSections() {
                   'bg-status-down/65 border-status-down/80 dark:bg-status-down/25 dark:border-status-down/40',
                 icon: Zap,
                 label: 'Lightning Lane',
+                termId: 'lightning-lane',
                 desc: 'Pase exprés de pago (p. ej. en Disney). Muestra el precio actual y la hora de regreso.',
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: 'Hora de Regreso',
+                termId: 'virtual-queue',
                 desc: 'Cola virtual gratuita – reserva un horario y regresa más tarde.',
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: 'Grupo de Embarque',
+                termId: 'boarding-group',
                 desc: 'Cola virtual con número de grupo – popular para nuevas atracciones muy demandadas.',
               },
-            ].map(({ color, icon, label, desc }) => (
+            ].map(({ color, icon, label, termId, desc }) => (
               <div key={label} className="flex items-start gap-3">
-                <DemoBadge color={color} label={label} icon={icon} />
+                <DemoBadge color={color} label={label} icon={icon} termId={termId} />
                 <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
@@ -4548,6 +4568,7 @@ function ContentFRSections() {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: User,
                 label: 'File Individuelle',
+                termId: 'single-rider',
                 desc: 'Souvent bien plus courte que la file normale – mais tu ne peux pas y aller avec ton groupe.',
               },
               {
@@ -4555,23 +4576,26 @@ function ContentFRSections() {
                   'bg-status-down/65 border-status-down/80 dark:bg-status-down/25 dark:border-status-down/40',
                 icon: Zap,
                 label: 'Lightning Lane',
+                termId: 'lightning-lane',
                 desc: "Pass express payant (p. ex. chez Disney). Affiche le prix actuel et l'heure de retour.",
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: 'Heure de Retour',
+                termId: 'virtual-queue',
                 desc: 'File virtuelle gratuite – réserve un créneau et reviens plus tard.',
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: "Groupe d'Embarquement",
+                termId: 'boarding-group',
                 desc: 'File virtuelle avec numéro de groupe – populaire pour les nouvelles attractions très demandées.',
               },
-            ].map(({ color, icon, label, desc }) => (
+            ].map(({ color, icon, label, termId, desc }) => (
               <div key={label} className="flex items-start gap-3">
-                <DemoBadge color={color} label={label} icon={icon} />
+                <DemoBadge color={color} label={label} icon={icon} termId={termId} />
                 <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
@@ -5380,6 +5404,7 @@ function ContentITSections() {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: User,
                 label: 'Fila Singola',
+                termId: 'single-rider',
                 desc: 'Spesso molto più breve della fila normale – ma non puoi andarci con il tuo gruppo.',
               },
               {
@@ -5387,23 +5412,26 @@ function ContentITSections() {
                   'bg-status-down/65 border-status-down/80 dark:bg-status-down/25 dark:border-status-down/40',
                 icon: Zap,
                 label: 'Lightning Lane',
+                termId: 'lightning-lane',
                 desc: "Pass express a pagamento (p. es. da Disney). Mostra il prezzo attuale e l'ora di ritorno.",
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: 'Ora di Ritorno',
+                termId: 'virtual-queue',
                 desc: 'Coda virtuale gratuita – prenota uno slot orario e torna più tardi.',
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: "Gruppo d'Imbarco",
+                termId: 'boarding-group',
                 desc: 'Coda virtuale con numero di gruppo – popolare per le nuove attrazioni molto richieste.',
               },
-            ].map(({ color, icon, label, desc }) => (
+            ].map(({ color, icon, label, termId, desc }) => (
               <div key={label} className="flex items-start gap-3">
-                <DemoBadge color={color} label={label} icon={icon} />
+                <DemoBadge color={color} label={label} icon={icon} termId={termId} />
                 <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
@@ -6185,6 +6213,7 @@ function ContentNLSections() {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: User,
                 label: 'Single Rider',
+                termId: 'single-rider',
                 desc: 'Vaak veel korter dan de gewone rij – maar je kunt niet met je groep meerijden.',
               },
               {
@@ -6192,23 +6221,26 @@ function ContentNLSections() {
                   'bg-status-down/65 border-status-down/80 dark:bg-status-down/25 dark:border-status-down/40',
                 icon: Zap,
                 label: 'Lightning Lane',
+                termId: 'lightning-lane',
                 desc: 'Betaald express-pas (bijv. bij Disney). Toont huidige prijs en terugtijdstip.',
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: 'Terugtijdstip',
+                termId: 'virtual-queue',
                 desc: 'Gratis virtuele wachtrij – reserveer een tijdslot en kom later terug.',
               },
               {
                 color: 'bg-primary/65 border-primary/80 dark:bg-primary/25 dark:border-primary/40',
                 icon: Ticket,
                 label: 'Boardinggroep',
+                termId: 'boarding-group',
                 desc: 'Virtuele wachtrij met groepsnummer – populair voor veelgevraagde nieuwe attracties.',
               },
-            ].map(({ color, icon, label, desc }) => (
+            ].map(({ color, icon, label, termId, desc }) => (
               <div key={label} className="flex items-start gap-3">
-                <DemoBadge color={color} label={label} icon={icon} />
+                <DemoBadge color={color} label={label} icon={icon} termId={termId} />
                 <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}

--- a/app/[locale]/howto/page.tsx
+++ b/app/[locale]/howto/page.tsx
@@ -15,6 +15,7 @@ import { Link } from '@/i18n/navigation';
 const getCachedGeoData = cache(() => getGeoStructure().catch(() => null));
 import { getIntegratedCalendar } from '@/lib/api/integrated-calendar';
 import { GlossaryInject } from '@/components/glossary/glossary-inject';
+import { GlossaryTermLink } from '@/components/glossary/glossary-term-link';
 import type { CalendarDay } from '@/lib/api/types';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';

--- a/app/[locale]/howto/page.tsx
+++ b/app/[locale]/howto/page.tsx
@@ -312,14 +312,14 @@ function InfoBox({ children, label = 'Hinweis' }: { children: React.ReactNode; l
   );
 }
 
-function TipBox({ children, label = 'Tipp' }: { children: React.ReactNode; label?: string }) {
+async function TipBox({ children, label = 'Tipp' }: { children: React.ReactNode; label?: string }) {
   return (
     <div className="!mt-6 rounded-lg border border-yellow-500/20 bg-yellow-500/5 px-3 py-2.5 text-sm leading-relaxed">
       <div className="mb-1 flex items-center gap-1.5 font-semibold text-yellow-600 dark:text-yellow-400">
         <Lightbulb className="h-3.5 w-3.5 shrink-0" />
         <span>{label}</span>
       </div>
-      {children}
+      {typeof children === 'string' ? <GlossaryInject>{children}</GlossaryInject> : children}
     </div>
   );
 }
@@ -1611,7 +1611,7 @@ function ContentDE() {
             ].map(({ icon: Icon, color, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={Icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -1682,7 +1682,7 @@ function ContentDE() {
                     {threshold}
                   </span>
                 </div>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -1726,7 +1726,7 @@ function ContentDE() {
                   <Icon className="h-4 w-4" />
                   {label}
                 </span>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -1778,7 +1778,7 @@ function ContentDE() {
             ].map(({ color, label, icon, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -1819,7 +1819,7 @@ function ContentDE() {
             ].map(({ color, icon, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -2021,7 +2021,7 @@ function ContentDE() {
               <span className="text-2xl">{icon}</span>
               <div>
                 <p className="font-semibold">{title}</p>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             </div>
           ))}
@@ -2267,8 +2267,9 @@ function ContentDE() {
           <Link href="/glossary" className="text-primary font-medium underline">
             park.fan/glossar
           </Link>{' '}
-          erreichbar – mit Begriffen aus 7 Kategorien: Wartezeiten, Besucherdichte, Park-Betrieb,
-          Planung, Attraktionen, Achterbahnen und Achterbahn-Elemente.
+          <GlossaryInject>
+            {'erreichbar – mit Begriffen aus 7 Kategorien: Wartezeiten, Besucherdichte, Park-Betrieb, Planung, Attraktionen, Achterbahnen und Achterbahn-Elemente.'}
+          </GlossaryInject>
         </TipBox>
       </Section>
 
@@ -2804,7 +2805,7 @@ function ContentENSections() {
             ].map(({ icon: Icon, color, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={Icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -2874,7 +2875,7 @@ function ContentENSections() {
                     {threshold}
                   </span>
                 </div>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -2913,7 +2914,7 @@ function ContentENSections() {
                   <Icon className="h-4 w-4" />
                   {label}
                 </span>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -2950,7 +2951,7 @@ function ContentENSections() {
             ].map(({ color, icon, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -3132,7 +3133,7 @@ function ContentENSections() {
               <span className="text-2xl">{icon}</span>
               <div>
                 <p className="font-semibold">{title}</p>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             </div>
           ))}
@@ -3321,8 +3322,9 @@ function ContentENSections() {
           <Link href="/glossary" className="text-primary font-medium underline">
             park.fan/glossary
           </Link>{' '}
-          – with terms organised across 7 categories: Wait Times, Crowd Levels, Park Operations,
-          Planning, Attractions, Coasters and Coaster Elements.
+          <GlossaryInject>
+            {'– with terms organised across 7 categories: Wait Times, Crowd Levels, Park Operations, Planning, Attractions, Coasters and Coaster Elements.'}
+          </GlossaryInject>
         </TipBox>
       </Section>
 
@@ -3601,7 +3603,7 @@ function ContentESSections() {
             ].map(({ icon: Icon, color, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={Icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -3671,7 +3673,7 @@ function ContentESSections() {
                     {threshold}
                   </span>
                 </div>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -3710,7 +3712,7 @@ function ContentESSections() {
                   <Icon className="h-4 w-4" />
                   {label}
                 </span>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -3747,7 +3749,7 @@ function ContentESSections() {
             ].map(({ color, icon, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -3932,7 +3934,7 @@ function ContentESSections() {
               <span className="text-2xl">{icon}</span>
               <div>
                 <p className="font-semibold">{title}</p>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             </div>
           ))}
@@ -4424,7 +4426,7 @@ function ContentFRSections() {
             ].map(({ icon: Icon, color, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={Icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -4494,7 +4496,7 @@ function ContentFRSections() {
                     {threshold}
                   </span>
                 </div>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -4533,7 +4535,7 @@ function ContentFRSections() {
                   <Icon className="h-4 w-4" />
                   {label}
                 </span>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -4570,7 +4572,7 @@ function ContentFRSections() {
             ].map(({ color, icon, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -4759,7 +4761,7 @@ function ContentFRSections() {
               <span className="text-2xl">{icon}</span>
               <div>
                 <p className="font-semibold">{title}</p>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             </div>
           ))}
@@ -5256,7 +5258,7 @@ function ContentITSections() {
             ].map(({ icon: Icon, color, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={Icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -5326,7 +5328,7 @@ function ContentITSections() {
                     {threshold}
                   </span>
                 </div>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -5365,7 +5367,7 @@ function ContentITSections() {
                   <Icon className="h-4 w-4" />
                   {label}
                 </span>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -5402,7 +5404,7 @@ function ContentITSections() {
             ].map(({ color, icon, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -5587,7 +5589,7 @@ function ContentITSections() {
               <span className="text-2xl">{icon}</span>
               <div>
                 <p className="font-semibold">{title}</p>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             </div>
           ))}
@@ -6063,7 +6065,7 @@ function ContentNLSections() {
             ].map(({ icon: Icon, color, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={Icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -6132,7 +6134,7 @@ function ContentNLSections() {
                     {threshold}
                   </span>
                 </div>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -6170,7 +6172,7 @@ function ContentNLSections() {
                   <Icon className="h-4 w-4" />
                   {label}
                 </span>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -6207,7 +6209,7 @@ function ContentNLSections() {
             ].map(({ color, icon, label, desc }) => (
               <div key={label} className="flex items-start gap-3">
                 <DemoBadge color={color} label={label} icon={icon} />
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             ))}
           </div>
@@ -6393,7 +6395,7 @@ function ContentNLSections() {
               <span className="text-2xl">{icon}</span>
               <div>
                 <p className="font-semibold">{title}</p>
-                <p className="text-muted-foreground text-sm">{desc}</p>
+                <p className="text-muted-foreground text-sm"><GlossaryInject>{desc}</GlossaryInject></p>
               </div>
             </div>
           ))}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { generateAlternateLanguages } from '@/i18n/config';
+import type { Locale } from '@/i18n/config';
 import { buildOpenGraphMetadata } from '@/lib/utils/metadata';
 import { Link } from '@/i18n/navigation';
 import { Clock, TrendingUp, ChevronRight, Map as MapIcon, BookOpen, Tag } from 'lucide-react';
@@ -214,7 +215,7 @@ export default async function HomePage({ params }: HomePageProps) {
       <FavoritesSection />
 
       {/* Featured Parks – locale-aware, direct park links for SEO */}
-      <FeaturedParksSection locale={locale} geoData={geoData} />
+      <FeaturedParksSection locale={locale as Locale} geoData={geoData} />
 
       {/* Global Stats */}
       {stats && (

--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/[attraction]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/[attraction]/page.tsx
@@ -43,6 +43,15 @@ const QUEUE_TYPE_KEYS = {
   PAID_STANDBY: 'queue.PAID_STANDBY',
 } as const satisfies Record<QueueType, string>;
 
+/** Maps API queue types to their glossary term IDs for tooltip linking. */
+const QUEUE_TYPE_TERM: Partial<Record<QueueType, string>> = {
+  SINGLE_RIDER: 'single-rider',
+  RETURN_TIME: 'virtual-queue',
+  PAID_RETURN_TIME: 'lightning-lane',
+  PAID_STANDBY: 'express-pass',
+  BOARDING_GROUP: 'boarding-group',
+};
+
 const QUEUE_STATUS_KEYS = {
   OPERATING: 'queue.status.OPERATING',
   DOWN: 'queue.status.DOWN',
@@ -66,6 +75,7 @@ import {
 } from '@/components/seo/structured-data';
 import { AttractionFAQStructuredData } from '@/components/seo/attraction-faq-structured-data';
 import { AttractionFAQSection } from '@/components/faq/attraction-faq-section';
+import { GlossaryTermLink } from '@/components/glossary/glossary-term-link';
 import { PageContainer } from '@/components/common/page-container';
 import { GlassCard } from '@/components/common/glass-card';
 import { StatusInfoCard } from '@/components/common/status-info-card';
@@ -487,7 +497,13 @@ export default async function AttractionPage({ params }: AttractionPageProps) {
                       <CardContent className="p-4">
                         <div className="mb-2 flex items-center justify-between">
                           <span className="font-medium">
-                            {t(QUEUE_TYPE_KEYS[queue.queueType])}{' '}
+                            {QUEUE_TYPE_TERM[queue.queueType] ? (
+                              <GlossaryTermLink termId={QUEUE_TYPE_TERM[queue.queueType]!}>
+                                {t(QUEUE_TYPE_KEYS[queue.queueType])}
+                              </GlossaryTermLink>
+                            ) : (
+                              t(QUEUE_TYPE_KEYS[queue.queueType])
+                            )}{' '}
                           </span>
                           <Badge variant="outline">{t(QUEUE_STATUS_KEYS[queue.status])}</Badge>
                         </div>

--- a/app/api/glossary-search/route.ts
+++ b/app/api/glossary-search/route.ts
@@ -12,12 +12,48 @@ export async function GET(request: Request) {
 
   const terms = await getGlossaryTerms(locale);
   const query = q.toLowerCase();
-  const results = terms.filter(
-    (t) => t.name.toLowerCase().includes(query) || t.shortDefinition.toLowerCase().includes(query)
-  );
+
+  // Calculate match score: exact name match = 100, alias match = 90, substring match = varies by position
+  interface ScoredTerm {
+    term: typeof terms[0];
+    score: number;
+  }
+
+  const scored: ScoredTerm[] = terms
+    .map((t) => {
+      const lowerName = t.name.toLowerCase();
+      const lowerQuery = query;
+
+      // Exact match on name = 100 points
+      if (lowerName === lowerQuery) {
+        return { term: t, score: 100 };
+      }
+
+      // Exact match on alias = 90 points
+      if (t.aliases?.some((alias) => alias.toLowerCase() === lowerQuery)) {
+        return { term: t, score: 90 };
+      }
+
+      // Substring matches
+      if (lowerName.includes(lowerQuery)) {
+        // Name starts with query = 50 points, otherwise 30 points
+        const score = lowerName.startsWith(lowerQuery) ? 50 : 30;
+        return { term: t, score };
+      }
+
+      // Substring in short definition = 20 points
+      if (t.shortDefinition.toLowerCase().includes(lowerQuery)) {
+        return { term: t, score: 20 };
+      }
+
+      // No match
+      return null;
+    })
+    .filter((x): x is ScoredTerm => x !== null)
+    .sort((a, b) => b.score - a.score);
 
   return Response.json({
-    results: results.slice(0, 5).map((t) => ({
+    results: scored.slice(0, 5).map(({ term: t }) => ({
       type: 'glossary',
       id: t.id,
       name: t.name,

--- a/components/glossary/glossary-inject.tsx
+++ b/components/glossary/glossary-inject.tsx
@@ -78,22 +78,25 @@ function parseSegments(text: string, terms: GlossaryTerm[]): Segment[] {
 }
 
 /**
- * Async server component — fetches glossary terms for the current locale and
+ * Async server component — fetches glossary terms for the given (or current) locale and
  * replaces the first occurrence of each term (or alias) with a dashed-underline
  * tooltip link. No provider or wrapper needed.
  *
+ * @param locale  Optional: the locale to use. If not provided, uses getLocale().
  * @param noUnderline  When true, suppress the dashed underline (e.g. inside headings).
  */
 export async function GlossaryInject({
   children,
+  locale: providedLocale,
   noUnderline = false,
 }: {
   children: string;
+  locale?: Locale;
   noUnderline?: boolean;
 }) {
   if (!children) return <>{children}</>;
 
-  const locale = (await getLocale()) as Locale;
+  const locale = (providedLocale ?? ((await getLocale()) as Locale)) as Locale;
   const terms = await getGlossaryTerms(locale);
   const segment = GLOSSARY_SEGMENTS[locale];
 

--- a/components/glossary/glossary-term-detail.tsx
+++ b/components/glossary/glossary-term-detail.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { BreadcrumbNav } from '@/components/common/breadcrumb-nav';
 import { Card } from '@/components/ui/card';
+import { GlossaryInject } from '@/components/glossary/glossary-inject';
 import type { GlossaryTerm } from '@/lib/glossary/types';
 import type { Breadcrumb } from '@/lib/api/types';
 import type { Locale } from '@/i18n/config';
@@ -47,7 +48,7 @@ export function GlossaryTermDetail({
                 <span className="text-muted-foreground text-xl font-normal">{labels.termH1Suffix}</span>
               </h1>
               <p className="text-muted-foreground text-lg leading-relaxed">
-                {term.shortDefinition}
+                <GlossaryInject>{term.shortDefinition}</GlossaryInject>
               </p>
             </div>
             {/* Category footer strip */}
@@ -61,7 +62,9 @@ export function GlossaryTermDetail({
           <Card className="border-primary/10 px-6 py-4 shadow-sm">
             <div className="text-foreground/85 space-y-3 leading-relaxed">
               {term.definition.split('\n\n').map((para, i) => (
-                <p key={i}>{para}</p>
+                <p key={i}>
+                  <GlossaryInject>{para}</GlossaryInject>
+                </p>
               ))}
             </div>
           </Card>

--- a/components/glossary/glossary-term-detail.tsx
+++ b/components/glossary/glossary-term-detail.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { BreadcrumbNav } from '@/components/common/breadcrumb-nav';

--- a/components/glossary/glossary-term-detail.tsx
+++ b/components/glossary/glossary-term-detail.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { BreadcrumbNav } from '@/components/common/breadcrumb-nav';

--- a/components/glossary/glossary-term-detail.tsx
+++ b/components/glossary/glossary-term-detail.tsx
@@ -48,7 +48,7 @@ export function GlossaryTermDetail({
                 <span className="text-muted-foreground text-xl font-normal">{labels.termH1Suffix}</span>
               </h1>
               <p className="text-muted-foreground text-lg leading-relaxed">
-                <GlossaryInject>{term.shortDefinition}</GlossaryInject>
+                <GlossaryInject locale={locale}>{term.shortDefinition}</GlossaryInject>
               </p>
             </div>
             {/* Category footer strip */}
@@ -63,7 +63,7 @@ export function GlossaryTermDetail({
             <div className="text-foreground/85 space-y-3 leading-relaxed">
               {term.definition.split('\n\n').map((para, i) => (
                 <p key={i}>
-                  <GlossaryInject>{para}</GlossaryInject>
+                  <GlossaryInject locale={locale}>{para}</GlossaryInject>
                 </p>
               ))}
             </div>

--- a/components/home/featured-parks-section.tsx
+++ b/components/home/featured-parks-section.tsx
@@ -4,6 +4,7 @@ import { ParkCard } from '@/components/parks/park-card';
 import { Link } from '@/i18n/navigation';
 import { ChevronRight } from 'lucide-react';
 import type { GeoStructure, ParkStatus, CrowdLevel, ScheduleSummary } from '@/lib/api/types';
+import type { Locale } from '@/i18n/config';
 
 /**
  * Featured parks per locale — verified slugs from footer + API structure.
@@ -124,7 +125,7 @@ export function extractFeaturedParks(geoData: GeoStructure | null, locale: strin
 }
 
 interface FeaturedParksSectionProps {
-  locale: string;
+  locale: Locale;
   geoData: GeoStructure | null;
 }
 
@@ -142,7 +143,7 @@ export async function FeaturedParksSection({ locale, geoData }: FeaturedParksSec
           {tHome('sections.featuredParks')}
         </h2>
         <p className="text-muted-foreground mb-8 text-center text-sm">
-          <GlossaryInject>{tHome('sections.featuredParksIntro')}</GlossaryInject>
+          <GlossaryInject locale={locale}>{tHome('sections.featuredParksIntro')}</GlossaryInject>
         </p>
 
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/components/search/search-bar.tsx
+++ b/components/search/search-bar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
+import type { ReactNode } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { useRouter } from '@/i18n/navigation';
 import { useQuery } from '@tanstack/react-query';
@@ -648,68 +649,98 @@ export function SearchCommand({
 
           {!isPending && results && results.results.length > 0 && (
             <>
-              {/* Group by type — locations first if present (e.g. "orlando" → show city before parks) */}
-              {(results.results.some((r) => r.type === 'location')
-                ? (['location', 'park', 'attraction', 'show', 'restaurant'] as const)
-                : (['park', 'attraction', 'show', 'restaurant', 'location'] as const)
-              ).map((type) => {
-                const items = results.results.filter((r) => r.type === type);
-                if (items.length === 0) return null;
+              {/* Build all category groups (including glossary), sort by best match score */}
+              {(() => {
+                const lowerQuery = debouncedQuery.toLowerCase();
+                const calcNameScore = (name: string): number => {
+                  const lower = name.toLowerCase();
+                  if (lower === lowerQuery) return 100;
+                  if (lower.startsWith(lowerQuery)) return 50;
+                  if (lower.includes(lowerQuery)) return 30;
+                  return 0;
+                };
 
-                // Sort by match score within each category (exact matches first)
-                const sortedItems = sortResultsByMatch(items);
+                const groups: { key: string; score: number; node: ReactNode }[] = [];
 
-                return (
-                  <CommandGroup
-                    key={type}
-                    heading={tSearch(`headings.${type}`, { count: items.length })}
-                  >
-                    {sortedItems.slice(0, 5).map((item, index) => renderResultItem(item, index))}
-                  </CommandGroup>
-                );
-              })}
+                const mainTypes = results.results.some((r) => r.type === 'location')
+                  ? (['location', 'park', 'attraction', 'show', 'restaurant'] as const)
+                  : (['park', 'attraction', 'show', 'restaurant', 'location'] as const);
 
-              {/* Glossary results */}
-              {glossaryData && glossaryData.results.length > 0 && (
-                <CommandGroup
-                  heading={tSearch('headings.glossary', { count: glossaryData.results.length })}
-                >
-                  {glossaryData.results.map((item) => {
-                    const glossarySegments: Record<string, string> = {
-                      en: 'glossary',
-                      de: 'glossar',
-                      fr: 'glossaire',
-                      it: 'glossario',
-                      nl: 'woordenlijst',
-                      es: 'glosario',
-                    };
-                    const seg = glossarySegments[locale] ?? 'glossary';
-                    return (
-                      <CommandItem
-                        key={item.id}
-                        value={`${item.name} glossary`}
-                        onSelect={() => {
-                          handleOpenChange(false);
-                          router.push(`/${seg}/${item.slug}` as '/parks/europe');
-                        }}
-                        className="flex cursor-pointer items-center gap-4"
+                mainTypes.forEach((type) => {
+                  const items = results.results.filter((r) => r.type === type);
+                  if (items.length === 0) return;
+                  const sortedItems = sortResultsByMatch(items);
+                  const bestScore = Math.max(...sortedItems.map((item) => calcNameScore(item.name)));
+                  groups.push({
+                    key: type,
+                    score: bestScore,
+                    node: (
+                      <CommandGroup
+                        key={type}
+                        heading={tSearch(`headings.${type}`, { count: items.length })}
                       >
-                        <div className="bg-foreground/10 flex h-11 w-11 shrink-0 items-center justify-center rounded-xl">
-                          <BookOpen className="text-foreground/65 h-5 w-5" />
-                        </div>
-                        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-                          <span className="truncate text-[15px] leading-none font-semibold">
-                            {item.name}
-                          </span>
-                          <span className="text-foreground/45 truncate text-xs">
-                            {item.shortDefinition}
-                          </span>
-                        </div>
-                      </CommandItem>
-                    );
-                  })}
-                </CommandGroup>
-              )}
+                        {sortedItems.slice(0, 5).map((item, index) =>
+                          renderResultItem(item, index)
+                        )}
+                      </CommandGroup>
+                    ),
+                  });
+                });
+
+                if (glossaryData && glossaryData.results.length > 0) {
+                  const glossarySegments: Record<string, string> = {
+                    en: 'glossary',
+                    de: 'glossar',
+                    fr: 'glossaire',
+                    it: 'glossario',
+                    nl: 'woordenlijst',
+                    es: 'glosario',
+                  };
+                  const seg = glossarySegments[locale] ?? 'glossary';
+                  const glossaryBestScore = calcNameScore(glossaryData.results[0].name);
+                  groups.push({
+                    key: 'glossary',
+                    score: glossaryBestScore,
+                    node: (
+                      <CommandGroup
+                        key="glossary"
+                        heading={tSearch('headings.glossary', {
+                          count: glossaryData.results.length,
+                        })}
+                      >
+                        {glossaryData.results.map((item) => (
+                          <CommandItem
+                            key={item.id}
+                            value={`${item.name} glossary`}
+                            onSelect={() => {
+                              handleOpenChange(false);
+                              router.push(`/${seg}/${item.slug}` as '/parks/europe');
+                            }}
+                            className="flex cursor-pointer items-center gap-4"
+                          >
+                            <div className="bg-foreground/10 flex h-11 w-11 shrink-0 items-center justify-center rounded-xl">
+                              <BookOpen className="text-foreground/65 h-5 w-5" />
+                            </div>
+                            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                              <span className="truncate text-[15px] leading-none font-semibold">
+                                {item.name}
+                              </span>
+                              <span className="text-foreground/45 truncate text-xs">
+                                {item.shortDefinition}
+                              </span>
+                            </div>
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    ),
+                  });
+                }
+
+                // Sort all groups: exact matches (score=100) first, then by descending score
+                groups.sort((a, b) => b.score - a.score);
+
+                return groups.map((g) => g.node);
+              })()}
 
               {/* Link to full search page */}
               <div className="border-border/30 border-t p-3">

--- a/components/search/search-bar.tsx
+++ b/components/search/search-bar.tsx
@@ -433,6 +433,34 @@ export function SearchCommand({
   // Show skeleton as soon as user types ≥3 chars (covers debounce window + fetch)
   const isPending = loading || (query.trim().length >= 3 && debouncedQuery.trim().length < 3);
 
+  // Calculate match score for exact matches: name should be compared with query
+  const calculateMatchScore = (item: SearchResultItem): number => {
+    const lowerName = item.name.toLowerCase();
+    const lowerQuery = debouncedQuery.toLowerCase();
+
+    // Exact name match = 100 points
+    if (lowerName === lowerQuery) {
+      return 100;
+    }
+
+    // Name starts with query = 50 points
+    if (lowerName.startsWith(lowerQuery)) {
+      return 50;
+    }
+
+    // Substring match = 30 points
+    if (lowerName.includes(lowerQuery)) {
+      return 30;
+    }
+
+    return 0;
+  };
+
+  // Sort results within each category by match score (exact matches first)
+  const sortResultsByMatch = (items: SearchResultItem[]): SearchResultItem[] => {
+    return [...items].sort((a, b) => calculateMatchScore(b) - calculateMatchScore(a));
+  };
+
   return (
     <>
       {/* Trigger */}
@@ -628,12 +656,15 @@ export function SearchCommand({
                 const items = results.results.filter((r) => r.type === type);
                 if (items.length === 0) return null;
 
+                // Sort by match score within each category (exact matches first)
+                const sortedItems = sortResultsByMatch(items);
+
                 return (
                   <CommandGroup
                     key={type}
                     heading={tSearch(`headings.${type}`, { count: items.length })}
                   >
-                    {items.slice(0, 5).map((item, index) => renderResultItem(item, index))}
+                    {sortedItems.slice(0, 5).map((item, index) => renderResultItem(item, index))}
                   </CommandGroup>
                 );
               })}

--- a/components/seo/glossary-structured-data.tsx
+++ b/components/seo/glossary-structured-data.tsx
@@ -5,7 +5,7 @@ import type { Locale } from '@/i18n/config';
 import { GLOSSARY_SEGMENTS } from '@/lib/glossary/translations';
 
 /** ISO date of last glossary content review — update when terms are added or changed */
-const GLOSSARY_CONTENT_DATE = '2026-03-16';
+const GLOSSARY_CONTENT_DATE = '2026-03-17';
 
 /** Maps locale codes to BCP-47 language tags used in schema.org inLanguage */
 const SCHEMA_LANGUAGE: Record<Locale, string> = {

--- a/content/glossary/de.ts
+++ b/content/glossary/de.ts
@@ -877,6 +877,16 @@ const translations: GlossaryTermTranslation[] = [
       "Eine Trackless Ride (schienenlose Themenfahrt) ist eine Dark-Ride-Variante, bei der die Fahrzeuge nicht an eine feste Schiene gebunden sind, sondern autonom durch den Attractionsraum navigieren — geführt durch Induktionsschleifen, WLAN oder Lasertechnik im Boden. Die freie Beweglichkeit ermöglicht wesentlich komplexere Szenengestaltung und nichtlineare Narrative: Fahrzeuge können drehen, kreisen und Szenen aus verschiedenen Winkeln anfahren. Bekannte Beispiele: Star Wars: Rise of the Resistance (Disney), Ratatouille: L'Aventure Totalement Toquée de Rémy (Disneyland Paris) und Symbolica (Efteling, Niederlande).",
     relatedTermIds: ['dark-ride', 'animatronics', 'themed-land'],
   },
+  {
+    id: 'roller-coaster-element',
+    name: 'Achterbahn-Element',
+    shortDefinition:
+      'Ein benannter Streckenabschnitt einer Achterbahn, z. B. Looping, Airtime-Hügel oder Inversion.',
+    definition:
+      'Ein Achterbahn-Element bezeichnet einen eigenständigen, benannten Teil einer Achterbahn-Strecke – von klassischen Inversionen wie Looping und Korkenzieher bis hin zu nicht-invertierenden Elementen wie Airtime-Hügeln, Helices und überneigten Kurven (Overbanks). Ingenieure gestalten jedes Element gezielt, um ein bestimmtes körperliches Erlebnis zu erzeugen: Schwerelosigkeit (Airtime), seitliche G-Kräfte oder die Desorientierung beim Kopf-über-Fahren. Enthusiasten und Hersteller weltweit verwenden präzise Begriffe für diese Elemente, um Coaster-Designs zu beschreiben und zu vergleichen.\n\nDas park.fan-Glossar erklärt Dutzende solcher Elemente – vom ersten Drop und Lifthill bis hin zu modernen Spezialformen wie dem Stengel Dive, Norwegian Loop und Heartline Roll.',
+    relatedTermIds: ['airtime', 'inversion', 'vertical-loop', 'helix', 'first-drop'],
+    aliases: ['Achterbahn-Elemente', 'Achterbahn-Elementen'],
+  },
 ];
 
 export default translations;

--- a/content/glossary/de.ts
+++ b/content/glossary/de.ts
@@ -880,6 +880,56 @@ const translations: GlossaryTermTranslation[] = [
     relatedTermIds: ['dark-ride', 'animatronics', 'themed-land'],
   },
   {
+    id: 'g-force',
+    name: 'G-Kraft',
+    shortDefinition:
+      'Die Beschleunigungseinheit, die Fahrgäste erleben, gemessen in Vielfachen der Erdgravitation (9,81 m/s²).',
+    definition:
+      'G-Kraft (Erdbeschleunigungsäquivalent) misst die Beschleunigung, die ein Fahrgast im Vergleich zur normalen Schwerkraft der Erde erlebt. Positive G-Kräfte (über 1G) drücken Fahrgäste in ihre Sitze, wenn der Zug durch ein Tal oder eine enge Kurve zieht. Negative G-Kräfte (unter 0G) heben Fahrgäste aus ihren Sitzen und erzeugen Airtime. Seitliche G-Kräfte (Laterals) wirken quer zur Fahrtrichtung und schieben Fahrgäste auf Kurven und Übergängen seitlich.\n\nAchterbahnen sind so konstruiert, dass diese Kräfte gezielt sequenziert werden. 4–5G in einem Talboden sind das Merkmal einer kraftvollen First-Drop-Einleitung. Ein kurzer Moment von −0,5G bis −1G auf einem Airtime-Hügel erzeugt das typische Schwebegefühl. Die meisten Bahnen zielen auf 0–5G anhaltende positive Kräfte ab, mit kurzen Spitzen für dramatische Effekte. Anhaltend hohe G-Belastungen über mehrere Sekunden können zu Unbehagen oder Greyout führen; gut gestaltete Coaster balancieren Intensitätspitzen mit Erholungsabschnitten.',
+    relatedTermIds: ['airtime', 'inversion', 'lateral-gs', 'hangtime'],
+    aliases: ['G-Kräfte', 'G-Force', 'G-Forces'],
+  },
+  {
+    id: 'lateral-gs',
+    name: 'Seitliche G-Kräfte',
+    shortDefinition:
+      'Seitwärtskräfte, die Fahrgäste auf Kurven, Übergängen und Helix-Abschnitten seitlich in den Sitz drücken.',
+    definition:
+      'Seitliche G-Kräfte (Laterals) entstehen, wenn sich eine Achterbahn in der horizontalen Ebene ändert – auf überhöhten und nichtüberhöhten Kurven, Helices und Richtungswechseln. Gut gestaltete Laterals sind weich und kontrolliert und tragen zu einem energetischen Fahrerlebnis bei. Schlecht konstruierte oder raue Laterals fühlen sich an, als würde man brutal gegen den Rückhalt oder die Sitzlehne geworfen – unangenehm und oft schmerzhaft.\n\nEnthusiasten unterscheiden zwischen glatten, beabsichtigten Laterals – wie in den weiten Tiefkurven einer klassischen Holzachterbahn – und harten, unbeabsichtigten Laterals durch Gleisverschleiß oder mangelhaftes Engineering. Holzachterbahnen sind besonders für Laterals bekannt: das Spiel im Gleis und die seitliche Energie nichtüberhöhter Kurven gelten als Teil des authentischen Holzachterbahn-Erlebnisses. Sanfte Lateral-Sequenzen in Helix-Passagen – wie bei Balder in Liseberg – werden von Coaster-Enthusiasten oft als Highlights genannt.',
+    relatedTermIds: ['g-force', 'airtime', 'helix', 'wooden-coaster'],
+    aliases: ['Laterals', 'Lateral-G-Kräfte', 'Lateral G', 'Laterale G-Kräfte'],
+  },
+  {
+    id: 'ejector-airtime',
+    name: 'Ejector Airtime',
+    shortDefinition:
+      'Intensive negative G-Kräfte, die Fahrgäste schlagartig aus dem Sitz reißen – gehalten nur vom Schoßbügel.',
+    definition:
+      'Ejector Airtime bezeichnet die intensivste Form negativer G-Kräfte: Die Bahn verlässt die freie Fallbahn so abrupt, dass Fahrgäste schlagartig aus ihren Sitzen gerissen werden – einzig der Schoßbügel hält sie im Fahrzeug. Der Name beschreibt genau das Gefühl: Es wirkt, als wolle der Sitz die Fahrgäste aktiv herausschleudern. Das unterscheidet sich fundamental vom sanften, langen Schweben beim Floater Airtime; Ejector ist scharf, plötzlich und kann bei abrupten Übergängen fast gewaltsam wirken.\n\nEjector Airtime ist am häufigsten mit RMC-Hybridachterbahnen, bestimmten Intamin-Hyper-Coastern und modernen Holzachterbahnen mit steilen, parabolischen Hügeln verbunden. Enthusiasten beschreiben die intensivsten Ejector-Momente als Höhepunkt eines Fahrprofils – ein kurzer, herzstockender Augenblick echter Schwerelosigkeit. Untamed in Walibi Holland, Wildfire in Kolmården und Steel Vengeance in Cedar Point gelten als Maßstab für intensive Ejector-Sequenzen.',
+    relatedTermIds: ['airtime', 'floater-airtime', 'airtime-hill', 'rmc', 'g-force'],
+    aliases: ['Ejector'],
+  },
+  {
+    id: 'floater-airtime',
+    name: 'Floater Airtime',
+    shortDefinition:
+      'Sanfte, anhaltende negative G-Kräfte mit einem langen Schwebegefühl beim Überkuppen eines Hügels.',
+    definition:
+      'Floater Airtime beschreibt das sanfte Ende des negativen G-Kraft-Spektrums: ein langsames, anhaltendes Schwebegefühl, bei dem Fahrgäste leicht aus dem Sitz aufsteigen und für einen ausgedehnten Moment schwerelos schweben, während der Zug einen Hügel auf einem flachen Parabelbogen überquert. Die Kraft ist mild – typischerweise etwa −0,1G bis −0,3G – und damit auch für Fahrgäste zugänglich, die den intensiven Ejector Airtime als zu viel empfinden.\n\nFloater Airtime ist am stärksten mit B&M-Hyper- und Giga-Coastern verbunden, die große, sanft gerundete Hügel nutzen, um lange Schwebeabschnitte zu erzeugen. Shambhala in PortAventura, Silver Star in Europa-Park und Goliath in Walibi Holland sind europäische Beispiele, die für ihre langen Floater-Sequenzen gefeiert werden. Viele Enthusiasten empfinden die entspannte Qualität des Floater Airtime als angenehmer und wiederholfähiger als den schroffen Ejector – die Gemeinschaft ist jedoch gespalten, welcher Stil vorzuziehen ist.',
+    relatedTermIds: ['airtime', 'ejector-airtime', 'airtime-hill', 'b-and-m', 'g-force'],
+    aliases: ['Floater'],
+  },
+  {
+    id: 'hangtime',
+    name: 'Hangtime',
+    shortDefinition:
+      'Das Gefühl, beim Überkopffahren schwerelos im Rückhalt zu hängen – ausgelöst durch negative G-Kräfte während einer Inversion.',
+    definition:
+      'Hangtime beschreibt die besondere Erfahrung negativer G-Kräfte während einer Inversion: Der Zug verweilt lange genug an der Spitze einer Überschlagsfigur, dass negative G-Kräfte wirksam werden – Fahrgäste hängen buchstäblich im Rückhalt. Anders als der kurze Kopf-unten-Moment eines schnellen Loopings entsteht Hangtime, wenn der Zug in der Nähe des Inversionsapex verlangsamt und ein ausgedehntes Hängegefühl erzeugt. Das Gewicht verlagert sich vollständig in die Schulterbügel oder den Schoßbügel, was eine einzigartig desorientierende Empfindung erzeugt.\n\nHangtime tritt am ausgeprägtesten bei Elementen auf, bei denen der Zug an der Inversions-Spitze stark verlangsamt – der Pretzel Loop auf Flying Coastern ist das klassische Beispiel, da die Geschwindigkeit so gering ist, dass anhaltende negative G-Kräfte im voll invertierten Zustand entstehen. Der Heartline Roll mancher moderner Bahnen kann ebenfalls Hangtime erzeugen. Enthusiasten betrachten Hangtime als eine der aufregendsten Inversionsempfindungen überhaupt.',
+    relatedTermIds: ['inversion', 'pretzel-loop', 'heartline-roll', 'g-force', 'airtime'],
+    aliases: ['Hang Time'],
+  },
+  {
     id: 'roller-coaster-element',
     name: 'Achterbahn-Element',
     shortDefinition:

--- a/content/glossary/de.ts
+++ b/content/glossary/de.ts
@@ -54,6 +54,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Die Besucherdichte beschreibt die allgemeine Besucherdichte in einem Park an einem bestimmten Tag oder zu einer bestimmten Zeit. park.fan verwendet eine Skala von Sehr Niedrig bis Extrem basierend auf historischen Wartezeitdaten, aktueller Belegung und KI-Prognosen. Ein Tag mit Sehr Niedriger Besucherdichte bedeutet kurze Schlangen und minimale Staus; ein Extremer Tag bedeutet maximale Besucherzahlen mit langen Wartezeiten bei den meisten Attraktionen.',
     relatedTermIds: ['crowd-calendar', 'peak-day', 'wait-time'],
+    aliases: ['Crowd-Level', 'Crowd-Levels', 'Besucherdichten'],
   },
   {
     id: 'crowd-calendar',
@@ -233,7 +234,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Die Warteschlange ist der physische Raum — Gänge, Außenbereiche mit Absperrungen oder thematisch gestaltete Innenräume —, den Besucher durchqueren, bevor sie eine Attraktion betreten. In modernen Freizeitparks ist die Warteschlange oft selbst Teil des Erlebnisses: Disney gestaltet sie als Einstimmung auf die Geschichte, Universal taucht die Wartenden bereits in die Welt der Attraktion ein. Eine gut gestaltete Warteschlange macht auch längere Wartezeiten erträglicher. park.fan zeigt dir die aktuellen Wartezeiten aller Attraktionen, damit du die Planung deines Parkbesuchs optimal anpassen kannst.',
     relatedTermIds: ['wait-time', 'standby-queue', 'single-rider'],
-    aliases: ['Warteschlangen'],
+    aliases: ['Warteschlangen', 'Schlange', 'Schlangen'],
   },
   {
     id: 'opening-day',
@@ -297,6 +298,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Eine Rückkehrzeit (oder Returntime) ist ein konkretes Zeitfenster — meist ein Ein-Stunden-Block —, in dem Besucher mit gebuchtem Vorrangzugang (über Lightning Lane, virtuelle Warteschlange oder ähnliche Systeme) am dedizierten Eingang der Attraktion einsteigen können. Die Rückkehrzeit gibt die Freiheit, die Zwischenzeit in anderen Parkbereichen zu genießen, anstatt in einer Schlange zu stehen. Wer das Zeitfenster verpasst — nach einer kurzen Toleranzzeit —, verliert die Reservierung. Mit den Live-Wartezeiten und Besucherdichte-Daten von park.fan kannst du gezielt entscheiden, welche Attraktionen du für Rückkehrzeiten einplanen möchtest.',
     relatedTermIds: ['lightning-lane', 'virtual-queue', 'fastpass', 'boarding-group'],
+    aliases: ['Rückkehrzeiten', 'Returntime', 'Returntimes'],
   },
   {
     id: 'airtime',

--- a/content/glossary/de.ts
+++ b/content/glossary/de.ts
@@ -362,6 +362,27 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Eine Holzachterbahn ist eine Bahn mit hölzerner Strecke und Struktur. Anders als Stahlbahnen hat Holz eine natürliche Flexibilität und Ungenauigkeit, die das charakteristische Rumpeln, seitliche Schaukeln und unberechenbare Airtime erzeugt, das Enthusiasten lieben. Berühmte Holzachterbahnen sind Balder in Liseberg, Colossos in Heide-Park und Wodan im Europa-Park. Holzachterbahnen erfordern intensive Wartung — das Schienenprofil muss regelmäßig erneuert werden. Das RMC (Rocky Mountain Construction)-Konvertierungsverfahren kann alte Holzachterbahnen in Hybrid-Coaster verwandeln, die die Holzstruktur behalten, aber einen Stahlschieneneinsatz erhalten.',
     relatedTermIds: ['airtime', 'hybrid-coaster', 'rmc'],
+    aliases: ['Holzachterbahnen', 'Holzbahn'],
+  },
+  {
+    id: 'steel-coaster',
+    name: 'Stahlachterbahn',
+    shortDefinition:
+      'Eine Achterbahn mit Stahlschiene und Stahlstruktur, bekannt für ihre glatte und präzise Fahrt.',
+    definition:
+      'Eine Stahlachterbahn wird mit Stahlschiene und Stahlstützgerüst gebaut. Anders als Holzachterbahnen mit ihrer natürlichen Flexibilität bietet Stahl Ingenieuren präzise Kontrolle über G-Kräfte, Übergänge und Inversionen. Die glatte, vorhersagbare Fahrt einer Stahlachterbahn ermöglicht komplexe Layouts mit mehreren Inversionen, engen Kurvenradien und hohen Geschwindigkeiten.\n\nStahlachterbahnen dominieren die moderne Achterbahnentwicklung, weil Designer damit fast jede Form verwirklichen können — Überkopf-Drops, vollständige Inversionen und schnelle Richtungswechsel. Berühmte Stahlachterbahnen in Europa sind Shambhala in PortAventura, Nemesis in Alton Towers und Silver Star im Europa-Park. Stahlachterbahnen reichen von kleinen Familienbahnen bis zu Rekord-Mega-Coastern. Die Präzision von Stahl erfordert regelmäßige Kontrolle und Wartung, ist aber weniger fehleranfällig als die flexible Holzkonstruktion.',
+    relatedTermIds: ['wooden-coaster', 'inversion', 'launch-coaster', 'hyper-coaster'],
+    aliases: ['Stahlachterbahnen', 'Stahlschiene'],
+  },
+  {
+    id: 'suspended-coaster',
+    name: 'Suspended Coaster',
+    shortDefinition:
+      'Eine Achterbahn, bei der die Wagen unter der Schiene an einem Pivot hängen und seitlich frei schwingen können.',
+    definition:
+      'Eine Suspended Coaster ist ein spezieller Achterbahntyp, bei dem der Zug von oben an einem Pivot aufgehängt ist und seitlich unabhängig von der Schienenbahn schwingen kann. Während der Zug durch Kurven navigiert, schwingt er wie ein Pendel — eine Bewegung, die die charakteristische "Whip"-Sensation erzeugt. Diese Schwingbewegung unterscheidet sich von einer Inverted Coaster, wo der Zug starr an der Schiene befestigt ist.\n\nSuspended Coasters sind seltener als Inverted Coasters, bieten aber ein einzigartiges Erlebnis. Die Schwingbewegung macht selbst moderate Kurven dramatisch wirken, und das Gefühl des Fliegens erzeugt eine spannende Exposition. Vekoma entwickelte in den 1990er Jahren die Suspended Looping Coaster (SLC), von denen weltweit hunderte gebaut wurden. Die Schwingbewegung kann chaotisch wirken im Vergleich zur Präzision moderner Inversionen — manche Enthusiasten lieben sie für ihre rohe, unvorhersagbare Natur, während andere sie weniger mochten.',
+    relatedTermIds: ['inverted-coaster', 'b-and-m', 'vekoma'],
+    aliases: ['Suspended', 'Hängende Achterbahn'],
   },
   {
     id: 'hybrid-coaster',

--- a/content/glossary/en.ts
+++ b/content/glossary/en.ts
@@ -27,6 +27,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "A virtual queue (sometimes called a boarding group or return time) lets guests register for a ride via a park app or kiosk and receive a notification when their turn is approaching. Instead of standing in a physical queue, guests can explore other attractions, eat, or rest until their group is called. Parks use virtual queues for their highest-demand new attractions where physical queuing would create dangerous or unmanageable crowd concentrations.\n\nVirtual queues typically open at a fixed time — often the moment the park gates open — and can fill within minutes on busy days. Disney has used the system for Star Wars: Rise of the Resistance and Tron Lightcycle Run; Universal introduced it for Hagrid's Magical Creatures Motorbike Adventure. The key planning insight is that securing a virtual queue spot is often the very first thing you should do upon entering the park, before visiting any other attraction.",
     relatedTermIds: ['express-pass', 'wait-time', 'single-rider'],
+    aliases: ['Virtual Queues'],
   },
   {
     id: 'express-pass',
@@ -54,6 +55,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "Crowd level describes the overall visitor density at a park on a given day or time. park.fan uses a scale from Very Low to Extreme based on historical wait time data, current occupancy patterns, and AI-driven predictions. A Very Low day means short queues across almost all attractions, a relaxed atmosphere, and manageable crowds at restaurants. An Extreme day means the park is operating near maximum capacity, with waits of 90 minutes or more for popular rides and queues forming even at quick-service food outlets.\n\nCrowd levels are shaped by school holidays, public holidays, special events (fireworks, Halloween nights), seasonal patterns, and even weather forecasts. Understanding how these factors combine is essential for planning a visit that matches your priorities. park.fan's crowd calendar presents this data in an easy day-by-day view so you can identify windows of lower attendance weeks or months in advance.",
     relatedTermIds: ['crowd-calendar', 'peak-day', 'wait-time'],
+    aliases: ['Crowd Levels'],
   },
   {
     id: 'crowd-calendar',
@@ -877,6 +879,16 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'A trackless ride is a type of dark ride where vehicles are not constrained to a fixed track but navigate autonomously through the attraction space, guided by induction loops, Wi-Fi positioning systems, or laser/optical guidance embedded in the floor. The freedom of movement allows for dramatically more complex scene layouts, non-linear storytelling, and sequences where vehicles approach scenes from multiple angles, spin to face different directions, or travel through the same space as other vehicles simultaneously.\n\nTrackless technology is increasingly the standard for major new dark ride investments. Star Wars: Rise of the Resistance at Disneyland Paris and Walt Disney World uses trackless vehicles as part of an extraordinarily complex multi-room experience. Ratatouille: The Adventure at Disneyland Paris was an early and beloved European example when it opened in 2014. Symbolica at Efteling in the Netherlands is another celebrated trackless ride that has become a flagship attraction. The flexibility of the format allows designers to create entirely new storytelling possibilities that the fixed-track dark ride format simply cannot replicate.',
     relatedTermIds: ['dark-ride', 'animatronics', 'themed-land'],
+  },
+  {
+    id: 'roller-coaster-element',
+    name: 'Roller Coaster Element',
+    shortDefinition:
+      'A named section or feature of a roller coaster track, such as a loop, airtime hill, or inversion.',
+    definition:
+      "A roller coaster element is any distinct, named feature incorporated into a coaster's layout — from classic inversions like vertical loops and corkscrews to non-inverting elements like airtime hills, helices, and overbanks. Engineers design each element to produce a specific physical sensation: weightlessness (airtime), lateral G-forces, or the disorientation of going upside down. Coaster enthusiasts and manufacturers use precise names for these features to describe, compare, and rate ride designs worldwide.\n\npark.fan's glossary covers dozens of individual coaster elements — from the first drop and lifthill that open every ride to advanced features like the Stengel dive, Norwegian loop, and heartline roll found on modern steel coasters.",
+    relatedTermIds: ['airtime', 'inversion', 'vertical-loop', 'helix', 'first-drop'],
+    aliases: ['Roller Coaster Elements'],
   },
 ];
 

--- a/content/glossary/en.ts
+++ b/content/glossary/en.ts
@@ -299,6 +299,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "A return time (sometimes called a return window) is a specific time period — typically a one-hour block — during which a guest who has booked priority access can present at the attraction's dedicated entrance. Return times are issued by Lightning Lane reservations, virtual queue boarding group assignments, and legacy systems like FastPass+. They allow guests to spend the intervening period exploring other areas of the park rather than standing in a physical queue.\n\nMissing your return time window typically forfeits the reservation, though Disney and Universal both offer some grace-period flexibility. Return time management — knowing which attractions to book first, when to book your second reservation, and how long it takes to walk between areas of the park — is a skill that separates experienced park visitors from first-timers. park.fan's live wait time data helps inform which attractions are worth using a return time on versus which can be done efficiently in standby.",
     relatedTermIds: ['lightning-lane', 'virtual-queue', 'fastpass', 'boarding-group'],
+    aliases: ['Return Times'],
   },
   {
     id: 'airtime',

--- a/content/glossary/en.ts
+++ b/content/glossary/en.ts
@@ -882,6 +882,56 @@ const translations: GlossaryTermTranslation[] = [
     relatedTermIds: ['dark-ride', 'animatronics', 'themed-land'],
   },
   {
+    id: 'g-force',
+    name: 'G-Force',
+    shortDefinition:
+      "The unit of acceleration experienced by riders, measured as multiples of Earth's gravitational acceleration (9.81 m/s²).",
+    definition:
+      "G-force (gravitational force equivalent) measures the acceleration a rider's body experiences relative to Earth's gravity. Positive G-forces (above 1G) press riders into their seats as the train pulls through a valley or tight curve — the same force that makes you feel heavy in a fast car. Negative G-forces (below 0G) lift riders from their seats, creating airtime. Lateral G-forces act sideways, pushing riders across their seat on turns and transitions.\n\nRoller coasters are designed to sequence these forces deliberately. A sustained 4–5G valley is the hallmark of a powerful first drop transition. A brief −0.5G to −1G moment on an airtime hill produces the signature floating sensation. Most coasters target a range of 0–5G of sustained positive G-force, with brief spikes above this for dramatic effect. Sustained high-G exposure beyond a few seconds can cause discomfort or greyout; well-designed coasters balance intensity peaks with recovery sections.",
+    relatedTermIds: ['airtime', 'inversion', 'lateral-gs', 'hangtime'],
+    aliases: ['G-Forces', 'G Force', 'G Forces'],
+  },
+  {
+    id: 'lateral-gs',
+    name: 'Lateral Gs',
+    shortDefinition:
+      'Sideways forces pushing riders across their seat during turns, transitions, and helix sections.',
+    definition:
+      "Lateral Gs (lateral G-forces) are the sideways accelerations riders experience when a coaster changes direction in the horizontal plane — on banked turns, unbanked transitions, helices, and direction changes. Well-designed laterals are smooth and controlled, contributing to an energetic and engaging ride experience. Poorly engineered or rough laterals feel like being thrown sideways against the restraint or seat back, which can be uncomfortable or even bruising.\n\nEnthusiasts distinguish between smooth, intentional laterals — like those found in the sweeping low turns of a classic wooden coaster or the exits of a well-banked steel turn — and harsh, unintended laterals produced by track deterioration or poor engineering. Wooden coasters are especially associated with lateral movement: the flex in the track and the side-to-side energy of unbanked turns is considered part of the authentic wooden coaster experience. Smooth lateral G sequences in a helix section, like those on Balder at Liseberg, are often cited as highlights by coaster enthusiasts.",
+    relatedTermIds: ['g-force', 'airtime', 'helix', 'wooden-coaster'],
+    aliases: ['Laterals', 'Lateral G-Forces', 'Lateral G'],
+  },
+  {
+    id: 'ejector-airtime',
+    name: 'Ejector Airtime',
+    shortDefinition:
+      'Intense negative G-forces that aggressively thrust riders from their seat, held in place only by the lap bar.',
+    definition:
+      "Ejector airtime describes the most intense form of negative G-force, where the coaster's trajectory departs so abruptly from free fall that riders are thrown powerfully from their seats — held in only by the lap bar. The name reflects the sensation: it feels as though the seat is actively trying to eject you. This is distinct from the gentle, prolonged floating of floater airtime; ejector is sharp, sudden, and can verge on violent if the transition into it is abrupt.\n\nEjector airtime is most commonly associated with RMC hybrid coasters, certain Intamin hypers, and modern wooden coasters with steep, parabolic hills. Enthusiasts describe the best ejector moments as the highlight of a ride experience — a brief, heart-stopping instant of true weightlessness before the track pulls you back. Untamed at Walibi Holland, Wildfire at Kolmården, and Steel Vengeance at Cedar Point are frequently cited as delivering some of the world's most intense ejector sequences. The intensity is one of the primary reasons RMC coasters have achieved cult status in the enthusiast community.",
+    relatedTermIds: ['airtime', 'floater-airtime', 'airtime-hill', 'rmc', 'g-force'],
+    aliases: ['Ejector'],
+  },
+  {
+    id: 'floater-airtime',
+    name: 'Floater Airtime',
+    shortDefinition:
+      'Gentle, sustained negative G-forces producing a prolonged floating sensation as the train crests a hill.',
+    definition:
+      "Floater airtime describes the gentle end of the negative G-force spectrum: a slow, prolonged sensation where riders rise slightly from their seats and float weightlessly for an extended moment as the train crests a hill following a gradual parabolic arc. The force is mild — typically around −0.1G to −0.3G — making it accessible and pleasurable even for riders who find intense ejector airtime overwhelming.\n\nFloater airtime is most characteristic of B&M hyper and giga coasters, which use large, gently rounded hills specifically engineered to produce extended float phases. Shambhala at PortAventura, Silver Star at Europa-Park, and Goliath at Walibi Holland are European examples celebrated for their long, floaty airtime sequences. Many enthusiasts consider the prolonged, relaxed quality of floater airtime more comfortable and repeatable than the sharp intensity of ejector, though enthusiast opinion is divided on which style is superior. The two types are not mutually exclusive — a single airtime hill can transition from floater at the crest to ejector on the descent.",
+    relatedTermIds: ['airtime', 'ejector-airtime', 'airtime-hill', 'b-and-m', 'g-force'],
+    aliases: ['Floater'],
+  },
+  {
+    id: 'hangtime',
+    name: 'Hangtime',
+    shortDefinition:
+      'The sensation of hanging weightlessly in restraints during an inversion, caused by negative G-forces while upside down.',
+    definition:
+      "Hangtime describes the distinct experience of negative G-forces while a rider is inverted — literally hanging in the restraints as the coaster moves through the top of an inversion slowly enough for negative Gs to take effect. Unlike the brief upside-down flash of a fast vertical loop, hangtime occurs when the train lingers near the apex of an inversion, producing a drawn-out sensation of suspension. Riders feel their weight shift entirely into the over-the-shoulder restraints or lap bar, creating a uniquely disorienting and memorable moment.\n\nHangtime is most pronounced on elements where the train slows significantly near the inversion apex — the pretzel loop on flying coasters is the classic example, as train speed at the apex is low enough for sustained negative Gs while fully inverted. The heartline roll on some modern coasters can also produce hangtime, as can the tops of slow Norwegian loops. Enthusiasts generally consider hangtime one of the most thrilling inversion sensations, distinct from both the sustained positive-G compression of a fast vertical loop and the floating of conventional airtime.",
+    relatedTermIds: ['inversion', 'pretzel-loop', 'heartline-roll', 'g-force', 'airtime'],
+    aliases: ['Hang Time'],
+  },
+  {
     id: 'roller-coaster-element',
     name: 'Roller Coaster Element',
     shortDefinition:

--- a/content/glossary/en.ts
+++ b/content/glossary/en.ts
@@ -363,6 +363,27 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "A wooden coaster is built with a wooden track structure (laminated layers of wood) on a wooden or steel support frame. Unlike steel coasters, wood has natural flex and imprecision in its construction that creates the characteristic rumble, lateral shuffle, and unpredictable airtime that enthusiasts prize. The experience tends to feel more raw and physical than the smooth precision of a steel coaster — a quality many riders find uniquely appealing.\n\nFamous wooden coasters include Balder at Liseberg (Sweden), widely regarded as Europe's best wooden coaster, The Beast at Kings Island (one of the longest in the world at 2.2 km), and Megafobia at Oakwood in Wales. Wooden coasters require significant ongoing maintenance — rails must be relaminated, checked, and replaced on a continuous cycle — and their ride characteristics change noticeably with temperature and humidity. Rocky Mountain Construction's conversion process can transform an ageing wooden coaster into a steel I-box hybrid, opening up new design possibilities while retaining the iconic wooden structure.",
     relatedTermIds: ['airtime', 'hybrid-coaster', 'rmc'],
+    aliases: ['Woodie', 'Woodies'],
+  },
+  {
+    id: 'steel-coaster',
+    name: 'Steel Coaster',
+    shortDefinition:
+      'A roller coaster built primarily with steel track and support structure, known for its smooth, precise ride experience.',
+    definition:
+      "A steel coaster is built with tubular or flat steel track supported by a steel lattice or tubular frame. Unlike wooden coasters with their natural flex and unpredictable motion, steel offers engineers precise control over G-forces, transitions, and inversions. The smooth, predictable ride of a steel coaster makes it ideal for executing complex layouts with multiple inversions, tight radius curves, and sustained high-speed sections.\n\nSteel coasters dominate modern coaster development because they allow designers to create nearly any shape imaginable — beyond-vertical drops, complete inversions, and rapid direction changes. The most celebrated steel coasters in Europe include Shambhala at PortAventura, Nemesis at Alton Towers, and Silver Star at Europa-Park. Steel coasters range from small family rides to record-breaking mega coasters, making the category the most versatile in the theme park industry. The precision of steel comes at a cost: maintenance requires careful track inspection and frequent repainting, and the steel structure is less forgiving of design errors than the flexibility of wood.",
+    relatedTermIds: ['wooden-coaster', 'inversion', 'launch-coaster', 'hyper-coaster'],
+    aliases: ['Steel Coasters', 'Steel track'],
+  },
+  {
+    id: 'suspended-coaster',
+    name: 'Suspended Coaster',
+    shortDefinition:
+      'A coaster where the train hangs below the track on a swinging pivot, allowing the vehicle to swing freely side to side.',
+    definition:
+      "A suspended coaster is a specialized coaster type where the train is suspended from above on a pivot point, allowing it to swing side to side independently of the track's path. As the train navigates curves, it swings outward like a pendulum — a motion that creates the characteristic 'whip' sensation and adds an unpredictable element to the ride experience. This swinging motion is distinct from an inverted coaster, where the train is rigidly attached above the track.\n\nSuspended coasters are less common than inverted coasters but offer a unique experience. The swinging motion makes even moderate-speed turns feel dramatic, and the sensation of 'flying' with the ground far below (or nearby obstacles) creates a thrilling exposure. Vekoma pioneered the Suspended Looping Coaster (SLC) model in the 1990s, and hundreds were built worldwide due to the format's compact footprint and distinctive experience. Kumba at Busch Gardens Tampa (B&M suspended) and the Vekoma suspended coasters at European parks remain popular examples. The swinging motion can feel chaotic compared to the precision of modern inversions, making suspended coasters either beloved for their raw, unpredictable nature or polarizing among enthusiasts.",
+    relatedTermIds: ['inverted-coaster', 'b-and-m', 'vekoma'],
+    aliases: ['Suspended', 'Swinging coaster'],
   },
   {
     id: 'hybrid-coaster',

--- a/content/glossary/es.ts
+++ b/content/glossary/es.ts
@@ -880,6 +880,56 @@ const translations: GlossaryTermTranslation[] = [
     aliases: ['Previsiones de afluencia'],
   },
   {
+    id: 'g-force',
+    name: 'Fuerza G',
+    shortDefinition:
+      "La unidad de aceleración que experimentan los pasajeros, medida como múltiplos de la aceleración gravitacional terrestre (9,81 m/s²).",
+    definition:
+      'La fuerza G (equivalente gravitacional) mide la aceleración que experimenta un pasajero en relación con la gravedad normal de la Tierra. Las fuerzas G positivas (por encima de 1G) presionan a los pasajeros contra sus asientos al pasar por valles o curvas cerradas. Las fuerzas G negativas (por debajo de 0G) levantan a los pasajeros de sus asientos y crean airtime. Las fuerzas G laterales actúan horizontalmente, empujando a los pasajeros hacia los lados en curvas y transiciones.\n\nLas montañas rusas están diseñadas para secuenciar estas fuerzas de forma deliberada. Un valle que genera 4–5G es la marca de una transición del primer descenso potente. Un breve momento de −0,5G en una colina de airtime produce la característica sensación de flotación. La mayoría de las atracciones apuntan a 0–5G de fuerzas positivas sostenidas, con picos breves para efectos dramáticos. Una exposición prolongada a fuerzas G elevadas puede causar malestar o greyout; las montañas rusas bien diseñadas equilibran los picos de intensidad con secciones de recuperación.',
+    relatedTermIds: ['airtime', 'inversion', 'lateral-gs', 'hangtime'],
+    aliases: ['Fuerzas G', 'G-Force', 'G-Forces'],
+  },
+  {
+    id: 'lateral-gs',
+    name: 'Fuerzas Laterales',
+    shortDefinition:
+      'Fuerzas horizontales que empujan a los pasajeros hacia los lados en curvas, transiciones y secciones en hélice.',
+    definition:
+      "Las fuerzas G laterales (o fuerzas laterales) son las aceleraciones horizontales que experimentan los pasajeros cuando una montaña rusa cambia de dirección en el plano horizontal — en curvas inclinadas o no inclinadas, hélices y cambios de dirección. Las fuerzas laterales bien diseñadas son suaves y controladas, contribuyendo a una experiencia dinámica. Las fuerzas laterales mal diseñadas o rugosas se sienten como ser lanzado bruscamente contra el respaldo o el costado del asiento, lo que puede ser incómodo o doloroso.\n\nLos entusiastas distinguen entre fuerzas laterales suaves e intencionales — como en las amplias curvas bajas de una clásica montaña rusa de madera — y fuerzas laterales bruscas debidas al desgaste del carril o a una ingeniería deficiente. Las montañas rusas de madera están especialmente asociadas al movimiento lateral: la flexibilidad del carril y la energía lateral de las curvas no inclinadas se consideran parte de la experiencia auténtica. Las secuencias laterales suaves en secciones de hélice — como en Balder en Liseberg — son frecuentemente citadas como momentos destacados por los aficionados.",
+    relatedTermIds: ['g-force', 'airtime', 'helix', 'wooden-coaster'],
+    aliases: ['Laterales', 'Fuerzas G Laterales', 'Lateral G'],
+  },
+  {
+    id: 'ejector-airtime',
+    name: 'Ejector Airtime',
+    shortDefinition:
+      'Intensas fuerzas G negativas que proyectan bruscamente a los pasajeros fuera de su asiento, retenidos solo por el arnés de rodillas.',
+    definition:
+      "El ejector airtime describe la forma más intensa de fuerzas G negativas: la trayectoria de la atracción se desvía tan bruscamente de la caída libre que los pasajeros son lanzados con fuerza fuera de sus asientos, retenidos únicamente por el arnés de rodillas. La sensación es la de ser activamente expulsado del asiento — distinta del suave y prolongado flotamiento del floater airtime, el ejector es repentino y puede rozar lo violento si la transición es demasiado abrupta.\n\nEl ejector airtime se asocia especialmente con los hybrid coasters RMC, ciertos hyper coasters Intamin y las modernas montañas rusas de madera con colinas parabólicas pronunciadas. Los entusiastas describen los mejores momentos de ejector como el punto culminante de un circuito — un breve e impactante instante de ingravidez real. Untamed en Walibi Holland, Wildfire en Kolmården y Steel Vengeance en Cedar Point son frecuentemente citados por sus secuencias ejector entre las más intensas del mundo.",
+    relatedTermIds: ['airtime', 'floater-airtime', 'airtime-hill', 'rmc', 'g-force'],
+    aliases: ['Ejector'],
+  },
+  {
+    id: 'floater-airtime',
+    name: 'Floater Airtime',
+    shortDefinition:
+      'Suaves y prolongadas fuerzas G negativas que producen una larga sensación de flotación al coronar una colina.',
+    definition:
+      'El floater airtime describe el extremo suave del espectro de fuerzas G negativas: una sensación lenta y prolongada en la que los pasajeros se elevan ligeramente de su asiento y flotan en ingravidez durante un largo momento mientras el tren corona una colina siguiendo un arco parabólico gradual. La fuerza es leve — típicamente entre −0,1G y −0,3G — lo que la hace accesible y placentera incluso para los pasajeros que encuentran demasiado intenso el ejector airtime.\n\nEl floater airtime es característico de los hyper y giga coasters de B&M, que utilizan grandes colinas suavemente redondeadas diseñadas para producir largas fases de flotación. Shambhala en PortAventura, Silver Star en Europa-Park y Goliath en Walibi Holland son ejemplos europeos celebrados por sus largas secuencias floater. Muchos entusiastas encuentran la calidad relajada del floater más cómoda y repetible que la aguda intensidad del ejector, aunque las opiniones están divididas sobre cuál estilo es superior.',
+    relatedTermIds: ['airtime', 'ejector-airtime', 'airtime-hill', 'b-and-m', 'g-force'],
+    aliases: ['Floater'],
+  },
+  {
+    id: 'hangtime',
+    name: 'Hangtime',
+    shortDefinition:
+      'La sensación de colgar suspendido en los arneses durante una inversión, causada por fuerzas G negativas boca abajo.',
+    definition:
+      "El hangtime describe la experiencia particular de las fuerzas G negativas durante una inversión: el tren permanece suficiente tiempo cerca del apogeo de un elemento invertido para que las fuerzas G negativas tengan efecto — los pasajeros quedan literalmente suspendidos en sus arneses. A diferencia del breve momento invertido de un looping rápido, el hangtime ocurre cuando el tren reduce la velocidad cerca del apex de la inversión y crea una suspensión prolongada. El peso del cuerpo se desplaza completamente hacia los arneses de hombros o el arnés de rodillas, creando una sensación de desorientación memorable.\n\nEl hangtime es más pronunciado en los elementos donde el tren reduce considerablemente la velocidad cerca del apex de la inversión — el pretzel loop en los flying coasters es el ejemplo clásico, ya que la velocidad es suficientemente baja para fuerzas G negativas sostenidas en posición completamente invertida. El heartline roll de algunas atracciones modernas también puede producir hangtime. Los entusiastas generalmente consideran el hangtime como una de las sensaciones de inversión más emocionantes.",
+    relatedTermIds: ['inversion', 'pretzel-loop', 'heartline-roll', 'g-force', 'airtime'],
+    aliases: ['Hang Time'],
+  },
+  {
     id: 'roller-coaster-element',
     name: 'Elemento de montaña rusa',
     shortDefinition:

--- a/content/glossary/es.ts
+++ b/content/glossary/es.ts
@@ -9,6 +9,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'El tiempo de espera es la duración estimada que un visitante pasa en la cola antes de poder subir a una atracción. Los parques muestran los tiempos de espera en las entradas de las atracciones y en sus aplicaciones. park.fan realiza un seguimiento de los tiempos de espera en vivo que se actualizan cada minuto.',
     relatedTermIds: ['posted-wait-time', 'virtual-queue', 'single-rider', 'express-pass'],
+    aliases: ['Tiempos de espera'],
   },
   {
     id: 'single-rider',
@@ -233,6 +234,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'La cola es el espacio físico — pasillos, serpentines exteriores o salas interiores — que los visitantes recorren mientras esperan para embarcar en una atracción. En muchos parques temáticos modernos, la cola forma parte de la propia experiencia: la cola de la Haunted Mansion de Disney ambienta antes incluso de subir al Doom Buggy, mientras que las atracciones de Harry Potter en Universal sumergen a los visitantes en su mundo desde que se unen a la fila. Una cola bien diseñada hace la espera mucho más llevadera, incluso cuando es larga.',
     relatedTermIds: ['wait-time', 'standby-queue', 'single-rider'],
+    aliases: ['Colas', 'Fila', 'Filas'],
   },
   {
     id: 'opening-day',
@@ -287,6 +289,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Una hora de regreso (o return window) es un período de tiempo específico — habitualmente un bloque de una hora — durante el cual un visitante que ha reservado acceso prioritario (mediante Lightning Lane, una cola virtual o sistema similar) puede presentarse en la entrada dedicada de la atracción. Las horas de regreso permiten a los visitantes explorar otras zonas del parque durante el intervalo en lugar de esperar en una cola física. Si se pierde la ventana horaria — normalmente definida como llegar más tarde de un número determinado de minutos — se suele perder la reserva. Los datos de tiempos de espera y niveles de afluencia de park.fan te ayudan a decidir qué atracciones priorizar para la reserva.',
     relatedTermIds: ['lightning-lane', 'virtual-queue', 'fastpass', 'boarding-group'],
+    aliases: ['Horas de regreso'],
   },
   {
     id: 'ert',

--- a/content/glossary/es.ts
+++ b/content/glossary/es.ts
@@ -27,6 +27,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Una cola virtual permite a los visitantes registrarse para una atracción a través de una app o quiosco y recibir una notificación cuando se acerca su turno. En lugar de hacer cola físicamente, los visitantes pueden disfrutar de otras áreas del parque y regresar cuando sean llamados.',
     relatedTermIds: ['express-pass', 'wait-time', 'single-rider'],
+    aliases: ['Colas virtuales'],
   },
   {
     id: 'express-pass',
@@ -54,6 +55,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'El nivel de afluencia describe la densidad general de visitantes en un parque en un día u hora determinados. park.fan utiliza una escala de Muy Bajo a Extremo basada en datos históricos de tiempos de espera, ocupación actual y predicciones de IA.',
     relatedTermIds: ['crowd-calendar', 'peak-day', 'wait-time'],
+    aliases: ['Niveles de afluencia'],
   },
   {
     id: 'crowd-calendar',
@@ -873,6 +875,16 @@ const translations: GlossaryTermTranslation[] = [
       'Una previsión de afluencia es una predicción basada en datos de cuánto de lleno estará un parque temático en un día u hora específicos. park.fan recalcula las previsiones de afluencia diariamente usando datos históricos de asistencia, calendarios escolares, datos meteorológicos y eventos especiales. Los resultados alimentan directamente el calendario de afluencia: los días verdes indican colas cortas, los días rojos señalan afluencia máxima con largas esperas.',
     relatedTermIds: ['crowd-calendar', 'ai-forecast', 'peak-day', 'crowd-level'],
     aliases: ['Previsiones de afluencia'],
+  },
+  {
+    id: 'roller-coaster-element',
+    name: 'Elemento de montaña rusa',
+    shortDefinition:
+      'Una sección o característica nombrada de una montaña rusa, como un loop, una colina de airtime o una inversión.',
+    definition:
+      'Un elemento de montaña rusa es cualquier característica distinta y denominada incorporada en el trazado de una montaña rusa — desde inversiones clásicas como loops y sacacorchos hasta elementos no inversores como colinas de airtime, hélices y overbanks. Los ingenieros diseñan cada elemento para producir una sensación física específica: ingravidez (airtime), fuerzas G laterales o la desorientación de ir boca abajo.\n\nEl glosario de park.fan cubre docenas de elementos individuales — desde el primer drop y el lifthill hasta especialidades modernas como el Stengel dive, el Norwegian loop y el heartline roll.',
+    relatedTermIds: ['airtime', 'inversion', 'vertical-loop', 'helix', 'first-drop'],
+    aliases: ['Elementos de montaña rusa'],
   },
 ];
 

--- a/content/glossary/es.ts
+++ b/content/glossary/es.ts
@@ -398,6 +398,27 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Una montaña rusa de madera es una atracción construida con pista y estructura de soporte de madera. A diferencia de las de acero, la madera tiene una flexión y una imprecisión naturales que crean la característica vibración, el bamboleo lateral y el airtime impredecible que tanto gustan a los entusiastas. Entre las montañas rusas de madera más famosas están Balder en Liseberg, The Beast en Kings Island y Megafobia en Oakwood. Requieren un mantenimiento constante — la pista debe relamiparse regularmente — y son sensibles a los cambios meteorológicos. El proceso de conversión de RMC puede transformar viejas montañas rusas de madera en coasters híbridos de pista de acero manteniendo la estructura de madera.',
     relatedTermIds: ['airtime', 'hybrid-coaster', 'rmc'],
+    aliases: ['Woodies', 'Montañas rusas de madera'],
+  },
+  {
+    id: 'steel-coaster',
+    name: 'Montaña rusa de acero',
+    shortDefinition:
+      'Una montaña rusa construida principalmente con pista y estructura de acero, conocida por su viaje suave y preciso.',
+    definition:
+      'Una montaña rusa de acero se construye con pista tubular o plana de acero soportada por una estructura de acero. A diferencia de las montañas rusas de madera con su flexibilidad natural, el acero ofrece a los ingenieros un control preciso de las fuerzas G, transiciones e inversiones. El viaje suave y predecible de una montaña rusa de acero permite crear layouts complejos con múltiples inversiones, curvas cerradas y secciones de alta velocidad.\n\nLas montañas rusas de acero dominan el desarrollo moderno de coasters. Los ejemplos más celebrados en Europa incluyen Shambhala en PortAventura, Nemesis en Alton Towers y Silver Star en Europa-Park. Las montañas rusas de acero van desde pequeñas atracciones familiares hasta mega coasters récord-rompedores. La precisión del acero requiere inspección y mantenimiento regular, pero permite menos margen de error de diseño que la flexibilidad de la madera.',
+    relatedTermIds: ['wooden-coaster', 'inversion', 'launch-coaster', 'hyper-coaster'],
+    aliases: ['Montañas rusas de acero', 'Acero'],
+  },
+  {
+    id: 'suspended-coaster',
+    name: 'Suspended Coaster',
+    shortDefinition:
+      'Un coaster donde el tren cuelga debajo de la pista en un pivote, permitiendo que el vehículo se balancee libremente de lado a lado.',
+    definition:
+      'Un suspended coaster es un tipo de coaster especializado donde el tren cuelga desde arriba en un punto pivote, permitiéndole balancearse libremente de un lado a otro independientemente de la trayectoria de la pista. Mientras el tren navega por las curvas, se balancea como un péndulo — un movimiento que crea la sensación característica del \"whip\" y añade un elemento impredecible a la experiencia. Este movimiento de balanceo es distinto de un coaster invertido, donde el tren está rígidamente unido encima de la pista.\n\nLos suspended coasters son menos comunes que los coasters invertidos pero ofrecen una experiencia única. El movimiento de balanceo hace que incluso las curvas moderadas se sientan dramáticas, y la sensación de \"volar\" con el terreno lejano crea una exposición emocionante. Vekoma creó el modelo Suspended Looping Coaster (SLC) en los años 90, y cientos fueron construidos mundialmente. El movimiento de balanceo puede parecer caótico en comparación con la precisión de las inversiones modernas, haciendo que los suspended coasters sean amados por su naturaleza cruda e impredecible.',
+    relatedTermIds: ['inverted-coaster', 'b-and-m', 'vekoma'],
+    aliases: ['Suspended', 'Oscilante'],
   },
   {
     id: 'hybrid-coaster',

--- a/content/glossary/fr.ts
+++ b/content/glossary/fr.ts
@@ -234,6 +234,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "La file d'attente est l'espace physique — couloirs, serpentins extérieurs ou salles intérieures — que les visiteurs parcourent en attendant d'embarquer sur une attraction. Dans de nombreux parcs modernes, la file fait elle-même partie de l'expérience : la file de la Haunted Mansion chez Disney crée l'atmosphère bien avant de monter dans le Doom Buggy, tandis que les attractions Harry Potter d'Universal plongent les visiteurs dans leur univers dès la file. Une file bien conçue rend l'attente beaucoup plus agréable, même lorsqu'elle est longue.",
     relatedTermIds: ['wait-time', 'standby-queue', 'single-rider'],
+    aliases: ["Files d'attente", 'file', 'files'],
   },
   {
     id: 'opening-day',
@@ -288,6 +289,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "Une heure de retour (parfois appelée fenêtre de retour) est un créneau horaire précis — généralement d'une heure — pendant lequel un visiteur ayant réservé un accès prioritaire (via la Lightning Lane, une file virtuelle ou un système similaire) peut se présenter à l'entrée dédiée de l'attraction. Les heures de retour permettent aux visiteurs de profiter d'autres zones du parc pendant l'intervalle plutôt que de faire la queue physiquement. Manquer sa fenêtre de retour (généralement définie par un retard de quelques minutes au-delà du créneau) entraîne en principe la perte de la réservation. Les données de temps d'attente et de niveau d'affluence de park.fan vous aident à décider quelles attractions prioriser pour les réservations.",
     relatedTermIds: ['lightning-lane', 'virtual-queue', 'fastpass', 'boarding-group'],
+    aliases: ['Heures de retour'],
   },
   {
     id: 'ert',

--- a/content/glossary/fr.ts
+++ b/content/glossary/fr.ts
@@ -398,6 +398,27 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "Les montagnes russes en bois sont des attractions dont la structure et la voie sont construites en bois. Contrairement aux coasters en acier, le bois possède une flexibilité naturelle qui crée le grondement caractéristique, le ballottement latéral et l'airtime imprévisible que les enthousiastes apprécient. Parmi les coasters en bois célèbres : Balder à Liseberg, The Beast à Kings Island et Megafobia à Oakwood. Les coasters en bois nécessitent un entretien constant — la voie doit être relaminée régulièrement — et sont sensibles aux variations climatiques. Le procédé de conversion RMC (Rocky Mountain Construction) peut transformer des coasters en bois vieillissants en coasters hybrides à voie acier tout en conservant la structure bois.",
     relatedTermIds: ['airtime', 'hybrid-coaster', 'rmc'],
+    aliases: ['Woodies', 'Bois'],
+  },
+  {
+    id: 'steel-coaster',
+    name: 'Montagne russe en acier',
+    shortDefinition:
+      'Une montagne russe construite avec une voie et une structure en acier, connue pour sa conduite lisse et précise.',
+    definition:
+      "Une montagne russe en acier est construite avec une voie tubulaire ou plate en acier supportée par un cadre en acier. Contrairement aux montagnes russes en bois avec leur flexibilité naturelle, l'acier offre aux ingénieurs un contrôle précis des forces G, des transitions et des inversions. La conduite lisse et prévisible d'une montagne russe en acier permet de créer des layouts complexes avec plusieurs inversions, des courbes serrées et des sections à haut vitesse.\n\nLes montagnes russes en acier dominent le développement moderne des coasters. Les exemples les plus célèbres en Europe incluent Shambhala à PortAventura, Nemesis à Alton Towers et Silver Star à Europa-Park. Les montagnes russes en acier vont des petites attractions familiales aux mega coasters record-brisants. La précision de l'acier exige une inspection et un entretien réguliers, mais offre moins de marge d'erreur de conception que la flexibilité du bois.",
+    relatedTermIds: ['wooden-coaster', 'inversion', 'launch-coaster', 'hyper-coaster'],
+    aliases: ['Montagnes russes en acier', 'Acier'],
+  },
+  {
+    id: 'suspended-coaster',
+    name: 'Suspended Coaster',
+    shortDefinition:
+      'Un coaster où le train pend sous la voie sur un pivot, permettant au véhicule de se balancer librement de côté.',
+    definition:
+      "Un suspended coaster est un type de coaster spécialisé où le train est suspendu depuis le haut sur un point pivot, lui permettant de se balancer librement d'un côté à l'autre. Alors que le train navigue dans les courbes, il se balance comme un pendule — un mouvement qui crée la sensation caractéristique du 'whip' et ajoute un élément imprévisible à l'expérience. Ce mouvement de balancement est distinct d'un inverted coaster, où le train est rigidement attaché au-dessus de la voie.\n\nLes suspended coasters sont moins courants que les inverted coasters mais offrent une expérience unique. Le mouvement de balancement rend même les virages modérés dramatiques, et la sensation de 'voler' avec le sol loin dessous crée une exposition frissonnante. Vekoma a créé le modèle Suspended Looping Coaster (SLC) dans les années 1990, et des centaines ont été construits mondialement. Le mouvement de balancement peut sembler chaotique comparé à la précision des inversions modernes, rendant les suspended coasters soit aimés pour leur nature brute et imprévisible.",
+    relatedTermIds: ['inverted-coaster', 'b-and-m', 'vekoma'],
+    aliases: ['Suspended', 'Balançant'],
   },
   {
     id: 'hybrid-coaster',

--- a/content/glossary/fr.ts
+++ b/content/glossary/fr.ts
@@ -27,6 +27,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "Une file d'attente virtuelle permet aux visiteurs de s'inscrire pour une attraction via une application ou une borne et de recevoir une notification quand leur tour approche. Au lieu de faire la queue physiquement, les visiteurs peuvent profiter d'autres zones du parc et revenir lorsqu'ils sont appelés.",
     relatedTermIds: ['express-pass', 'wait-time', 'single-rider'],
+    aliases: ["Files d'attente virtuelles"],
   },
   {
     id: 'express-pass',
@@ -53,6 +54,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "Le niveau d'affluence décrit la densité globale de visiteurs dans un parc un jour ou une heure donnés. park.fan utilise une échelle de Très Faible à Extrême basée sur les données historiques de temps d'attente, l'occupation actuelle et les prévisions IA.",
     relatedTermIds: ['crowd-calendar', 'peak-day', 'wait-time'],
+    aliases: ["Niveaux d'affluence"],
   },
   {
     id: 'crowd-calendar',
@@ -873,6 +875,16 @@ const translations: GlossaryTermTranslation[] = [
       "Une prévision de fréquentation est une prédiction basée sur les données de l'affluence attendue dans un parc à thème pour un jour ou une heure spécifique. park.fan recalcule les prévisions de fréquentation quotidiennement en utilisant les données historiques, les calendriers scolaires, la météo et les événements spéciaux. Les résultats alimentent directement le calendrier de fréquentation : les jours verts indiquent de courtes files d'attente, les jours rouges signalent une forte affluence.",
     relatedTermIds: ['crowd-calendar', 'ai-forecast', 'peak-day', 'crowd-level'],
     aliases: ['Prévisions de fréquentation'],
+  },
+  {
+    id: 'roller-coaster-element',
+    name: 'Élément de montagnes russes',
+    shortDefinition:
+      "Une section ou caractéristique nommée d'une montagne russe, comme un looping, une bosse d'airtime ou une inversion.",
+    definition:
+      "Un élément de montagnes russes désigne toute caractéristique distincte et nommée intégrée dans le tracé d'une montagne russe — des inversions classiques comme les loopings et les tire-bouchons aux éléments non-inversants comme les bosses d'airtime, les hélices et les virages surélevés (overbanks). Les ingénieurs conçoivent chaque élément pour produire une sensation physique précise : apesanteur (airtime), forces G latérales ou la désorientation de la tête en bas.\n\nLe glossaire de park.fan répertorie des dizaines d'éléments individuels — du premier drop et du lifthill aux spécialités modernes comme le Stengel dive, le Norwegian loop et le heartline roll.",
+    relatedTermIds: ['airtime', 'inversion', 'vertical-loop', 'helix', 'first-drop'],
+    aliases: ['Éléments de montagnes russes'],
   },
 ];
 

--- a/content/glossary/fr.ts
+++ b/content/glossary/fr.ts
@@ -943,7 +943,7 @@ const translations: GlossaryTermTranslation[] = [
     id: 'hangtime',
     name: 'Hangtime',
     shortDefinition:
-      'La sensation de rester suspendu dans les harnais lors d\'une inversion, causée par des forces G négatives la tête en bas.',
+      "La sensation de rester suspendu dans les harnais lors d'une inversion, causée par des forces G négatives la tête en bas.",
     definition:
       "Le hangtime désigne l'expérience particulière des forces G négatives lors d'une inversion : le train s'attarde suffisamment au sommet d'une figure tête en bas pour que des forces G négatives se manifestent — les passagers se retrouvent littéralement suspendus dans leurs harnais. Contrairement au bref passage inversé d'un looping rapide, le hangtime se produit lorsque le train ralentit près du sommet d'une inversion et crée une suspension prolongée. Le poids du corps se déporte entièrement dans les harnais d'épaules ou le harnais de genoux, créant une désorientation mémorable.\n\nLe hangtime est le plus prononcé sur les éléments où le train ralentit fortement au sommet de l'inversion — le pretzel loop sur les flying coasters en est l'exemple classique, car la vitesse est suffisamment faible pour des forces G négatives soutenues en position totalement inversée. Le heartline roll de certaines attractions modernes peut aussi produire du hangtime. Les amateurs considèrent généralement le hangtime comme l'une des sensations d'inversion les plus marquantes.",
     relatedTermIds: ['inversion', 'pretzel-loop', 'heartline-roll', 'g-force', 'airtime'],

--- a/content/glossary/fr.ts
+++ b/content/glossary/fr.ts
@@ -879,6 +879,56 @@ const translations: GlossaryTermTranslation[] = [
     aliases: ['Prévisions de fréquentation'],
   },
   {
+    id: 'g-force',
+    name: 'Force G',
+    shortDefinition:
+      "L'unité d'accélération ressentie par les passagers, mesurée en multiples de l'accélération gravitationnelle terrestre (9,81 m/s²).",
+    definition:
+      "La force G (équivalent gravitationnel) mesure l'accélération ressentie par un passager par rapport à la gravité terrestre normale. Les forces G positives (au-dessus de 1G) plaquent les passagers dans leur siège lors de passages dans des creux ou des virages serrés. Les forces G négatives (sous 0G) soulèvent les passagers de leur siège et créent de l'airtime. Les forces G latérales agissent horizontalement, poussant les passagers sur les côtés dans les virages et transitions.\n\nLes montagnes russes sont conçues pour enchaîner ces forces délibérément. Un creux générant 4–5G est la marque d'un premier drop puissant. Un bref moment à −0,5G sur une bosse d'airtime produit la sensation de flottement caractéristique. La plupart des attractions ciblent 0–5G de forces positives soutenues, avec des pics courts pour l'effet dramatique. Une exposition prolongée à des forces G élevées peut provoquer un malaise ou un « greyout » ; les bonnes conceptions alternent pics d'intensité et phases de récupération.",
+    relatedTermIds: ['airtime', 'inversion', 'lateral-gs', 'hangtime'],
+    aliases: ['Forces G', 'G-Force', 'G-Forces'],
+  },
+  {
+    id: 'lateral-gs',
+    name: 'Forces Latérales',
+    shortDefinition:
+      'Forces horizontales qui poussent les passagers sur les côtés lors de virages, transitions et sections en hélice.',
+    definition:
+      "Les forces G latérales (ou forces latérales) sont les accélérations horizontales ressenties lorsqu'une montagne russe change de direction dans le plan horizontal — dans les virages inclinés ou non, les hélices et les changements de cap. Des forces latérales bien conçues sont fluides et contrôlées, contribuant à une expérience dynamique. Des forces latérales mal maîtrisées se traduisent par un choc brutal contre le dossier ou le harnais, source d'inconfort ou de douleur.\n\nLes amateurs distinguent les forces latérales douces et intentionnelles — comme dans les grands virages bas d'une montagne russe en bois classique — des forces latérales brutales dues à l'usure du rail ou à une mauvaise conception. Les montagnes russes en bois sont particulièrement associées aux sensations latérales : le mouvement d'un côté à l'autre des virages non inclinés fait partie de l'expérience authentique. Les séquences latérales fluides en hélice — comme sur Balder à Liseberg — sont souvent citées comme des moments marquants par les passionnés.",
+    relatedTermIds: ['g-force', 'airtime', 'helix', 'wooden-coaster'],
+    aliases: ['Latéraux', 'Forces G Latérales', 'Lateral G', 'Laterals'],
+  },
+  {
+    id: 'ejector-airtime',
+    name: 'Ejector Airtime',
+    shortDefinition:
+      'Forces G négatives intenses qui propulsent brutalement les passagers hors de leur siège, retenus uniquement par le harnais de genoux.',
+    definition:
+      "L'ejector airtime décrit la forme la plus intense des forces G négatives : la trajectoire de l'attraction s'écarte si brusquement de la chute libre que les passagers sont violemment propulsés hors de leur siège, retenus uniquement par le harnais de genoux. La sensation est celle d'une éjection active du siège — distincte du flottement doux et prolongé du floater airtime, elle est soudaine et peut frôler le brutal si la transition est trop abrupte.\n\nL'ejector airtime est particulièrement associé aux hybrid coasters RMC, à certains hyper coasters Intamin et aux montagnes russes en bois modernes avec des collines paraboliques raides. Les amateurs citent les meilleurs moments d'ejector comme le sommet d'un circuit — un bref instant saisissant d'apesanteur réelle. Untamed à Walibi Holland, Wildfire à Kolmården et Steel Vengeance à Cedar Point sont souvent cités pour leurs séquences d'ejector parmi les plus intenses au monde.",
+    relatedTermIds: ['airtime', 'floater-airtime', 'airtime-hill', 'rmc', 'g-force'],
+    aliases: ['Ejector'],
+  },
+  {
+    id: 'floater-airtime',
+    name: 'Floater Airtime',
+    shortDefinition:
+      "Forces G négatives douces et prolongées produisant une longue sensation de flottement au sommet d'une bosse.",
+    definition:
+      "Le floater airtime décrit l'extrémité douce du spectre des forces G négatives : une sensation lente et prolongée où les passagers s'élèvent légèrement de leur siège et flottent en apesanteur pendant un long moment lorsque le train passe au sommet d'une colline suivant une courbe parabolique progressive. La force est faible — généralement −0,1G à −0,3G — ce qui la rend accessible et agréable même pour les passagers que l'intensité de l'ejector rebute.\n\nLe floater airtime est caractéristique des hyper et giga coasters B&M, qui utilisent de grandes collines doucement arrondies conçues pour produire de longues phases de flottement. Shambhala à PortAventura, Silver Star à Europa-Park et Goliath à Walibi Holland sont des exemples européens célèbres pour leurs longues séquences floater. De nombreux amateurs trouvent la qualité détendue du floater plus confortable que l'intensité de l'ejector, bien que les avis soient partagés sur le style supérieur.",
+    relatedTermIds: ['airtime', 'ejector-airtime', 'airtime-hill', 'b-and-m', 'g-force'],
+    aliases: ['Floater'],
+  },
+  {
+    id: 'hangtime',
+    name: 'Hangtime',
+    shortDefinition:
+      'La sensation de rester suspendu dans les harnais lors d\'une inversion, causée par des forces G négatives la tête en bas.',
+    definition:
+      "Le hangtime désigne l'expérience particulière des forces G négatives lors d'une inversion : le train s'attarde suffisamment au sommet d'une figure tête en bas pour que des forces G négatives se manifestent — les passagers se retrouvent littéralement suspendus dans leurs harnais. Contrairement au bref passage inversé d'un looping rapide, le hangtime se produit lorsque le train ralentit près du sommet d'une inversion et crée une suspension prolongée. Le poids du corps se déporte entièrement dans les harnais d'épaules ou le harnais de genoux, créant une désorientation mémorable.\n\nLe hangtime est le plus prononcé sur les éléments où le train ralentit fortement au sommet de l'inversion — le pretzel loop sur les flying coasters en est l'exemple classique, car la vitesse est suffisamment faible pour des forces G négatives soutenues en position totalement inversée. Le heartline roll de certaines attractions modernes peut aussi produire du hangtime. Les amateurs considèrent généralement le hangtime comme l'une des sensations d'inversion les plus marquantes.",
+    relatedTermIds: ['inversion', 'pretzel-loop', 'heartline-roll', 'g-force', 'airtime'],
+    aliases: ['Hang Time'],
+  },
+  {
     id: 'roller-coaster-element',
     name: 'Élément de montagnes russes',
     shortDefinition:

--- a/content/glossary/it.ts
+++ b/content/glossary/it.ts
@@ -398,6 +398,27 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "Un ottovolante in legno è un giro costruito con binari e struttura portante in legno. A differenza dei coaster in acciaio, il legno ha una flessione naturale che crea il caratteristico fragore, lo scuotimento laterale e l'airtime imprevedibile amato dagli appassionati. Famosi ottovolanti in legno includono Balder a Liseberg, The Beast a Kings Island e Megafobia a Oakwood. Gli ottovolanti in legno richiedono una manutenzione costante — il binario deve essere rilaminato regolarmente — e sono suscettibili ai cambiamenti climatici. Il processo di conversione RMC (Rocky Mountain Construction) può trasformare i vecchi ottovolanti in coaster ibridi con binario in acciaio mantenendo la struttura in legno.",
     relatedTermIds: ['airtime', 'hybrid-coaster', 'rmc'],
+    aliases: ['Woodies', 'Legno'],
+  },
+  {
+    id: 'steel-coaster',
+    name: 'Montagna russa in acciaio',
+    shortDefinition:
+      "Una montagna russa costruita principalmente con binario e struttura in acciaio, nota per la sua corsa liscia e precisa.",
+    definition:
+      "Una montagna russa in acciaio è costruita con binario tubolare o piatto in acciaio supportato da un'armatura in acciaio. A differenza delle montagne russe in legno con la loro flessibilità naturale, l'acciaio offre ai progettisti un controllo preciso delle forze G, delle transizioni e delle inversioni. La corsa liscia e prevedibile di una montagna russa in acciaio consente di creare layout complessi con molteplici inversioni, curve strette e sezioni ad alta velocità.\n\nLe montagne russe in acciaio dominano lo sviluppo moderno dei coaster. Gli esempi più celebri in Europa includono Shambhala a PortAventura, Nemesis ad Alton Towers e Silver Star a Europa-Park. Le montagne russe in acciaio spaziano da piccole attrazioni familiari a mega coaster record-holder. La precisione dell'acciaio richiede ispezione e manutenzione regolari, ma offre meno margini di errore di progettazione rispetto alla flessibilità del legno.",
+    relatedTermIds: ['wooden-coaster', 'inversion', 'launch-coaster', 'hyper-coaster'],
+    aliases: ['Montagne russe in acciaio', 'Acciaio'],
+  },
+  {
+    id: 'suspended-coaster',
+    name: 'Suspended Coaster',
+    shortDefinition:
+      "Un coaster dove il treno è sospeso sotto il binario su un perno, consentendo al veicolo di oscillare liberamente da un lato all'altro.",
+    definition:
+      "Un suspended coaster è un tipo di coaster specializzato dove il treno è sospeso dall'alto su un punto di perno, consentendogli di oscillare liberamente da un lato all'altro indipendentemente dal percorso del binario. Mentre il treno naviga nelle curve, oscilla come un pendolo — un movimento che crea la caratteristica sensazione di 'frusta' e aggiunge un elemento imprevedibile all'esperienza. Questo movimento oscillante è distinto da un inverted coaster, dove il treno è rigidamente attaccato al di sopra del binario.\n\nI suspended coaster sono meno comuni dei coaster invertiti ma offrono un'esperienza unica. Il movimento oscillante rende anche le curve moderate drammatiche, e la sensazione di 'volare' con il terreno lontano crea un'esposizione emozionante. Vekoma ha sviluppato il modello Suspended Looping Coaster (SLC) negli anni '90, e centinaia sono stati costruiti in tutto il mondo. Il movimento oscillante può sembrare caotico rispetto alla precisione delle inversioni moderne, rendendo i suspended coaster amati per la loro natura grezza e imprevedibile.",
+    relatedTermIds: ['inverted-coaster', 'b-and-m', 'vekoma'],
+    aliases: ['Suspended', 'Oscillante'],
   },
   {
     id: 'hybrid-coaster',

--- a/content/glossary/it.ts
+++ b/content/glossary/it.ts
@@ -27,6 +27,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "Una coda virtuale permette agli ospiti di registrarsi per un'attrazione tramite un'app o un chiosco e ricevere una notifica quando si avvicina il loro turno. Invece di fare la coda fisicamente, gli ospiti possono godersi altre aree del parco e tornare quando chiamati.",
     relatedTermIds: ['express-pass', 'wait-time', 'single-rider'],
+    aliases: ['Code virtuali'],
   },
   {
     id: 'express-pass',
@@ -54,6 +55,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "Il livello di affluenza descrive la densità complessiva dei visitatori in un parco in un dato giorno o momento. park.fan utilizza una scala da Molto Basso a Estremo basata sui dati storici dei tempi di attesa, l'occupazione attuale e le previsioni IA.",
     relatedTermIds: ['crowd-calendar', 'peak-day', 'wait-time'],
+    aliases: ['Livelli di affluenza'],
   },
   {
     id: 'crowd-calendar',
@@ -873,6 +875,16 @@ const translations: GlossaryTermTranslation[] = [
       "Una previsione affluenza è una previsione basata sui dati di quanto sarà affollato un parco a tema in un giorno o a un'ora specifica. park.fan ricalcola le previsioni di affluenza quotidianamente utilizzando dati storici di presenze, calendari scolastici, dati meteorologici ed eventi speciali. I risultati alimentano direttamente il calendario delle affluenze: i giorni verdi indicano code brevi, i giorni rossi segnalano affluenza di punta con lunghi tempi di attesa.",
     relatedTermIds: ['crowd-calendar', 'ai-forecast', 'peak-day', 'crowd-level'],
     aliases: ['Previsioni affluenza'],
+  },
+  {
+    id: 'roller-coaster-element',
+    name: 'Elemento delle montagne russe',
+    shortDefinition:
+      "Una sezione o caratteristica denominata di una montagna russa, come un looping, una collina airtime o un'inversione.",
+    definition:
+      "Un elemento delle montagne russe è qualsiasi caratteristica distinta e denominata incorporata nel percorso di una montagna russa — dalle classiche inversioni come looping e cavatappi agli elementi non invertenti come le colline airtime, le eliche e le curve sopraelevate (overbank). Gli ingegneri progettano ogni elemento per produrre una specifica sensazione fisica: assenza di peso (airtime), forze G laterali o il disorientamento da capogiro.\n\nIl glossario di park.fan copre decine di elementi individuali — dal primo drop e dal lifthill alle specialità moderne come lo Stengel dive, il Norwegian loop e l'heartline roll.",
+    relatedTermIds: ['airtime', 'inversion', 'vertical-loop', 'helix', 'first-drop'],
+    aliases: ['Elementi delle montagne russe'],
   },
 ];
 

--- a/content/glossary/it.ts
+++ b/content/glossary/it.ts
@@ -880,6 +880,56 @@ const translations: GlossaryTermTranslation[] = [
     aliases: ['Previsioni affluenza'],
   },
   {
+    id: 'g-force',
+    name: 'Forza G',
+    shortDefinition:
+      "L'unità di accelerazione sperimentata dai passeggeri, misurata come multipli dell'accelerazione gravitazionale terrestre (9,81 m/s²).",
+    definition:
+      "La forza G (equivalente gravitazionale) misura l'accelerazione che un passeggero sperimenta rispetto alla gravità normale della Terra. Le forze G positive (sopra 1G) schiacciano i passeggeri nel sedile durante passaggi in avvallamenti o curve strette. Le forze G negative (sotto 0G) sollevano i passeggeri dal sedile, creando airtime. Le forze G laterali agiscono orizzontalmente, spingendo i passeggeri di lato nelle curve e nelle transizioni.\n\nLe montagne russe sono progettate per sequenziare queste forze deliberatamente. Un avvallamento che genera 4–5G è il marchio di un primo drop potente. Un breve momento a −0,5G su una collina di airtime produce la caratteristica sensazione di galleggiamento. La maggior parte delle attrazioni mira a 0–5G di forze positive sostenute, con brevi picchi per effetti drammatici. Un'esposizione prolungata a forze G elevate può causare disagio o greyout; le montagne russe ben progettate bilanciano picchi di intensità con sezioni di recupero.",
+    relatedTermIds: ['airtime', 'inversion', 'lateral-gs', 'hangtime'],
+    aliases: ['Forze G', 'G-Force', 'G-Forces'],
+  },
+  {
+    id: 'lateral-gs',
+    name: 'Forze Laterali',
+    shortDefinition:
+      'Forze orizzontali che spingono i passeggeri di lato durante curve, transizioni e sezioni a elica.',
+    definition:
+      "Le forze G laterali (o forze laterali) sono le accelerazioni orizzontali che i passeggeri sperimentano quando una montagna russa cambia direzione nel piano orizzontale — nelle curve inclinate o non inclinate, nelle eliche e nei cambi di direzione. Forze laterali ben progettate sono fluide e controllate, contribuendo a un'esperienza dinamica. Forze laterali mal gestite producono una brusca spinta contro il fianco o la schiena, fonte di disagio o dolore.\n\nGli appassionati distinguono tra forze laterali morbide e intenzionali — come nelle ampie curve basse di una classica montagna russa in legno — e forze laterali brutali dovute all'usura del binario o a una progettazione scadente. Le montagne russe in legno sono particolarmente associate al movimento laterale: il gioco del binario e l'energia laterale delle curve non inclinate fanno parte dell'autentica esperienza su legno. Le sequenze laterali fluide nelle sezioni a elica — come su Balder a Liseberg — sono spesso citate come momenti salienti dagli appassionati.",
+    relatedTermIds: ['g-force', 'airtime', 'helix', 'wooden-coaster'],
+    aliases: ['Laterali', 'Forze G Laterali', 'Lateral G', 'Laterals'],
+  },
+  {
+    id: 'ejector-airtime',
+    name: 'Ejector Airtime',
+    shortDefinition:
+      'Intense forze G negative che proiettano bruscamente i passeggeri fuori dal sedile, trattenuti solo dal dispositivo di sicurezza.',
+    definition:
+      "L'ejector airtime descrive la forma più intensa delle forze G negative: la traiettoria dell'attrazione si discosta così bruscamente dalla caduta libera che i passeggeri vengono proiettati violentemente fuori dai loro sedili, trattenuti solo dal dispositivo di sicurezza. La sensazione è quella di un'espulsione attiva dal sedile — netta e improvvisa, può rasentare la violenza se la transizione è troppo brusca.\n\nL'ejector airtime è più comunemente associato agli hybrid coaster RMC, ad alcuni hyper coaster Intamin e alle moderne montagne russe in legno con colline paraboliche ripide. Gli appassionati descrivono i migliori momenti ejector come il culmine di un circuito — un breve istante mozzafiato di vera assenza di peso. Untamed a Walibi Holland, Wildfire a Kolmården e Steel Vengeance a Cedar Point sono frequentemente citati per le loro sequenze ejector tra le più intense al mondo.",
+    relatedTermIds: ['airtime', 'floater-airtime', 'airtime-hill', 'rmc', 'g-force'],
+    aliases: ['Ejector'],
+  },
+  {
+    id: 'floater-airtime',
+    name: 'Floater Airtime',
+    shortDefinition:
+      'Forze G negative dolci e prolungate che producono una lunga sensazione di galleggiamento in cima a una collina.',
+    definition:
+      "Il floater airtime descrive l'estremità morbida dello spettro delle forze G negative: una sensazione lenta e prolungata in cui i passeggeri si sollevano leggermente dal sedile e galleggiano in assenza di peso per un lungo momento mentre il treno supera una collina seguendo un arco parabolico graduale. La forza è lieve — tipicamente tra −0,1G e −0,3G — rendendola accessibile anche ai passeggeri che trovano l'intensità dell'ejector eccessiva.\n\nIl floater airtime è caratteristico degli hyper e giga coaster B&M, che utilizzano grandi colline dolcemente arrotondate progettate per produrre lunghe fasi di galleggiamento. Shambhala a PortAventura, Silver Star a Europa-Park e Goliath a Walibi Holland sono esempi europei celebrati per le loro lunghe sequenze floater. Molti appassionati trovano la qualità rilassata del floater più confortevole dell'intensità dell'ejector, anche se le opinioni sono divise su quale stile sia superiore.",
+    relatedTermIds: ['airtime', 'ejector-airtime', 'airtime-hill', 'b-and-m', 'g-force'],
+    aliases: ['Floater'],
+  },
+  {
+    id: 'hangtime',
+    name: 'Hangtime',
+    shortDefinition:
+      "La sensazione di essere sospesi nei dispositivi di sicurezza durante un'inversione, causata da forze G negative a testa in giù.",
+    definition:
+      "L'hangtime descrive l'esperienza particolare delle forze G negative durante un'inversione: il treno rimane abbastanza a lungo in cima a una figura capovolta perché le forze G negative si manifestino — i passeggeri si ritrovano letteralmente sospesi nei dispositivi di sicurezza. A differenza del breve momento capovolto di un looping veloce, l'hangtime si verifica quando il treno rallenta vicino all'apice di un'inversione, creando una sospensione prolungata. Il peso del corpo si sposta interamente nelle spalle o nelle ginocchia.\n\nL'hangtime è più pronunciato sugli elementi in cui il treno rallenta notevolmente all'apice dell'inversione — il pretzel loop sui flying coaster è l'esempio classico, poiché la velocità è sufficientemente bassa da generare forze G negative sostenute in posizione completamente capovolta. Il heartline roll di alcune attrazioni moderne può produrre hangtime. Gli appassionati considerano generalmente l'hangtime una delle sensazioni di inversione più emozionanti.",
+    relatedTermIds: ['inversion', 'pretzel-loop', 'heartline-roll', 'g-force', 'airtime'],
+    aliases: ['Hang Time'],
+  },
+  {
     id: 'roller-coaster-element',
     name: 'Elemento delle montagne russe',
     shortDefinition:

--- a/content/glossary/it.ts
+++ b/content/glossary/it.ts
@@ -9,6 +9,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "Il tempo di attesa è la durata stimata che un ospite trascorre in coda prima di poter salire su un'attrazione. I parchi mostrano i tempi di attesa agli ingressi delle attrazioni e nelle loro app. park.fan traccia i tempi di attesa in diretta aggiornati ogni minuto.",
     relatedTermIds: ['posted-wait-time', 'virtual-queue', 'single-rider', 'express-pass'],
+    aliases: ['Tempi di attesa'],
   },
   {
     id: 'single-rider',

--- a/content/glossary/it.ts
+++ b/content/glossary/it.ts
@@ -234,6 +234,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "La coda è lo spazio fisico — corridoi, serpentine all'aperto o sale interne — che gli ospiti attraversano aspettando di imbarcarsi su un'attrazione. Nei parchi moderni, la coda è spesso parte dell'esperienza stessa: la coda della Haunted Mansion di Disney crea atmosfera ancora prima di salire sul Doom Buggy, mentre le attrazioni di Harry Potter a Universal immergono i visitatori nel loro mondo fin dalla fila. Una coda ben progettata rende l'attesa molto più piacevole, anche quando è lunga.",
     relatedTermIds: ['wait-time', 'standby-queue', 'single-rider'],
+    aliases: ['Code', 'Fila', 'File'],
   },
   {
     id: 'opening-day',
@@ -287,6 +288,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "Un orario di ritorno (return time) è un periodo specifico — tipicamente un blocco di un'ora — durante il quale un ospite che ha prenotato l'accesso prioritario (tramite Lightning Lane, coda virtuale o sistema simile) può presentarsi all'ingresso dedicato dell'attrazione. Gli orari di ritorno consentono agli ospiti di esplorare altre parti del parco nell'intervallo invece di stare in coda fisica. Perdere la propria finestra oraria (di solito definita come un ritardo superiore a un certo numero di minuti) comporta in genere la perdita della prenotazione. I dati sui tempi di attesa e i livelli di affluenza di park.fan possono aiutarvi a decidere quali attrazioni prioritizzare per la prenotazione dell'orario di ritorno.",
     relatedTermIds: ['lightning-lane', 'virtual-queue', 'fastpass', 'boarding-group'],
+    aliases: ['Orari di ritorno', 'Ora di ritorno', 'Ore di ritorno'],
   },
   {
     id: 'ert',

--- a/content/glossary/nl.ts
+++ b/content/glossary/nl.ts
@@ -9,6 +9,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'De wachttijd is de geschatte duur die een bezoeker in de rij staat voordat hij een attractie kan betreden. Parken geven wachttijden aan bij attractie-ingangen en in hun apps. park.fan houdt live wachttijden bij die elke minuut worden bijgewerkt.',
     relatedTermIds: ['posted-wait-time', 'virtual-queue', 'single-rider', 'express-pass'],
+    aliases: ['Wachttijden'],
   },
   {
     id: 'single-rider',
@@ -234,6 +235,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'De wachtrij is de fysieke ruimte — gangen, buitenserpentines of themagekleden zalen binnenin — die bezoekers doorlopen terwijl ze wachten om op een attractie te stappen. In veel moderne pretparken maakt de wachtrij zelf deel uit van de beleving: bij de Haunted Mansion van Disney schept de rij sfeer voordat je überhaupt instapt, terwijl Harry Potter-attracties bij Universal bezoekers al vanaf de wachtrij onderdompelen in hun wereld. Een goed ontworpen wachtrij maakt het wachten veel aangenamer, ook als het lang duurt.',
     relatedTermIds: ['wait-time', 'standby-queue', 'single-rider'],
+    aliases: ['Wachtrijen'],
   },
   {
     id: 'opening-day',
@@ -287,6 +289,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Een terugkomsttijd (soms terugkomstvenster genoemd) is een specifieke periode — doorgaans een blok van één uur — waarbinnen een gast die prioriteitstoegang heeft geboekt (via Lightning Lane, een virtuele wachtrij of een vergelijkbaar systeem) zich bij de speciale ingang van de attractie kan melden. Terugkomsttijden stellen gasten in staat de tussenliggende tijd te besteden aan het verkennen van andere delen van het park in plaats van fysiek in de rij te staan. Je terugkomstvenster missen (doorgaans te laat arriveren met meer dan een ingesteld aantal minuten) betekent het verlies van je reservering. De wachttijd- en drukte-niveaudata van park.fan helpen je beslissen welke attracties je prioriteit moet geven voor het boeken van terugkomsttijden.',
     relatedTermIds: ['lightning-lane', 'virtual-queue', 'fastpass', 'boarding-group'],
+    aliases: ['Terugkomsttijden'],
   },
   {
     id: 'ert',

--- a/content/glossary/nl.ts
+++ b/content/glossary/nl.ts
@@ -27,6 +27,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Een virtuele wachtrij stelt bezoekers in staat zich aan te melden voor een attractie via een app of kiosk en een melding te ontvangen wanneer hun beurt nadert. In plaats van fysiek in de rij te staan, kunnen bezoekers andere parkgebieden verkennen en terugkeren wanneer ze worden opgeroepen.',
     relatedTermIds: ['express-pass', 'wait-time', 'single-rider'],
+    aliases: ['Virtuele wachtrijen'],
   },
   {
     id: 'express-pass',
@@ -54,6 +55,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Het drukte-niveau beschrijft de algehele bezoekerdichtheid in een park op een bepaalde dag of tijd. park.fan gebruikt een schaal van Zeer Laag tot Extreem op basis van historische wachttijdgegevens, huidige bezetting en AI-voorspellingen.',
     relatedTermIds: ['crowd-calendar', 'peak-day', 'wait-time'],
+    aliases: ['Drukte-niveaus'],
   },
   {
     id: 'crowd-calendar',
@@ -871,6 +873,16 @@ const translations: GlossaryTermTranslation[] = [
       'Een drukte-prognose is een datagestuurde voorspelling van hoe druk een attractiepark op een bepaalde dag of tijd zal zijn. park.fan herberekent drukte-prognoses dagelijks op basis van historische bezoekerscijfers, schoolvakanties, weerdata en speciale evenementen. De resultaten vloeien direct in de drukte-kalender: groene dagen betekenen korte rijen, rode dagen signaleren piekdrukte met lange wachttijden.',
     relatedTermIds: ['crowd-calendar', 'ai-forecast', 'peak-day', 'crowd-level'],
     aliases: ['Drukte-prognoses'],
+  },
+  {
+    id: 'roller-coaster-element',
+    name: 'Achtbaanelement',
+    shortDefinition:
+      'Een benoemd onderdeel van een achtbaanspoor, zoals een looping, airtime-heuvel of inversie.',
+    definition:
+      'Een achtbaanelement is elk afzonderlijk, benoemd kenmerk in het parcours van een achtbaan — van klassieke inversies zoals loopings en kurketrekkers tot niet-inverterende elementen zoals airtime-heuvels, helices en overbanks. Ontwerpers ontwikkelen elk element om een specifieke fysieke gewaarwording te produceren: gewichtloosheid (airtime), zijwaartse G-krachten of de desoriëntatie van ondersteboven rijden.\n\nDe woordenlijst van park.fan beschrijft tientallen individuele elementen — van de eerste drop en lifthill tot moderne specialiteiten als de Stengel dive, Norwegian loop en heartline roll.',
+    relatedTermIds: ['airtime', 'inversion', 'vertical-loop', 'helix', 'first-drop'],
+    aliases: ['Achtbaanelementen'],
   },
 ];
 

--- a/content/glossary/nl.ts
+++ b/content/glossary/nl.ts
@@ -398,6 +398,27 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Een houten achtbaan is een rit met een houten spoor en draagconstructie. In tegenstelling tot stalen achtbanen heeft hout van nature enige flexibiliteit en onnauwkeurigheid, wat het kenmerkende gerommel, de laterale beweging en de onvoorspelbare airtime creëert waar enthousiastelingen van houden. Beroemde houten achtbanen zijn Balder bij Liseberg, The Beast bij Kings Island en Megafobia bij Oakwood. Houten achtbanen vereisen constant onderhoud — de rails moeten regelmatig worden herverlamd — en zijn gevoelig voor weersveranderingen. Het RMC-conversieproces kan verouderde houten achtbanen omtoveren tot staalspoor-hybride achtbanen met behoud van de houten constructie.',
     relatedTermIds: ['airtime', 'hybrid-coaster', 'rmc'],
+    aliases: ['Woodies', 'Houten achtbanen'],
+  },
+  {
+    id: 'steel-coaster',
+    name: 'Stalen achtbaan',
+    shortDefinition:
+      'Een achtbaan gebouwd met stalen rail en stalen constructie, bekend om zijn vloeiende en nauwkeurige rijervaring.',
+    definition:
+      'Een stalen achtbaan wordt gebouwd met buisvormige of platte stalen rail ondersteund door een stalen frame. In tegenstelling tot houten achtbanen met hun natuurlijke flexibiliteit, biedt staal ingenieurs nauwkeurige controle over G-krachten, overgangen en inversies. De vloeiende, voorspelbare rit van een stalen achtbaan maakt het mogelijk om complexe layouts met meerdere inversies, nauwe bochten en snelle secties te creëren.\n\nStalen achtbanen domineren de moderne achtbaanentwickeling. De meest gevierde voorbeelden in Europa zijn Shambhala in PortAventura, Nemesis in Alton Towers en Silver Star in Europa-Park. Stalen achtbanen variëren van kleine familieattracties tot recordbrekende mega coasters. De nauwkeurigheid van staal vereist regelmatig onderhoud en inspectie, maar staat minder ontwerp-fouten toe dan de flexibiliteit van hout.',
+    relatedTermIds: ['wooden-coaster', 'inversion', 'launch-coaster', 'hyper-coaster'],
+    aliases: ['Stalen achtbanen', 'Staal'],
+  },
+  {
+    id: 'suspended-coaster',
+    name: 'Suspended Coaster',
+    shortDefinition:
+      'Een coaster waarbij de trein onder het spoor aan een scharnier hangt, waardoor het voertuig vrij opzij kan zwaaien.',
+    definition:
+      'Een suspended coaster is een gespecialiseerd coastertype waarbij de trein van bovenaf aan een spilpunt hangt en vrij van links naar rechts kan zwaaien. Terwijl de trein door bochten navigeert, zwaait het als een slinger — een beweging die de karakteristieke "whip"-sensatie creëert en een onvoorspelbaar element aan de rit toevoegt. Deze zwaaibeweging is anders dan een inverted coaster, waar de trein star aan het spoor boven bevestigd is.\n\nSuspended coasters zijn minder algemeen dan inverted coasters, maar bieden een unieke ervaring. De zwaaibeweging maakt zelfs matige bochten dramatisch, en het gevoel van vliegen creëert sensatie. Vekoma ontwikkelde in de jaren 90 het Suspended Looping Coaster (SLC)-model, waarvan wereldwijd honderden werden gebouwd. De zwaaibeweging kan chaotisch lijken vergeleken met de precisie van moderne inversies, waardoor suspended coasters door sommigen worden liefgehad voor hun ruwe, onvoorspelbare aard.',
+    relatedTermIds: ['inverted-coaster', 'b-and-m', 'vekoma'],
+    aliases: ['Suspended', 'Hangende achtbaan'],
   },
   {
     id: 'hybrid-coaster',

--- a/content/glossary/nl.ts
+++ b/content/glossary/nl.ts
@@ -878,6 +878,56 @@ const translations: GlossaryTermTranslation[] = [
     aliases: ['Drukte-prognoses'],
   },
   {
+    id: 'g-force',
+    name: 'G-Kracht',
+    shortDefinition:
+      "De eenheid van versnelling die passagiers ervaren, gemeten als veelvouden van de zwaartekrachtversnelling op Aarde (9,81 m/s²).",
+    definition:
+      'G-kracht (gravitationeel equivalent) meet de versnelling die een passagier ervaart ten opzichte van de normale zwaartekracht van de Aarde. Positieve G-krachten (boven 1G) drukken passagiers in hun stoel tijdens dalen of scherpe bochten. Negatieve G-krachten (onder 0G) heffen passagiers uit hun stoel en creëren airtime. Laterale G-krachten werken zijdelings en duwen passagiers opzij in bochten en overgangen.\n\nAchtbanen zijn ontworpen om deze krachten doelgericht te rangschikken. Een dal dat 4–5G genereert is het kenmerk van een krachtige first drop-overgang. Een kort moment van −0,5G op een airtime-heuvel produceert het typische zweefgevoel. De meeste attracties richten zich op 0–5G aanhoudende positieve krachten, met korte pieken voor dramatisch effect. Langdurige hoge G-belasting boven enkele seconden kan ongemak of greyout veroorzaken; goed ontworpen achtbanen balanceren intensiteitspieken met herstelsecties.',
+    relatedTermIds: ['airtime', 'inversion', 'lateral-gs', 'hangtime'],
+    aliases: ['G-Krachten', 'G-Force', 'G-Forces'],
+  },
+  {
+    id: 'lateral-gs',
+    name: 'Laterale G-Krachten',
+    shortDefinition:
+      'Zijdelingse krachten die passagiers opzij duwen tijdens bochten, overgangen en helixgedeelten.',
+    definition:
+      'Laterale G-krachten zijn de zijdelingse versnellingen die passagiers ervaren wanneer een achtbaan van richting verandert in het horizontale vlak — in gembankte of ongembankte bochten, helices en richtingswisselingen. Goed ontworpen lateralen zijn vloeiend en gecontroleerd en dragen bij aan een energieke rijervaring. Slecht ontworpen of ruwe lateralen voelen aan als bruusk opzijgegooid worden tegen de rug- of zijkant van de stoel, wat oncomfortabel of pijnlijk kan zijn.\n\nEnthousiastelingen onderscheiden gladde, intentionele lateralen — zoals in de uitbochten van klassieke houten achtbanen — van harde, onbedoelde lateralen door railleer of slechte constructie. Houten achtbanen zijn sterk geassocieerd met laterale beweging: de flexibiliteit van het spoor en de zijdelingse energie van ongembankte bochten worden beschouwd als authentiek onderdeel van de houten achtbaanervaring. Vloeiende laterale sequenties in helixgedeelten — zoals op Balder in Liseberg — worden door enthousiastelingen vaak als hoogtepunten van een circuitprofiel genoemd.',
+    relatedTermIds: ['g-force', 'airtime', 'helix', 'wooden-coaster'],
+    aliases: ['Lateralen', 'Laterale G', 'Lateral G', 'Laterals'],
+  },
+  {
+    id: 'ejector-airtime',
+    name: 'Ejector Airtime',
+    shortDefinition:
+      'Intense negatieve G-krachten die passagiers abrupt uit hun stoel slingeren, gehouden door alleen de schootbeugel.',
+    definition:
+      'Ejector airtime beschrijft de meest intense vorm van negatieve G-krachten: de baan wijkt zo abrupt af van de vrije val dat passagiers krachtig uit hun stoel worden gesmeten — alleen de schootbeugel houdt hen in het voertuig. De naam omschrijft precies het gevoel: het lijkt alsof de stoel je actief wil uitwerpen. Dit is fundamenteel anders dan het rustige, langdurige zweven van floater airtime; ejector is scherp, plotseling en kan bijna gewelddadig aanvoelen bij abrupte overgangen.\n\nEjector airtime is het meest geassocieerd met RMC hybride achtbanen, bepaalde Intamin hyper coasters en moderne houten achtbanen met steile parabolische heuvels. Enthousiastelingen beschrijven de beste ejector-momenten als het hoogtepunt van een circuit — een kort, hartverscheurend moment van echte gewichtloosheid. Untamed in Walibi Holland, Wildfire in Kolmården en Steel Vengeance in Cedar Point worden vaak geciteerd voor hun buitengewoon intense ejector-sequenties.',
+    relatedTermIds: ['airtime', 'floater-airtime', 'airtime-hill', 'rmc', 'g-force'],
+    aliases: ['Ejector'],
+  },
+  {
+    id: 'floater-airtime',
+    name: 'Floater Airtime',
+    shortDefinition:
+      'Zachte, aanhoudende negatieve G-krachten die een lang zweefgevoel produceren bij het passeren van een heuvel.',
+    definition:
+      'Floater airtime beschrijft het zachte uiterste van het negatieve G-kracht spectrum: een langzame, aanhoudende sensatie waarbij passagiers lichtjes uit hun stoel opstijgen en gewichtloos zweven voor een verlengd moment terwijl de trein een heuvel overgaat langs een geleidelijke parabolische boog. De kracht is mild — doorgaans −0,1G tot −0,3G — waardoor het toegankelijk en aangenaam is voor passagiers die de intensiteit van ejector airtime te heftig vinden.\n\nFloater airtime is het meest kenmerkend voor B&M hyper en giga coasters, die grote, zacht afgeronde heuvels gebruiken die zijn ontworpen om lange zweeffasen te produceren. Shambhala in PortAventura, Silver Star in Europa-Park en Goliath in Walibi Holland zijn Europese voorbeelden die worden gevierd om hun lange floater-sequenties. Veel enthousiastelingen vinden de ontspannen kwaliteit van floater airtime comfortabeler en herhaalbaarder dan de scherpe intensiteit van ejector, hoewel de meningen verdeeld zijn over welk stijl superieur is.',
+    relatedTermIds: ['airtime', 'ejector-airtime', 'airtime-hill', 'b-and-m', 'g-force'],
+    aliases: ['Floater'],
+  },
+  {
+    id: 'hangtime',
+    name: 'Hangtime',
+    shortDefinition:
+      'Het gevoel van gewichtloos hangen in de beveiliging tijdens een inversie, veroorzaakt door negatieve G-krachten ondersteboven.',
+    definition:
+      'Hangtime beschrijft de bijzondere ervaring van negatieve G-krachten tijdens een inversie: de trein treuzelt lang genoeg nabij de top van een omgekeerd element zodat negatieve G-krachten hun effect voelen — passagiers hangen letterlijk in hun beveiliging. In tegenstelling tot het korte omgekeerde moment van een snelle looping, treedt hangtime op wanneer de trein langzamer gaat nabij het inversie-apex en een uitgerekte suspensie creëert. Het lichaamsgewicht verschuift volledig naar de schouderbeuges of schootbeugel, wat een uniek desoriënterende ervaring oplevert.\n\nHangtime is het meest uitgesproken op elementen waar de trein aanzienlijk vertraagt nabij het inversie-apex — de pretzel loop op flying coasters is het klassieke voorbeeld, omdat de snelheid laag genoeg is voor aanhoudende negatieve G\'s in volledig omgekeerde positie. De heartline roll van sommige moderne attracties kan ook hangtime produceren. Enthousiastelingen beschouwen hangtime over het algemeen als een van de meest opwindende inversiesensaties.',
+    relatedTermIds: ['inversion', 'pretzel-loop', 'heartline-roll', 'g-force', 'airtime'],
+    aliases: ['Hang Time'],
+  },
+  {
     id: 'roller-coaster-element',
     name: 'Achtbaanelement',
     shortDefinition:

--- a/lib/glossary/data.ts
+++ b/lib/glossary/data.ts
@@ -560,6 +560,30 @@ export const GLOSSARY_TERMS: GlossaryTermData[] = [
     },
   },
   {
+    id: 'steel-coaster',
+    category: 'coasters',
+    slugs: {
+      en: 'steel-coaster',
+      de: 'stahlachterbahn',
+      fr: 'montagne-russe-acier',
+      it: 'montagna-russa-acciaio',
+      nl: 'stalen-achtbaan',
+      es: 'montana-rusa-acero',
+    },
+  },
+  {
+    id: 'suspended-coaster',
+    category: 'coasters',
+    slugs: {
+      en: 'suspended-coaster',
+      de: 'suspended-coaster',
+      fr: 'suspended-coaster',
+      it: 'suspended-coaster',
+      nl: 'suspended-coaster',
+      es: 'suspended-coaster',
+    },
+  },
+  {
     id: 'hybrid-coaster',
     category: 'coasters',
     slugs: {

--- a/lib/glossary/data.ts
+++ b/lib/glossary/data.ts
@@ -1150,6 +1150,66 @@ export const GLOSSARY_TERMS: GlossaryTermData[] = [
       es: 'rollback',
     },
   },
+  {
+    id: 'g-force',
+    category: 'coaster-elements',
+    slugs: {
+      en: 'g-force',
+      de: 'g-kraft',
+      fr: 'force-g',
+      it: 'forza-g',
+      nl: 'g-kracht',
+      es: 'fuerza-g',
+    },
+  },
+  {
+    id: 'lateral-gs',
+    category: 'coaster-elements',
+    slugs: {
+      en: 'lateral-gs',
+      de: 'laterale-g-kraefte',
+      fr: 'forces-laterales',
+      it: 'forze-laterali',
+      nl: 'laterale-g-krachten',
+      es: 'fuerzas-laterales',
+    },
+  },
+  {
+    id: 'ejector-airtime',
+    category: 'coaster-elements',
+    slugs: {
+      en: 'ejector-airtime',
+      de: 'ejector-airtime',
+      fr: 'ejector-airtime',
+      it: 'ejector-airtime',
+      nl: 'ejector-airtime',
+      es: 'ejector-airtime',
+    },
+  },
+  {
+    id: 'floater-airtime',
+    category: 'coaster-elements',
+    slugs: {
+      en: 'floater-airtime',
+      de: 'floater-airtime',
+      fr: 'floater-airtime',
+      it: 'floater-airtime',
+      nl: 'floater-airtime',
+      es: 'floater-airtime',
+    },
+  },
+  {
+    id: 'hangtime',
+    category: 'coaster-elements',
+    slugs: {
+      en: 'hangtime',
+      de: 'hangtime',
+      fr: 'hangtime',
+      it: 'hangtime',
+      nl: 'hangtime',
+      es: 'hangtime',
+    },
+  },
   // ── Roller Coaster Element (meta term) ────────────────────────────────────
   {
     id: 'roller-coaster-element',

--- a/lib/glossary/data.ts
+++ b/lib/glossary/data.ts
@@ -1150,6 +1150,19 @@ export const GLOSSARY_TERMS: GlossaryTermData[] = [
       es: 'rollback',
     },
   },
+  // ── Roller Coaster Element (meta term) ────────────────────────────────────
+  {
+    id: 'roller-coaster-element',
+    category: 'coaster-elements',
+    slugs: {
+      en: 'roller-coaster-element',
+      de: 'achterbahn-element',
+      fr: 'element-montagnes-russes',
+      it: 'elemento-montagne-russe',
+      nl: 'achtbaanelement',
+      es: 'elemento-montana-rusa',
+    },
+  },
   // ── New Attractions ────────────────────────────────────────────────────────
   {
     id: 'animatronics',


### PR DESCRIPTION
## Summary
This PR enhances glossary integration across the application by automatically injecting glossary term links into descriptive text content and adding a new meta-term for roller coaster elements.

## Key Changes

- **Glossary Term Injection**: Wrapped all description text (`desc` variables) throughout the how-to page content sections (DE, EN, ES, FR, IT, NL) with `<GlossaryInject>` component to enable automatic glossary term highlighting and linking
- **TipBox Enhancement**: Made `TipBox` component async and added conditional glossary injection for string children, allowing tip content to benefit from automatic term linking
- **Queue Type Linking**: Added `QUEUE_TYPE_TERM` mapping in the attraction page to link queue type labels (Single Rider, Virtual Queue, Lightning Lane, Express Pass, Boarding Group) to their corresponding glossary terms via `GlossaryTermLink` component
- **New Glossary Term**: Added "roller-coaster-element" as a meta-term across all language files (DE, EN, ES, FR, IT, NL) with comprehensive definitions and related term references
- **Glossary Aliases**: Added plural form aliases for "Virtual Queue", "Crowd Level" terms across all languages to improve search and matching
- **Schema Update**: Updated glossary structured data content date to reflect the new term addition

## Implementation Details

- The `GlossaryInject` component is applied to description text in multiple content sections, enabling automatic detection and linking of glossary terms within those descriptions
- Queue type terms are conditionally linked only when a mapping exists in `QUEUE_TYPE_TERM`, falling back to plain text for unmapped types
- The new roller coaster element term includes cross-references to related element types (airtime, inversion, vertical-loop, helix, first-drop) to support navigation between related concepts

https://claude.ai/code/session_01D9j1Wks2x2u2ew5g6oAxXu