### PR TITLE
Add background image support to featured parks components

### DIFF
--- a/components/home/featured-parks-section-client.tsx
+++ b/components/home/featured-parks-section-client.tsx
@@ -85,6 +85,7 @@ export function PopularParksGridClient() {
             city={park.city}
             country={translateCountry(tGeo, park)}
             href={park.href as '/'}
+            backgroundImage={park.backgroundImage}
             status={park.status}
             crowdLevel={park.crowdLevel}
             averageWaitTime={park.averageWaitTime}
@@ -155,6 +156,7 @@ export function FeaturedParksSectionClient({
                 city={park.city}
                 country={translateCountry(tGeo, park)}
                 href={park.href as '/'}
+                backgroundImage={park.backgroundImage}
                 status={park.status}
                 crowdLevel={park.crowdLevel}
                 averageWaitTime={park.averageWaitTime}

--- a/components/home/featured-parks-section.tsx
+++ b/components/home/featured-parks-section.tsx
@@ -6,6 +6,16 @@ import { ChevronRight } from 'lucide-react';
 import type { GeoStructure, ParkStatus, CrowdLevel, ScheduleSummary } from '@/lib/api/types';
 import type { Locale } from '@/i18n/config';
 
+// Server-side only — avoids bundling `fs` into any client chunk
+/* eslint-disable @typescript-eslint/no-require-imports */
+const serverAssets =
+  typeof window === 'undefined'
+    ? (require('@/lib/utils/park-assets') as {
+        getParkBackgroundImage: (slug: string) => string | null;
+      })
+    : null;
+/* eslint-enable @typescript-eslint/no-require-imports */
+
 /**
  * Featured parks per locale — verified slugs from footer + API structure.
  * Ordered by visit relevance for each language audience.
@@ -72,6 +82,7 @@ interface FeaturedPark {
   countrySlug: string;
   countryName: string; // raw name, translated in component
   href: string;
+  backgroundImage?: string | null;
   // Live data from ParkReference
   status?: ParkStatus;
   crowdLevel?: CrowdLevel;
@@ -105,6 +116,7 @@ export function extractFeaturedParks(geoData: GeoStructure | null, locale: strin
               countrySlug: country.slug,
               countryName: country.name,
               href: `/parks/${continent.slug}/${country.slug}/${city.slug}/${park.slug}`,
+              backgroundImage: serverAssets?.getParkBackgroundImage(park.slug) ?? null,
               status: park.status,
               crowdLevel: park.currentLoad?.crowdLevel,
               averageWaitTime: park.analytics?.statistics?.avgWaitTime,
@@ -162,6 +174,7 @@ export async function FeaturedParksSection({ locale, geoData }: FeaturedParksSec
                 city={park.city}
                 country={translatedCountry}
                 href={park.href as '/'}
+                backgroundImage={park.backgroundImage}
                 status={park.status}
                 crowdLevel={park.crowdLevel}
                 averageWaitTime={park.averageWaitTime}


### PR DESCRIPTION
## Summary
This PR adds support for displaying background images on featured park cards by integrating server-side asset loading and passing the image data through the component hierarchy.

## Key Changes
- **Server-side asset loading**: Added conditional require of `park-assets` utility that only executes on the server to avoid bundling `fs` into client chunks
- **Data structure enhancement**: Extended `FeaturedPark` interface with optional `backgroundImage` field
- **Data flow**: Updated `extractFeaturedParks()` to populate background images using the server-side asset loader
- **Component propagation**: Passed `backgroundImage` prop through both `FeaturedParksSection` and `FeaturedParksSectionClient` components to the individual park card components

## Implementation Details
- Used `typeof window === 'undefined'` check to ensure asset loading only occurs server-side
- Added ESLint disable comments to allow dynamic require imports
- Background image is optional and defaults to `null` if not found, maintaining backward compatibility
- Changes maintain the existing component API while adding the new optional prop

https://claude.ai/code/session_01GYznK5RmMkrHU3AErE9mtU