### PR TITLE
Refactor show time logic to separate date calculation from formatting

### DIFF
--- a/components/parks/park-map.tsx
+++ b/components/parks/park-map.tsx
@@ -440,16 +440,23 @@ export function ParkMap({ park }: ParkMapProps) {
               <div>
                 <div className="font-semibold">{stripNewPrefix(show.name)}</div>
                 <div className="text-muted-foreground text-xs">{t('show')}</div>
-                {show.showtimes && show.showtimes.length > 0 && (
-                  <div className="mt-1 text-xs">
-                    {t('nextShowtime')}:{' '}
-                    {new Date(show.showtimes[0].startTime).toLocaleTimeString(locale, {
-                      hour: '2-digit',
-                      minute: '2-digit',
-                      timeZone: park.timezone,
-                    })}
-                  </div>
-                )}
+                {show.showtimes && show.showtimes.length > 0 && (() => {
+                  const now = new Date();
+                  const nextShowtime = show.showtimes
+                    .map((st) => new Date(st.startTime))
+                    .filter((time) => time > now)
+                    .sort((a, b) => a.getTime() - b.getTime())[0];
+                  return nextShowtime ? (
+                    <div className="mt-1 text-xs">
+                      {t('nextShowtime')}:{' '}
+                      {nextShowtime.toLocaleTimeString(locale, {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        timeZone: park.timezone,
+                      })}
+                    </div>
+                  ) : null;
+                })()}
               </div>
             </Popup>
           </Marker>

--- a/components/parks/park-map.tsx
+++ b/components/parks/park-map.tsx
@@ -136,8 +136,8 @@ function getWaitTime(attraction: ParkAttraction): number | null {
   return standbyQueue?.waitTime ?? null;
 }
 
-// Helper function to get next show time
-function getNextShowTime(show: ParkShow): string | null {
+// Returns the next future showtime as a Date, or null if none remain
+function getNextShowtimeDate(show: ParkShow): Date | null {
   if (!show.showtimes || show.showtimes.length === 0) return null;
 
   const now = new Date();
@@ -146,11 +146,15 @@ function getNextShowTime(show: ParkShow): string | null {
     .filter((time: Date) => time > now)
     .sort((a: Date, b: Date) => a.getTime() - b.getTime());
 
-  if (futureShowtimes.length === 0) return null;
+  return futureShowtimes[0] ?? null;
+}
 
-  const nextShow = futureShowtimes[0];
-  const diffMs = nextShow.getTime() - now.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
+// Returns the next show time as a relative string (e.g. "45 min"), used in the in-park panel
+function getNextShowTime(show: ParkShow): string | null {
+  const nextShow = getNextShowtimeDate(show);
+  if (!nextShow) return null;
+
+  const diffMins = Math.floor((nextShow.getTime() - Date.now()) / 60000);
 
   if (diffMins < 60) {
     return `${diffMins} min`;
@@ -440,12 +444,8 @@ export function ParkMap({ park }: ParkMapProps) {
               <div>
                 <div className="font-semibold">{stripNewPrefix(show.name)}</div>
                 <div className="text-muted-foreground text-xs">{t('show')}</div>
-                {show.showtimes && show.showtimes.length > 0 && (() => {
-                  const now = new Date();
-                  const nextShowtime = show.showtimes
-                    .map((st) => new Date(st.startTime))
-                    .filter((time) => time > now)
-                    .sort((a, b) => a.getTime() - b.getTime())[0];
+                {(() => {
+                  const nextShowtime = getNextShowtimeDate(show);
                   return nextShowtime ? (
                     <div className="mt-1 text-xs">
                       {t('nextShowtime')}:{' '}


### PR DESCRIPTION
## Summary
Refactored the show time handling logic to improve code organization and reusability by separating the concerns of calculating the next showtime from formatting it for display.

## Key Changes
- **Extracted `getNextShowtimeDate()`**: New helper function that returns the next future showtime as a `Date` object, replacing the inline logic that was previously in `getNextShowTime()`
- **Updated `getNextShowTime()`**: Now uses `getNextShowtimeDate()` internally and focuses solely on formatting the relative time string (e.g., "45 min")
- **Fixed show time display in popup**: Updated the show details popup to use `getNextShowtimeDate()` instead of directly accessing `show.showtimes[0]`, ensuring it displays the actual next future showtime rather than always showing the first scheduled time
- **Improved code clarity**: Added descriptive comments to clarify the purpose of each function

## Implementation Details
- `getNextShowtimeDate()` filters showtimes to find only future times and returns the earliest one
- The popup now correctly handles cases where no future showtimes exist by returning `null`
- Simplified time calculation in `getNextShowTime()` by using `Date.now()` directly instead of creating an intermediate variable

https://claude.ai/code/session_015XTHaN5Tru5x3XKUnTvHL9