### PR TITLE
Update parks page title to more engaging tagline across all languages

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -188,7 +188,7 @@
     "toggle": "Design wechseln"
   },
   "parks": {
-    "title": "Freizeitpark Wartezeiten & KI-Prognosen",
+    "title": "Mehr Loopings, weniger Stehen",
     "heroWelcome": "Herzlich willkommen im {parkName}",
     "heroNearPark": "Der {parkName} ist in deiner Nähe (unter 5 km). Unten siehst du aktuelle Wartezeiten, Öffnungszeiten und Auslastung – oder suche einen anderen Park.",
     "heroWelcomeAttractions": "{count} Attraktionen in Betrieb",

--- a/messages/en.json
+++ b/messages/en.json
@@ -188,7 +188,7 @@
     "toggle": "Toggle theme"
   },
   "parks": {
-    "title": "Theme Park Wait Times & AI Crowd Predictions",
+    "title": "More Thrills, Less Waiting",
     "heroWelcome": "Welcome to {parkName}",
     "heroNearPark": "{parkName} is nearby (within 5 km). Below you’ll find live wait times, opening hours and crowd levels – or search for another park.",
     "heroWelcomeAttractions": "{count} attractions operating",

--- a/messages/es.json
+++ b/messages/es.json
@@ -188,7 +188,7 @@
     "toggle": "Cambiar tema"
   },
   "parks": {
-    "title": "Tiempos de Espera & Predicciones IA de Parques",
+    "title": "Más loopings, menos esperas",
     "heroWelcome": "Bienvenido a {parkName}",
     "heroNearPark": "{parkName} está cerca (a menos de 5 km). Abajo verás tiempos de espera en vivo, horarios y nivel de afluencia – o busca otro parque.",
     "heroWelcomeAttractions": "{count} atracciones en funcionamiento",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -188,7 +188,7 @@
     "toggle": "Changer de thème"
   },
   "parks": {
-    "title": "Temps d'Attente & Prédictions IA de Parcs",
+    "title": "Plus de loopings, moins d'attente",
     "heroWelcome": "Bienvenue à {parkName}",
     "heroNearPark": "{parkName} est à proximité (moins de 5 km). Consultez ci-dessous les temps d'attente en direct, horaires d'ouverture et affluence – ou recherchez un autre parc.",
     "heroWelcomeAttractions": "{count} attractions en fonctionnement",

--- a/messages/it.json
+++ b/messages/it.json
@@ -188,7 +188,7 @@
     "toggle": "Cambia tema"
   },
   "parks": {
-    "title": "Tempi di attesa nei parchi a tema e previsioni di affluenza IA",
+    "title": "Più looping, meno attese",
     "heroWelcome": "Benvenuti a {parkName}",
     "heroNearPark": "{parkName} è nelle vicinanze (entro 5 km). Di seguito trovi i tempi di attesa live, gli orari di apertura e i livelli di affluenza – oppure cerca un altro parco.",
     "heroWelcomeAttractions": "{count} attrazioni operative",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -188,7 +188,7 @@
     "toggle": "Thema wisselen"
   },
   "parks": {
-    "title": "Pretpark Wachttijden & AI-Drukte Voorspellingen",
+    "title": "Meer loopings, minder wachten",
     "heroWelcome": "Welkom in {parkName}",
     "heroNearPark": "{parkName} is in de buurt (binnen 5 km). Hieronder vind je actuele wachttijden, openingstijden en drukte – of zoek een ander park.",
     "heroWelcomeAttractions": "{count} attracties in bedrijf",


### PR DESCRIPTION
## Summary
Updated the parks page title to a more engaging and user-focused tagline across all supported languages, replacing the technical description with a benefit-driven message.

## Changes
- **English**: "Theme Park Wait Times & AI Crowd Predictions" → "More Thrills, Less Waiting"
- **German**: "Freizeitpark Wartezeiten & KI-Prognosen" → "Mehr Loopings, weniger Stehen"
- **Spanish**: "Tiempos de Espera & Predicciones IA de Parques" → "Más loopings, menos esperas"
- **French**: "Temps d'Attente & Prédictions IA de Parcs" → "Plus de loopings, moins d'attente"
- **Italian**: "Tempi di attesa nei parchi a tema e previsioni di affluenza IA" → "Più looping, meno attese"
- **Dutch**: "Pretpark Wachttijden & AI-Drukte Voorspellingen" → "Meer loopings, minder wachten"

## Details
The new tagline focuses on the user benefit (enjoying more attractions with less waiting) rather than the technical features (wait times and AI predictions). This messaging is more emotionally resonant and better communicates the value proposition to users across all language markets.

https://claude.ai/code/session_0149Xxm5UDNhv575uXwrg7Dr