### PR TITLE
feat: Rename Walt Disney Studios to Disney Adventure World

### DIFF
--- a/components/home/featured-parks-section.tsx
+++ b/components/home/featured-parks-section.tsx
@@ -42,7 +42,7 @@ const FEATURED_PARK_SLUGS: Record<string, string[]> = {
   ],
   fr: [
     'disneyland-park', // Paris — 10.2M, #1 Europe, dominant FR query
-    'walt-disney-studios-park', // 5.6M, same resort
+    'disney-adventure-world', // 5.6M, same resort
     'parc-asterix', // 2.84M, 2024 record, #1 French domestic after Disney
     'europa-park', // 6M, very popular with French-Swiss and Alsace visitors
     'futuroscope', // 2.05M, France's 3rd most visited domestic park

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -263,12 +263,12 @@ export async function Footer({ locale }: FooterProps) {
                     Parc Asterix
                   </Link>
                   <Link
-                    href="/parks/europe/france/paris/walt-disney-studios-park"
+                    href="/parks/europe/france/paris/disney-adventure-world"
                     prefetch={false}
                     className="text-muted-foreground hover:text-foreground transition-colors"
-                    aria-label="Walt Disney Studios Park - Wait Times"
+                    aria-label="Disney Adventure World - Wait Times"
                   >
-                    Walt Disney Studios
+                    Disney Adventure World
                   </Link>
                   <Link
                     href="/parks/europe/france/chasseneuil-du-poitou/futuroscope"

--- a/lib/attraction-images.ts
+++ b/lib/attraction-images.ts
@@ -8,7 +8,8 @@
  */
 export const ATTRACTION_IMAGES: Record<string, string> = {
   'attractiepark-toverland/fenix': '/images/parks/attractiepark-toverland/fenix.jpg',
-  'attractiepark-toverland/maximus-blitzbahn': '/images/parks/attractiepark-toverland/maximus-blitzbahn.jpeg',
+  'attractiepark-toverland/maximus-blitzbahn':
+    '/images/parks/attractiepark-toverland/maximus-blitzbahn.jpeg',
   'attractiepark-toverland/troy': '/images/parks/attractiepark-toverland/troy.jpg',
   'attractiepark-toverland/villa-fiasko': '/images/parks/attractiepark-toverland/villa-fiasko.jpg',
   'bobbejaanland/fury': '/images/parks/bobbejaanland/fury.jpg',
@@ -28,17 +29,23 @@ export const ATTRACTION_IMAGES: Record<string, string> = {
   'europa-park/castello-dei-medici': '/images/parks/europa-park/castello-dei-medici.jpg',
   'europa-park/eurosat-cancan-coaster': '/images/parks/europa-park/eurosat-cancan-coaster.jpg',
   'europa-park/eurosat-coastiality': '/images/parks/europa-park/eurosat-coastiality.jpg',
-  'europa-park/madame-freudenreich-curiosites': '/images/parks/europa-park/madame-freudenreich-curiosites.jpg',
+  'europa-park/madame-freudenreich-curiosites':
+    '/images/parks/europa-park/madame-freudenreich-curiosites.jpg',
   'europa-park/matterhorn-blitz': '/images/parks/europa-park/matterhorn-blitz.jpg',
   'europa-park/pirates-in-batavia': '/images/parks/europa-park/pirates-in-batavia.jpg',
   'europa-park/silver-star': '/images/parks/europa-park/silver-star.jpg',
-  'europa-park/voltron-nevera-powered-by-rimac': '/images/parks/europa-park/voltron-nevera-powered-by-rimac.jpg',
-  'europa-park/water-rollercoaster-poseidon': '/images/parks/europa-park/water-rollercoaster-poseidon.jpg',
+  'europa-park/voltron-nevera-powered-by-rimac':
+    '/images/parks/europa-park/voltron-nevera-powered-by-rimac.jpg',
+  'europa-park/water-rollercoaster-poseidon':
+    '/images/parks/europa-park/water-rollercoaster-poseidon.jpg',
   'europa-park/wodan-timburcoaster': '/images/parks/europa-park/wodan-timburcoaster.jpg',
-  'movie-park-germany/area-51-top-secret': '/images/parks/movie-park-germany/area-51-top-secret.jpg',
+  'movie-park-germany/area-51-top-secret':
+    '/images/parks/movie-park-germany/area-51-top-secret.jpg',
   'movie-park-germany/iron-claw': '/images/parks/movie-park-germany/iron-claw.jpg',
-  'movie-park-germany/movie-park-studio-tour': '/images/parks/movie-park-germany/movie-park-studio-tour.jpg',
-  'movie-park-germany/star-trek-operation-enterprise': '/images/parks/movie-park-germany/star-trek-operation-enterprise.jpg',
+  'movie-park-germany/movie-park-studio-tour':
+    '/images/parks/movie-park-germany/movie-park-studio-tour.jpg',
+  'movie-park-germany/star-trek-operation-enterprise':
+    '/images/parks/movie-park-germany/star-trek-operation-enterprise.jpg',
   'phantasialand/black-mamba': '/images/parks/phantasialand/black-mamba.jpg',
   'phantasialand/chiapas-die-wasserbahn': '/images/parks/phantasialand/chiapas-die-wasserbahn.jpg',
   'phantasialand/fly': '/images/parks/phantasialand/fly.jpg',

--- a/next.config.ts
+++ b/next.config.ts
@@ -83,6 +83,20 @@ const nextConfig: NextConfig = {
       );
     }
 
+    // 3. Renamed parks
+    rules.push(
+      {
+        source: '/:locale/parks/europe/france/paris/walt-disney-studios-park',
+        destination: '/:locale/parks/europe/france/paris/disney-adventure-world',
+        permanent: true,
+      },
+      {
+        source: '/parks/europe/france/paris/walt-disney-studios-park',
+        destination: '/parks/europe/france/paris/disney-adventure-world',
+        permanent: true,
+      }
+    );
+
     return rules;
   },
   async rewrites() {


### PR DESCRIPTION
Updates the park name from Walt Disney Studios Park to Disney Adventure World in the footer and featured parks section, and sets up 301 redirects to ensure the old park slug continues to work seamlessly.

---
*PR created automatically by Jules for task [101338864393454598](https://jules.google.com/task/101338864393454598) started by @PArns*