### PR TITLE
🧹 Remove unused `timeRefreshKey` variable in `ParkMap`

### DIFF
--- a/components/parks/park-map.tsx
+++ b/components/parks/park-map.tsx
@@ -176,8 +176,7 @@ export function ParkMap({ park }: ParkMapProps) {
   const locale = useLocale();
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
   const [userHasZoomed, setUserHasZoomed] = useState(false);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [timeRefreshKey, setTimeRefreshKey] = useState(0); // Force re-render for time updates
+  const [, setTimeRefreshKey] = useState(0); // Force re-render for time updates
 
   const requestLocation = () => {
     if (!navigator.geolocation) return;


### PR DESCRIPTION
🎯 **What:** The unused variable `timeRefreshKey` in `components/parks/park-map.tsx` and its associated ESLint disable comment were removed.
💡 **Why:** This improves maintainability and readability by using ES6 destructuring to extract only the state setter (`setTimeRefreshKey`), avoiding unnecessary unused variables.
✅ **Verification:** Verified by successfully running `pnpm lint` and `pnpm build`.
✨ **Result:** A cleaner component without unused variables or unneeded ESLint exceptions.

---
*PR created automatically by Jules for task [4670962273532635679](https://jules.google.com/task/4670962273532635679) started by @PArns*