### PR TITLE
🧹 Remove debug log from generate-build-info.mjs

### DIFF
--- a/scripts/generate-build-info.mjs
+++ b/scripts/generate-build-info.mjs
@@ -60,7 +60,6 @@ async function generateBuildInfo() {
     };
 
     fs.writeFileSync('build-info.json', JSON.stringify(buildInfo, null, 2));
-    console.log(`✅ Build info generated: ${JSON.stringify(buildInfo, null, 2)}`);
   } catch (err) {
     console.error('❌ Failed to generate build info:', err);
     // Create fallback build-info


### PR DESCRIPTION
🎯 **What:** Removed a debug `console.log` statement in `scripts/generate-build-info.mjs`.
💡 **Why:** This improves maintainability and readability by reducing noise in the build output. The script now generates `build-info.json` silently unless an error occurs.
✅ **Verification:** Ran `node scripts/generate-build-info.mjs` to confirm it still generates the JSON file correctly without the verbose output. Verified with `read_file` that the change was applied correctly.
✨ **Result:** A cleaner build process and improved code health.

---
*PR created automatically by Jules for task [2505154072790796426](https://jules.google.com/task/2505154072790796426) started by @PArns*