### PR TITLE
⚡ Optimize search result group filtering in search-bar.tsx

### DIFF
--- a/components/search/search-bar.tsx
+++ b/components/search/search-bar.tsx
@@ -695,9 +695,11 @@ export function SearchCommand({
                   ? (['location', 'park', 'attraction', 'show', 'restaurant'] as const)
                   : (['park', 'attraction', 'show', 'restaurant', 'location'] as const);
 
+                const itemsByType = Object.groupBy(results.results, (r) => r.type);
+
                 mainTypes.forEach((type) => {
-                  const items = results.results.filter((r) => r.type === type);
-                  if (items.length === 0) return;
+                  const items = itemsByType[type];
+                  if (!items || items.length === 0) return;
                   const sortedItems = sortResultsByMatch(items);
                   const bestScore = Math.max(
                     ...sortedItems.map((item) => calcNameScore(item.name))

--- a/scripts/benchmark-search-grouping.mjs
+++ b/scripts/benchmark-search-grouping.mjs
@@ -1,0 +1,81 @@
+import { performance } from 'node:perf_hooks';
+
+// Mock data
+const generateMockResults = (count) => {
+  const types = ['location', 'park', 'attraction', 'show', 'restaurant'];
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    results.push({
+      type: types[i % types.length],
+      name: `Mock Item ${i}`,
+    });
+  }
+  return { results };
+};
+
+const results = generateMockResults(100000); // large number to make diff obvious
+
+// Baseline
+const runBaseline = () => {
+  const start = performance.now();
+
+  const mainTypes = results.results.some((r) => r.type === 'location')
+    ? (['location', 'park', 'attraction', 'show', 'restaurant'])
+    : (['park', 'attraction', 'show', 'restaurant', 'location']);
+
+  const groups = [];
+
+  mainTypes.forEach((type) => {
+    const items = results.results.filter((r) => r.type === type);
+    if (items.length === 0) return;
+    groups.push({ key: type, count: items.length });
+  });
+
+  const end = performance.now();
+  return end - start;
+};
+
+// Optimized
+const runOptimized = () => {
+  const start = performance.now();
+
+  const mainTypes = results.results.some((r) => r.type === 'location')
+    ? (['location', 'park', 'attraction', 'show', 'restaurant'])
+    : (['park', 'attraction', 'show', 'restaurant', 'location']);
+
+  const groups = [];
+
+  const itemsByType = results.results.reduce((acc, item) => {
+    if (!acc[item.type]) acc[item.type] = [];
+    acc[item.type].push(item);
+    return acc;
+  }, {});
+
+  mainTypes.forEach((type) => {
+    const items = itemsByType[type];
+    if (!items || items.length === 0) return;
+    groups.push({ key: type, count: items.length });
+  });
+
+  const end = performance.now();
+  return end - start;
+};
+
+// Warmup
+for (let i = 0; i < 10; i++) {
+  runBaseline();
+  runOptimized();
+}
+
+let baselineTotal = 0;
+let optimizedTotal = 0;
+const iterations = 100;
+
+for (let i = 0; i < iterations; i++) {
+  baselineTotal += runBaseline();
+  optimizedTotal += runOptimized();
+}
+
+console.log(`Baseline Average: ${(baselineTotal / iterations).toFixed(3)} ms`);
+console.log(`Optimized Average: ${(optimizedTotal / iterations).toFixed(3)} ms`);
+console.log(`Improvement: ${((baselineTotal - optimizedTotal) / baselineTotal * 100).toFixed(2)}%`);

--- a/scripts/benchmark-search-grouping2.mjs
+++ b/scripts/benchmark-search-grouping2.mjs
@@ -1,0 +1,78 @@
+import { performance } from 'node:perf_hooks';
+
+const generateMockResults = (count) => {
+  const types = ['location', 'park', 'attraction', 'show', 'restaurant'];
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    results.push({
+      type: types[i % types.length],
+      name: `Mock Item ${i}`,
+    });
+  }
+  return { results };
+};
+
+const results = generateMockResults(100000);
+
+const runOptimizedReduce = () => {
+  const start = performance.now();
+
+  const mainTypes = results.results.some((r) => r.type === 'location')
+    ? (['location', 'park', 'attraction', 'show', 'restaurant'])
+    : (['park', 'attraction', 'show', 'restaurant', 'location']);
+
+  const groups = [];
+
+  const itemsByType = results.results.reduce((acc, item) => {
+    if (!acc[item.type]) acc[item.type] = [];
+    acc[item.type].push(item);
+    return acc;
+  }, {});
+
+  mainTypes.forEach((type) => {
+    const items = itemsByType[type];
+    if (!items || items.length === 0) return;
+    groups.push({ key: type, count: items.length });
+  });
+
+  const end = performance.now();
+  return end - start;
+};
+
+const runOptimizedGroupBy = () => {
+  const start = performance.now();
+
+  const mainTypes = results.results.some((r) => r.type === 'location')
+    ? (['location', 'park', 'attraction', 'show', 'restaurant'])
+    : (['park', 'attraction', 'show', 'restaurant', 'location']);
+
+  const groups = [];
+
+  const itemsByType = Object.groupBy(results.results, (r) => r.type);
+
+  mainTypes.forEach((type) => {
+    const items = itemsByType[type];
+    if (!items || items.length === 0) return;
+    groups.push({ key: type, count: items.length });
+  });
+
+  const end = performance.now();
+  return end - start;
+};
+
+for (let i = 0; i < 10; i++) {
+  runOptimizedReduce();
+  runOptimizedGroupBy();
+}
+
+let reduceTotal = 0;
+let groupByTotal = 0;
+const iterations = 100;
+
+for (let i = 0; i < iterations; i++) {
+  reduceTotal += runOptimizedReduce();
+  groupByTotal += runOptimizedGroupBy();
+}
+
+console.log(`Reduce Average: ${(reduceTotal / iterations).toFixed(3)} ms`);
+console.log(`GroupBy Average: ${(groupByTotal / iterations).toFixed(3)} ms`);

--- a/scripts/benchmark-search-grouping3.mjs
+++ b/scripts/benchmark-search-grouping3.mjs
@@ -1,0 +1,73 @@
+import { performance } from 'node:perf_hooks';
+
+const generateMockResults = (count) => {
+  const types = ['location', 'park', 'attraction', 'show', 'restaurant'];
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    results.push({
+      type: types[i % types.length],
+      name: `Mock Item ${i}`,
+    });
+  }
+  return { results };
+};
+
+const results = generateMockResults(100000);
+
+const runBaselineFilter = () => {
+  const start = performance.now();
+
+  const mainTypes = results.results.some((r) => r.type === 'location')
+    ? (['location', 'park', 'attraction', 'show', 'restaurant'])
+    : (['park', 'attraction', 'show', 'restaurant', 'location']);
+
+  const groups = [];
+
+  mainTypes.forEach((type) => {
+    const items = results.results.filter((r) => r.type === type);
+    if (items.length === 0) return;
+    groups.push({ key: type, count: items.length });
+  });
+
+  const end = performance.now();
+  return end - start;
+};
+
+const runOptimizedGroupBy = () => {
+  const start = performance.now();
+
+  const mainTypes = results.results.some((r) => r.type === 'location')
+    ? (['location', 'park', 'attraction', 'show', 'restaurant'])
+    : (['park', 'attraction', 'show', 'restaurant', 'location']);
+
+  const groups = [];
+
+  const itemsByType = Object.groupBy(results.results, (r) => r.type);
+
+  mainTypes.forEach((type) => {
+    const items = itemsByType[type];
+    if (!items || items.length === 0) return;
+    groups.push({ key: type, count: items.length });
+  });
+
+  const end = performance.now();
+  return end - start;
+};
+
+for (let i = 0; i < 10; i++) {
+  runBaselineFilter();
+  runOptimizedGroupBy();
+}
+
+let baselineTotal = 0;
+let groupByTotal = 0;
+const iterations = 100;
+
+for (let i = 0; i < iterations; i++) {
+  baselineTotal += runBaselineFilter();
+  groupByTotal += runOptimizedGroupBy();
+}
+
+console.log(`Baseline Average: ${(baselineTotal / iterations).toFixed(3)} ms`);
+console.log(`GroupBy Average: ${(groupByTotal / iterations).toFixed(3)} ms`);
+console.log(`Improvement: ${((baselineTotal - groupByTotal) / baselineTotal * 100).toFixed(2)}%`);


### PR DESCRIPTION
💡 **What:** The optimization implemented is the use of `Object.groupBy(results.results, (r) => r.type)` to group search results exactly once, replacing the previous code which repeatedly filtered the entire `results.results` array inside a loop.

🎯 **Why:** The previous approach executed a `.filter()` on an array inside a `.forEach()`, resulting in an unnecessary O(N * M) operational complexity (where N is the number of results, and M is the number of types). For longer search result arrays, this creates multiple wasteful iteration sweeps over the results array.

📊 **Measured Improvement:** We created a benchmark simulating 100,000 array elements spread across 5 categories. Results show a substantial 46.7% improvement in runtime for the grouping part of the function logic:

- **Baseline Average:** 9.325 ms
- **GroupBy Average:** 4.968 ms
- **Improvement:** 46.73%

---
*PR created automatically by Jules for task [13709710033887150464](https://jules.google.com/task/13709710033887150464) started by @PArns*