### PR TITLE
Add Singapore to supported countries in all locales

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -625,6 +625,7 @@
       "mexico": "Mexiko",
       "hong-kong": "Hongkong",
       "south-korea": "Südkorea",
+      "singapore": "Singapur",
       "australia": "Australien",
       "brazil": "Brasilien"
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -625,6 +625,7 @@
       "mexico": "Mexico",
       "hong-kong": "Hong Kong",
       "south-korea": "South Korea",
+      "singapore": "Singapore",
       "australia": "Australia",
       "brazil": "Brazil"
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -625,6 +625,7 @@
       "mexico": "México",
       "hong-kong": "Hong Kong",
       "south-korea": "Corea del Sur",
+      "singapore": "Singapur",
       "australia": "Australia",
       "brazil": "Brasil"
     },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -625,6 +625,7 @@
       "mexico": "Mexique",
       "hong-kong": "Hong Kong",
       "south-korea": "Corée du Sud",
+      "singapore": "Singapour",
       "australia": "Australie",
       "brazil": "Brésil"
     },

--- a/messages/it.json
+++ b/messages/it.json
@@ -621,6 +621,7 @@
       "mexico": "Messico",
       "hong-kong": "Hong Kong",
       "south-korea": "Corea del Sud",
+      "singapore": "Singapore",
       "australia": "Australia",
       "brazil": "Brasile"
     },

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -625,6 +625,7 @@
       "mexico": "Mexico",
       "hong-kong": "Hongkong",
       "south-korea": "Zuid-Korea",
+      "singapore": "Singapore",
       "australia": "Australië",
       "brazil": "Brazilië"
     },


### PR DESCRIPTION
## Summary
This PR adds Singapore as a supported country option across all language locales in the application.

## Changes
- Added "singapore" country entry with appropriate translations in all supported language files:
  - English: "Singapore"
  - German: "Singapur"
  - Spanish: "Singapur"
  - French: "Singapour"
  - Italian: "Singapore"
  - Dutch: "Singapore"

The new entry is consistently placed between "south-korea" and "australia" in the countries list across all locale files, maintaining alphabetical/logical ordering.

https://claude.ai/code/session_01SF9JzmkJzXUkeqgue7bfXD