### PR TITLE
Include result ID in search command item value

### DIFF
--- a/components/search/search-bar.tsx
+++ b/components/search/search-bar.tsx
@@ -341,7 +341,7 @@ export function SearchCommand({
     return (
       <CommandItem
         key={result.id}
-        value={`${stripNewPrefix(result.name)} ${result.type}`}
+        value={`${stripNewPrefix(result.name)} ${result.type} ${result.id}`}
         onSelect={() => handleSelect(result, position)}
         className="flex cursor-pointer items-center gap-4"
       >


### PR DESCRIPTION
## Summary
Updated the search command item value to include the result ID alongside the name and type, improving the uniqueness and identifiability of search results.

## Key Changes
- Modified the `CommandItem` value prop in the SearchCommand component to append `result.id` to the existing name and type string
- This ensures each search result has a more unique identifier in the command palette, which can help with selection tracking and result differentiation

## Implementation Details
The change concatenates three pieces of information in the command item value: the stripped result name, result type, and result ID. This provides better context for identifying and selecting specific search results, particularly useful when multiple results might have similar names or types.

https://claude.ai/code/session_01MJo437Lkym7jM2jQ6c11Fv