### PR TITLE
Optimize SVG loading

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,7 +1,6 @@
 import { getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 import { ExternalLink } from 'lucide-react';
-import Image from 'next/image';
 import { Separator } from '@/components/ui/separator';
 import { BuildInfo } from '@/components/common/build-info';
 import { GLOSSARY_SEGMENTS } from '@/lib/glossary/translations';
@@ -28,35 +27,43 @@ export async function Footer({ locale }: FooterProps) {
               className="inline-flex items-center gap-1.5"
               aria-label={`park.fan - ${locale === 'de' ? 'Startseite' : 'Home'}`}
             >
-              <Image
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
                 src="/logo.svg"
                 width={27}
                 height={32}
                 alt="park.fan"
                 className="h-8 w-auto shrink-0 md:h-12 dark:hidden"
+                loading="lazy"
                 aria-hidden="true"
               />
-              <Image
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
                 src="/logo-dark.svg"
                 width={27}
                 height={32}
                 alt="park.fan"
                 className="hidden h-8 w-auto shrink-0 md:h-12 dark:block"
+                loading="lazy"
                 aria-hidden="true"
               />
-              <Image
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
                 src="/parkfan.svg"
                 width={84}
                 height={24}
                 alt="park.fan"
                 className="h-8 w-auto md:h-12 dark:hidden"
+                loading="lazy"
               />
-              <Image
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
                 src="/parkfan-dark.svg"
                 width={84}
                 height={24}
                 alt="park.fan"
                 className="hidden h-8 w-auto md:h-12 dark:block"
+                loading="lazy"
               />
             </Link>
             <p className="text-muted-foreground text-base leading-relaxed">{t('description')}</p>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -6,7 +6,6 @@ import { Link, usePathname } from '@/i18n/navigation';
 import { GLOSSARY_SEGMENTS } from '@/lib/glossary/translations';
 import type { Locale } from '@/i18n/config';
 import { Menu, MapPin } from 'lucide-react';
-import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { ThemeToggle } from '@/components/common/theme-toggle';
@@ -75,39 +74,43 @@ export function Header() {
           aria-label="park.fan - Home"
           tabIndex={isTransparent ? -1 : 0}
         >
-          <Image
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
             src="/logo-small.svg"
             width={26}
             height={30}
             alt="park.fan"
             className="h-7 w-auto md:h-9 dark:hidden"
-            priority
+            fetchPriority="high"
             aria-hidden="true"
           />
-          <Image
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
             src="/logo-small-dark.svg"
             width={26}
             height={30}
             alt="park.fan"
             className="hidden h-7 w-auto md:h-9 dark:block"
-            priority
+            fetchPriority="high"
             aria-hidden="true"
           />
-          <Image
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
             src="/parkfan.svg"
             width={84}
             height={24}
             alt="park.fan"
             className="h-7 w-auto md:h-9 dark:hidden"
-            priority
+            fetchPriority="high"
           />
-          <Image
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
             src="/parkfan-dark.svg"
             width={84}
             height={24}
             alt="park.fan"
             className="hidden h-7 w-auto md:h-9 dark:block"
-            priority
+            fetchPriority="high"
           />
         </Link>
 

--- a/lib/attraction-images.ts
+++ b/lib/attraction-images.ts
@@ -8,7 +8,8 @@
  */
 export const ATTRACTION_IMAGES: Record<string, string> = {
   'attractiepark-toverland/fenix': '/images/parks/attractiepark-toverland/fenix.jpg',
-  'attractiepark-toverland/maximus-blitzbahn': '/images/parks/attractiepark-toverland/maximus-blitzbahn.jpeg',
+  'attractiepark-toverland/maximus-blitzbahn':
+    '/images/parks/attractiepark-toverland/maximus-blitzbahn.jpeg',
   'attractiepark-toverland/troy': '/images/parks/attractiepark-toverland/troy.jpg',
   'attractiepark-toverland/villa-fiasko': '/images/parks/attractiepark-toverland/villa-fiasko.jpg',
   'bobbejaanland/fury': '/images/parks/bobbejaanland/fury.jpg',
@@ -28,17 +29,23 @@ export const ATTRACTION_IMAGES: Record<string, string> = {
   'europa-park/castello-dei-medici': '/images/parks/europa-park/castello-dei-medici.jpg',
   'europa-park/eurosat-cancan-coaster': '/images/parks/europa-park/eurosat-cancan-coaster.jpg',
   'europa-park/eurosat-coastiality': '/images/parks/europa-park/eurosat-coastiality.jpg',
-  'europa-park/madame-freudenreich-curiosites': '/images/parks/europa-park/madame-freudenreich-curiosites.jpg',
+  'europa-park/madame-freudenreich-curiosites':
+    '/images/parks/europa-park/madame-freudenreich-curiosites.jpg',
   'europa-park/matterhorn-blitz': '/images/parks/europa-park/matterhorn-blitz.jpg',
   'europa-park/pirates-in-batavia': '/images/parks/europa-park/pirates-in-batavia.jpg',
   'europa-park/silver-star': '/images/parks/europa-park/silver-star.jpg',
-  'europa-park/voltron-nevera-powered-by-rimac': '/images/parks/europa-park/voltron-nevera-powered-by-rimac.jpg',
-  'europa-park/water-rollercoaster-poseidon': '/images/parks/europa-park/water-rollercoaster-poseidon.jpg',
+  'europa-park/voltron-nevera-powered-by-rimac':
+    '/images/parks/europa-park/voltron-nevera-powered-by-rimac.jpg',
+  'europa-park/water-rollercoaster-poseidon':
+    '/images/parks/europa-park/water-rollercoaster-poseidon.jpg',
   'europa-park/wodan-timburcoaster': '/images/parks/europa-park/wodan-timburcoaster.jpg',
-  'movie-park-germany/area-51-top-secret': '/images/parks/movie-park-germany/area-51-top-secret.jpg',
+  'movie-park-germany/area-51-top-secret':
+    '/images/parks/movie-park-germany/area-51-top-secret.jpg',
   'movie-park-germany/iron-claw': '/images/parks/movie-park-germany/iron-claw.jpg',
-  'movie-park-germany/movie-park-studio-tour': '/images/parks/movie-park-germany/movie-park-studio-tour.jpg',
-  'movie-park-germany/star-trek-operation-enterprise': '/images/parks/movie-park-germany/star-trek-operation-enterprise.jpg',
+  'movie-park-germany/movie-park-studio-tour':
+    '/images/parks/movie-park-germany/movie-park-studio-tour.jpg',
+  'movie-park-germany/star-trek-operation-enterprise':
+    '/images/parks/movie-park-germany/star-trek-operation-enterprise.jpg',
   'phantasialand/black-mamba': '/images/parks/phantasialand/black-mamba.jpg',
   'phantasialand/chiapas-die-wasserbahn': '/images/parks/phantasialand/chiapas-die-wasserbahn.jpg',
   'phantasialand/fly': '/images/parks/phantasialand/fly.jpg',

--- a/messages/de.json
+++ b/messages/de.json
@@ -626,9 +626,11 @@
       "hong-kong": "Hongkong",
       "south-korea": "Südkorea",
       "singapore": "Singapur",
+      "saudi-arabia": "Saudi Arabia",
       "australia": "Australien",
       "brazil": "Brasilien",
-      "singapore": "Singapur"
+      "singapore": "Singapur",
+      "saudi-arabia": "Saudi Arabia"
     },
     "parksIn": "Freizeitparks in {location}",
     "parkCount": "{count, plural, =1 {1 Park} other {# Parks}}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -626,9 +626,11 @@
       "hong-kong": "Hong Kong",
       "south-korea": "South Korea",
       "singapore": "Singapore",
+      "saudi-arabia": "Saudi Arabia",
       "australia": "Australia",
       "brazil": "Brazil",
-      "singapore": "Singapore"
+      "singapore": "Singapore",
+      "saudi-arabia": "Saudi Arabia"
     },
     "parksIn": "Theme Parks in {location}",
     "parkCount": "{count, plural, =1 {1 park} other {# parks}}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -626,9 +626,11 @@
       "hong-kong": "Hong Kong",
       "south-korea": "Corea del Sur",
       "singapore": "Singapur",
+      "saudi-arabia": "Saudi Arabia",
       "australia": "Australia",
       "brazil": "Brasil",
-      "singapore": "Singapur"
+      "singapore": "Singapur",
+      "saudi-arabia": "Saudi Arabia"
     },
     "parksIn": "Parques temáticos en {location}",
     "parkCount": "{count, plural, =1 {1 parque} other {# parques}}",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -626,9 +626,11 @@
       "hong-kong": "Hong Kong",
       "south-korea": "Corée du Sud",
       "singapore": "Singapour",
+      "saudi-arabia": "Saudi Arabia",
       "australia": "Australie",
       "brazil": "Brésil",
-      "singapore": "Singapour"
+      "singapore": "Singapour",
+      "saudi-arabia": "Saudi Arabia"
     },
     "parksIn": "Parcs d'attractions à {location}",
     "parkCount": "{count, plural, =1 {1 parc} other {# parcs}}",

--- a/messages/it.json
+++ b/messages/it.json
@@ -626,6 +626,7 @@
       "hong-kong": "Hong Kong",
       "south-korea": "Corea del Sud",
       "singapore": "Singapore",
+      "saudi-arabia": "Saudi Arabia",
       "australia": "Australia",
       "brazil": "Brasile"
     },

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -626,9 +626,11 @@
       "hong-kong": "Hongkong",
       "south-korea": "Zuid-Korea",
       "singapore": "Singapore",
+      "saudi-arabia": "Saudi Arabia",
       "australia": "Australië",
       "brazil": "Brazilië",
-      "singapore": "Singapore"
+      "singapore": "Singapore",
+      "saudi-arabia": "Saudi Arabia"
     },
     "parksIn": "Attractieparken in {location}",
     "parkCount": "{count, plural, =1 {1 park} other {# parken}}",


### PR DESCRIPTION
Replaces `<Image>` components from `next/image` with standard `<img>` tags for SVG logos in the header and footer components. Adds `fetchPriority="high"` to header logos for performance, and `loading="lazy"` to footer logos. Also fixes a missing translation for Saudi Arabia.

---
*PR created automatically by Jules for task [3478377968217059270](https://jules.google.com/task/3478377968217059270) started by @PArns*