### PR TITLE
Add glossary term tooltips to queue badges and aliases display

### DIFF
--- a/app/[locale]/glossary/[term]/page.tsx
+++ b/app/[locale]/glossary/[term]/page.tsx
@@ -143,6 +143,7 @@ export default async function GlossaryTermPage({ params }: TermPageProps) {
           labels={{
             backToGlossary: t('backToGlossary'),
             relatedTerms: t('relatedTerms'),
+            alsoKnownAs: t('alsoKnownAs'),
             category: t(`category.${term.category}`),
             termH1Suffix: t('termH1Suffix'),
           }}

--- a/components/glossary/glossary-term-detail.tsx
+++ b/components/glossary/glossary-term-detail.tsx
@@ -17,6 +17,7 @@ interface GlossaryTermDetailProps {
   labels: {
     backToGlossary: string;
     relatedTerms: string;
+    alsoKnownAs: string;
     category: string;
     termH1Suffix: string;
   };
@@ -52,6 +53,12 @@ export function GlossaryTermDetail({
               <p className="text-muted-foreground text-lg leading-relaxed">
                 <GlossaryInject locale={locale}>{term.shortDefinition}</GlossaryInject>
               </p>
+              {term.aliases && term.aliases.length > 0 && (
+                <p className="text-muted-foreground mt-2 text-sm">
+                  <span className="font-medium">{labels.alsoKnownAs}:</span>{' '}
+                  {term.aliases.join(' · ')}
+                </p>
+              )}
             </div>
             {/* Category footer strip */}
             <div className="border-primary/10 flex items-center gap-1.5 border-t px-6 py-3">

--- a/components/glossary/glossary-term-link.tsx
+++ b/components/glossary/glossary-term-link.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { useLocale } from 'next-intl';
 import { GLOSSARY_TERMS } from '@/lib/glossary/data';
@@ -11,10 +12,14 @@ import type { Locale } from '@/i18n/config';
 interface GlossaryTermLinkProps {
   /** Glossary term id (from data.ts). */
   termId: string;
-  children: string;
+  children: ReactNode;
   className?: string;
   /** Show tooltip on hover. Enabled by default. */
   showTooltip?: boolean;
+  /**
+   * Render as a tooltip-only span (no link). Use inside card links to avoid nested <a> elements.
+   */
+  tooltipOnly?: boolean;
 }
 
 /**
@@ -26,6 +31,7 @@ export function GlossaryTermLink({
   children,
   className,
   showTooltip = true,
+  tooltipOnly = false,
 }: GlossaryTermLinkProps) {
   const locale = useLocale() as Locale;
   const termData = GLOSSARY_TERMS.find((t) => t.id === termId);
@@ -37,6 +43,27 @@ export function GlossaryTermLink({
   const clientTerm = showTooltip ? CLIENT_GLOSSARY_TERMS[termId] : null;
   const tooltipName = clientTerm?.name[locale];
   const tooltipDefinition = clientTerm?.shortDefinition[locale];
+
+  // tooltipOnly mode: render a span with tooltip but no link (use inside card <Link> elements)
+  if (tooltipOnly) {
+    const trigger = <span className={className ?? 'cursor-help'}>{children}</span>;
+    if (tooltipName && tooltipDefinition) {
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipContent
+            side="top"
+            className="bg-background/80 text-foreground border-border/60 max-w-64 border shadow-lg backdrop-blur-md"
+            arrowClassName="bg-background/80 fill-background border-border/60"
+          >
+            <p className="font-semibold">{tooltipName}</p>
+            <p className="text-muted-foreground mt-0.5">{tooltipDefinition}</p>
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
+    return <>{children}</>;
+  }
 
   const link = (
     <Link

--- a/components/parks/queue-type-badge.tsx
+++ b/components/parks/queue-type-badge.tsx
@@ -3,6 +3,15 @@ import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import type { QueueDataItem } from '@/lib/api/types';
+import { GlossaryTermLink } from '@/components/glossary/glossary-term-link';
+
+const QUEUE_GLOSSARY_TERMS: Partial<Record<string, string>> = {
+  SINGLE_RIDER: 'single-rider',
+  RETURN_TIME: 'virtual-queue',
+  BOARDING_GROUP: 'boarding-group',
+  PAID_RETURN_TIME: 'lightning-lane',
+  PAID_STANDBY: 'express-pass',
+};
 
 const colorPrimary =
   'bg-primary/65 text-white border border-primary/80 dark:bg-primary/25 dark:border-primary/40';
@@ -106,10 +115,21 @@ export function QueueTypeBadge({ queue }: QueueTypeBadgeProps) {
       return null;
   }
 
-  return (
+  const termId = QUEUE_GLOSSARY_TERMS[queue.queueType];
+  const badge = (
     <Badge className={cn('font-bold tracking-wide uppercase backdrop-blur-md', colorClass)}>
       <Icon className="h-3 w-3 shrink-0 text-inherit" />
       <span className="min-w-0 truncate">{label}</span>
     </Badge>
   );
+
+  if (termId) {
+    return (
+      <GlossaryTermLink termId={termId} tooltipOnly>
+        {badge}
+      </GlossaryTermLink>
+    );
+  }
+
+  return badge;
 }

--- a/content/glossary/en.ts
+++ b/content/glossary/en.ts
@@ -17,6 +17,7 @@ const translations: GlossaryTermTranslation[] = [
       'A separate, faster queue lane for guests willing to ride alone and fill odd empty seats.',
     definition:
       'Single rider queues allow guests who are comfortable riding alone — or separated from their group — to fill odd seats left over in ride vehicles. Because single riders slot into gaps rather than waiting for an entire row to fill, the line moves dramatically faster than the standby queue, often cutting wait times by 50–70%. Rides with large multi-row vehicles, such as roller coasters and simulator attractions, benefit the most from this system.\n\nNot every park or attraction offers single rider access. Where available it is one of the most cost-free strategies for reducing your daily queue time. The trade-off is that you may not sit alongside your companions, so it works best for larger thrill rides where the experience is largely individual. Always check the ride entrance signage or the park app before committing to the single rider lane.',
+    aliases: ['Single Rider Lane'],
     relatedTermIds: ['wait-time', 'express-pass', 'virtual-queue'],
   },
   {

--- a/content/glossary/fr.ts
+++ b/content/glossary/fr.ts
@@ -31,7 +31,7 @@ const translations: GlossaryTermTranslation[] = [
     definition:
       "Une file d'attente virtuelle permet aux visiteurs de s'inscrire pour une attraction via une application ou une borne et de recevoir une notification quand leur tour approche. Au lieu de faire la queue physiquement, les visiteurs peuvent profiter d'autres zones du parc et revenir lorsqu'ils sont appelés.",
     relatedTermIds: ['express-pass', 'wait-time', 'single-rider'],
-    aliases: ["Files d'attente virtuelles"],
+    aliases: ["Files d'attente virtuelles", 'File Virtuelle', 'File virtuelle'],
   },
   {
     id: 'express-pass',

--- a/messages/de.json
+++ b/messages/de.json
@@ -750,6 +750,7 @@
     "termH1Suffix": "erklärt – Wortbedeutung",
     "overviewH1": "Freizeitpark-Glossar – Alle Begriffe & Definitionen",
     "relatedTerms": "Verwandte Begriffe",
+    "alsoKnownAs": "Auch bekannt als",
     "backToGlossary": "Zurück zum Glossar",
     "category": {
       "wait-times": "Wartezeiten",

--- a/messages/en.json
+++ b/messages/en.json
@@ -750,6 +750,7 @@
     "termH1Suffix": "Explained – Theme Park Definition",
     "overviewH1": "Theme Park Glossary – All Terms & Definitions",
     "relatedTerms": "Related Terms",
+    "alsoKnownAs": "Also known as",
     "backToGlossary": "Back to Glossary",
     "category": {
       "wait-times": "Wait Times",

--- a/messages/es.json
+++ b/messages/es.json
@@ -750,6 +750,7 @@
     "termH1Suffix": "explicado – Definición",
     "overviewH1": "Glosario de Parques Temáticos – Todos los términos y definiciones",
     "relatedTerms": "Términos relacionados",
+    "alsoKnownAs": "También conocido como",
     "backToGlossary": "Volver al glosario",
     "category": {
       "wait-times": "Tiempos de espera",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -750,6 +750,7 @@
     "termH1Suffix": "expliqué – Définition",
     "overviewH1": "Glossaire des Parcs à Thème – Tous les termes & définitions",
     "relatedTerms": "Termes associés",
+    "alsoKnownAs": "Aussi connu sous",
     "backToGlossary": "Retour au glossaire",
     "category": {
       "wait-times": "Temps d'attente",

--- a/messages/it.json
+++ b/messages/it.json
@@ -750,6 +750,7 @@
     "termH1Suffix": "spiegato – Definizione",
     "overviewH1": "Glossario dei Parchi a Tema – Tutti i termini e le definizioni",
     "relatedTerms": "Termini correlati",
+    "alsoKnownAs": "Conosciuto anche come",
     "backToGlossary": "Torna al glossario",
     "category": {
       "wait-times": "Tempi di attesa",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -750,6 +750,7 @@
     "termH1Suffix": "uitgelegd – Betekenis",
     "overviewH1": "Pretpark Woordenlijst – Alle begrippen & definities",
     "relatedTerms": "Gerelateerde begrippen",
+    "alsoKnownAs": "Ook bekend als",
     "backToGlossary": "Terug naar woordenlijst",
     "category": {
       "wait-times": "Wachttijden",


### PR DESCRIPTION
## Summary
This PR enhances the glossary system by adding interactive tooltips to queue type badges and displaying term aliases on glossary detail pages. It introduces a new `tooltipOnly` mode to `GlossaryTermLink` to support tooltips within nested link contexts.

## Key Changes

- **GlossaryTermLink Component Enhancement**
  - Added `tooltipOnly` prop to render tooltips without creating nested `<a>` elements
  - Changed `children` prop type from `string` to `ReactNode` for greater flexibility
  - Implemented tooltip-only rendering mode that displays a span with tooltip but no link navigation

- **Queue Type Badge Integration**
  - Added glossary term mappings for queue types (Single Rider, Virtual Queue, Boarding Group, Lightning Lane, Express Pass)
  - Integrated `GlossaryTermLink` with `tooltipOnly` mode to display tooltips on queue badges
  - Badges now show contextual glossary definitions on hover without breaking card link functionality

- **Glossary Term Detail Page**
  - Added "Also known as" section to display term aliases
  - Aliases are shown as a comma-separated list (joined with · separator) below the short definition
  - Added `alsoKnownAs` label to all supported languages (EN, FR, DE, ES, IT, NL)

- **Content Updates**
  - Expanded French virtual queue aliases with additional variations
  - Added comprehensive translations for the new "Also known as" label across all supported languages

## Implementation Details

The `tooltipOnly` mode prevents nested `<a>` elements by rendering a styled span instead of a link, making it safe to use within card components that are already wrapped in links. The tooltip content remains fully functional with the same styling and behavior as regular glossary term links.

https://claude.ai/code/session_01JnKjXtHZaPEcZ6G899dH69