### PR TITLE
Scroll to top when search result is selected

### DIFF
--- a/components/search/search-bar.tsx
+++ b/components/search/search-bar.tsx
@@ -300,6 +300,8 @@ export function SearchCommand({
       queryLength: query.trim().length,
     });
 
+    window.scrollTo(0, 0);
+
     if (result.url) {
       // Use centralized utility for URL conversion
       const cleanUrl = convertApiUrlToFrontendUrl(result.url);


### PR DESCRIPTION
## Summary
Added automatic scroll-to-top behavior when a search result is selected in the search command component.

## Key Changes
- Added `window.scrollTo(0, 0)` call after search result selection to scroll the page to the top
- This ensures users are positioned at the top of the page when navigating to a search result

## Implementation Details
The scroll action is triggered immediately after logging the search analytics event and before URL navigation, ensuring the page scrolls to the top as the new content loads.

https://claude.ai/code/session_01Nu1h6rAtgiX5cazcD8Ye4h