### PR TITLE
Load Umami Analytics with beforeInteractive strategy

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -119,10 +119,10 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
   // Render html/body here to have access to locale for lang attribute
   return (
     <html lang={locale} suppressHydrationWarning>
-      {/* Umami Analytics - Privacy-friendly, cookie-free tracking */}
+      {/* Umami Analytics - beforeInteractive so PerformanceObserver captures Web Vitals */}
       {process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID && process.env.NEXT_PUBLIC_UMAMI_URL && (
         <Script
-          defer
+          strategy="beforeInteractive"
           src={process.env.NEXT_PUBLIC_UMAMI_URL}
           data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
           data-domains="park.fan"


### PR DESCRIPTION
## Summary
Changed the Umami Analytics script loading strategy from `defer` to `beforeInteractive` to ensure Web Vitals are properly captured by PerformanceObserver.

## Key Changes
- Updated Umami Analytics script strategy from `defer` to `beforeInteractive` in the root layout
- Updated the comment to reflect the reason for this change: enabling PerformanceObserver to capture Web Vitals metrics

## Implementation Details
The `beforeInteractive` strategy ensures the Umami script loads before the page becomes interactive, allowing the PerformanceObserver to properly capture Web Vitals data. This is important for accurate performance monitoring and analytics collection.

https://claude.ai/code/session_0153YzDRFbqAKJZy3URJrnR3