### PR TITLE
Improve image quality and add blur placeholders to hero sections

### DIFF
--- a/components/home/announce-section.tsx
+++ b/components/home/announce-section.tsx
@@ -65,7 +65,7 @@ export async function AnnounceSection({ locale }: AnnounceSectionProps) {
             className="object-cover object-top"
             sizes="100vw"
             priority={true}
-            quality={75}
+            quality={85}
           />
           <div className="from-background via-background/90 to-muted/50 absolute inset-0 bg-gradient-to-br" />
           <div className="from-park-primary/10 absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] via-transparent to-transparent" />

--- a/components/layout/hero-background.tsx
+++ b/components/layout/hero-background.tsx
@@ -66,7 +66,7 @@ export function RandomHeroImage({ imageSrc, noAnimation }: RandomHeroImageProps)
       style={
         noAnimation ? undefined : { animation: 'ken-burns 22s ease-in-out infinite alternate' }
       }
-      sizes="100vw"
+      sizes="(max-width: 768px) 100vw, 115vw"
     />
   );
 }

--- a/components/parks/park-background.tsx
+++ b/components/parks/park-background.tsx
@@ -16,7 +16,7 @@ export function ParkBackground({ imageSrc, alt }: ParkBackgroundProps) {
           alt={alt}
           fill
           priority
-          quality={75}
+          quality={85}
           className="object-cover"
           sizes="100vw"
           fetchPriority="high"

--- a/components/parks/park-background.tsx
+++ b/components/parks/park-background.tsx
@@ -1,5 +1,9 @@
 import Image from 'next/image';
 
+// Brand-matched blur placeholder — same as hero-background.tsx
+const PARK_BLUR_DATA_URL =
+  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScxMCcgaGVpZ2h0PSc3Jz48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9J2cnIHgxPScwJyB5MT0nMCcgeDI9JzAnIHkyPScxJz48c3RvcCBvZmZzZXQ9JzAlJyBzdG9wLWNvbG9yPScjMWEzZjZmJy8+PHN0b3Agb2Zmc2V0PSc0MCUnIHN0b3AtY29sb3I9JyMxZTVmNzgnLz48c3RvcCBvZmZzZXQ9Jzc1JScgc3RvcC1jb2xvcj0nIzFlNWEzYScvPjxzdG9wIG9mZnNldD0nMTAwJScgc3RvcC1jb2xvcj0nIzBmMWUwZicvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPScxMCcgaGVpZ2h0PSc3JyBmaWxsPSd1cmwoI2cpJy8+PC9zdmc+';
+
 interface ParkBackgroundProps {
   imageSrc: string | null;
   alt: string;
@@ -17,6 +21,8 @@ export function ParkBackground({ imageSrc, alt }: ParkBackgroundProps) {
           fill
           priority
           quality={85}
+          placeholder="blur"
+          blurDataURL={PARK_BLUR_DATA_URL}
           className="object-cover"
           sizes="100vw"
           fetchPriority="high"


### PR DESCRIPTION
## Summary
Enhanced image loading experience across hero and background components by increasing image quality, adding blur placeholders, and optimizing responsive image sizing.

## Key Changes
- **Image Quality**: Increased `quality` from 75 to 85 in `park-background.tsx` and `announce-section.tsx` for better visual fidelity
- **Blur Placeholders**: Added brand-matched SVG blur placeholder (`PARK_BLUR_DATA_URL`) to `park-background.tsx` with gradient matching the design system
- **Responsive Sizing**: Updated `hero-background.tsx` image sizes from fixed `100vw` to responsive `(max-width: 768px) 100vw, 115vw` for better mobile/desktop optimization
- **Next.js Image Optimization**: Enabled `placeholder="blur"` with `blurDataURL` in `park-background.tsx` for improved perceived performance during image load

## Implementation Details
- The blur placeholder uses a linear gradient SVG (base64 encoded) with colors matching the existing design system (#1a3f6f → #0f1e0f)
- Quality increase from 75 to 85 provides better image clarity while maintaining reasonable file sizes
- Responsive sizes adjustment allows the hero image to scale appropriately across breakpoints (115vw on larger screens for Ken Burns animation effect)

https://claude.ai/code/session_01M7uPQVYxFm5jD65SyQo8dJ