### PR TITLE
Add German alias for crowd density glossary term

### DIFF
--- a/content/glossary/de.ts
+++ b/content/glossary/de.ts
@@ -58,7 +58,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       'Die Besucherdichte beschreibt die allgemeine Besucherdichte in einem Park an einem bestimmten Tag oder zu einer bestimmten Zeit. park.fan verwendet eine Skala von Sehr Niedrig bis Extrem basierend auf historischen Wartezeitdaten, aktueller Belegung und KI-Prognosen. Ein Tag mit Sehr Niedriger Besucherdichte bedeutet kurze Schlangen und minimale Staus; ein Extremer Tag bedeutet maximale Besucherzahlen mit langen Wartezeiten bei den meisten Attraktionen.',
     relatedTermIds: ['crowd-calendar', 'peak-day', 'wait-time'],
-    aliases: ['Crowd-Level', 'Crowd-Levels', 'Besucherdichten'],
+    aliases: ['Crowd-Level', 'Crowd-Levels', 'Besucherdichten', 'Besucherandrang'],
   },
   {
     id: 'crowd-calendar',


### PR DESCRIPTION
## Summary
Added an additional German alias to the crowd density glossary term to improve discoverability and search functionality.

## Changes
- Added `'Besucherandrang'` as a new alias for the crowd density (`crowd-density`) glossary term in the German translations file
- This complements the existing aliases: `'Crowd-Level'`, `'Crowd-Levels'`, and `'Besucherdichten'`

## Details
This change enhances the German language support by providing an alternative term that users might search for when looking up information about visitor density in parks. The new alias `'Besucherandrang'` is a commonly used German term for crowd/visitor surge that will help users find the relevant glossary definition more easily.

https://claude.ai/code/session_01DT7dgjGZMs6Aw8kebr1VXt