### PR TITLE
Fix SEO H1 length and remove generic suffixes

### DIFF
--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/[attraction]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/[attraction]/page.tsx
@@ -331,12 +331,12 @@ export default async function AttractionPage({ params }: AttractionPageProps) {
               )}
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
-                  <h1 className="mb-2 text-3xl font-bold md:text-4xl">
-                    {attractionName}
+                  <div className="mb-2 flex flex-wrap items-baseline">
+                    <h1 className="text-3xl font-bold md:text-4xl">{attractionName}</h1>
                     <span className="text-muted-foreground ml-2 text-xl font-normal md:text-2xl">
                       – {t('h1Suffix')}
                     </span>
-                  </h1>
+                  </div>
                   <div className="text-foreground flex flex-wrap items-center gap-3">
                     <Link
                       href={

--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -252,13 +252,11 @@ export default async function ParkPage({ params }: ParkPageProps) {
             <GlassCard variant="medium">
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div className="flex-1">
-                  <div className="mb-2">
-                    <h1 className="text-3xl font-bold md:text-4xl">
-                      {parkName}
-                      <span className="text-muted-foreground ml-2 text-xl font-normal md:text-2xl">
-                        – {t('h1Suffix')}
-                      </span>
-                    </h1>
+                  <div className="mb-2 flex flex-wrap items-baseline">
+                    <h1 className="text-3xl font-bold md:text-4xl">{parkName}</h1>
+                    <span className="text-muted-foreground ml-2 text-xl font-normal md:text-2xl">
+                      – {t('h1Suffix')}
+                    </span>
                   </div>
                   <div className="text-muted-foreground flex flex-wrap items-center gap-3">
                     <address className="flex items-center gap-1 not-italic">

--- a/messages/de.json
+++ b/messages/de.json
@@ -198,9 +198,9 @@
     "disclaimer": "Alle Angaben ohne Gewähr. Die angezeigten Wartezeiten und Statusinformationen werden automatisiert bereitgestellt und können von der tatsächlichen Situation vor Ort abweichen."
   },
   "explore": {
-    "title": "Freizeitparks in {location}",
+    "title": "Freizeitpark Wartezeiten in {location}",
     "parks": "Parks",
-    "parksTitle": "Parks weltweit",
+    "parksTitle": "Freizeitpark Wartezeiten weltweit",
     "description": "Entdecke Freizeitparks in {location} mit Echtzeit-Wartezeiten und Andrangsprognosen.",
     "breadcrumbs": {
       "home": "Startseite"
@@ -628,9 +628,10 @@
       "singapore": "Singapur",
       "australia": "Australien",
       "brazil": "Brasilien",
-      "singapore": "Singapur"
+      "singapore": "Singapur",
+      "saudi-arabia": "Saudi-Arabien"
     },
-    "parksIn": "Freizeitparks in {location}",
+    "parksIn": "Freizeitpark Wartezeiten in {location}",
     "parkCount": "{count, plural, =1 {1 Park} other {# Parks}}",
     "exploreByRegion": "Nach Region entdecken"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -198,9 +198,9 @@
     "disclaimer": "All information provided without warranty. The displayed wait times and status information are automatically provided and may differ from the actual situation on site."
   },
   "explore": {
-    "title": "Theme Parks in {location}",
+    "title": "Theme Park Wait Times in {location}",
     "parks": "Parks",
-    "parksTitle": "Parks Worldwide",
+    "parksTitle": "Theme Park Wait Times Worldwide",
     "description": "Explore theme parks in {location} with real-time wait times and crowd predictions.",
     "breadcrumbs": {
       "home": "Home"
@@ -628,9 +628,10 @@
       "singapore": "Singapore",
       "australia": "Australia",
       "brazil": "Brazil",
-      "singapore": "Singapore"
+      "singapore": "Singapore",
+      "saudi-arabia": "Saudi Arabia"
     },
-    "parksIn": "Theme Parks in {location}",
+    "parksIn": "Theme Park Wait Times in {location}",
     "parkCount": "{count, plural, =1 {1 park} other {# parks}}",
     "exploreByRegion": "Explore by Region"
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -198,9 +198,9 @@
     "disclaimer": "Toda la información se proporciona sin garantía. Los tiempos de espera y estados mostrados se proporcionan automáticamente y pueden diferir de la situación real en el lugar."
   },
   "explore": {
-    "title": "Parques temáticos en {location}",
+    "title": "Tiempos de espera de Parques Temáticos en {location}",
     "parks": "Parques",
-    "parksTitle": "Parques en el Mundo",
+    "parksTitle": "Tiempos de espera de Parques Temáticos en el Mundo",
     "description": "Explora parques temáticos en {location} con tiempos de espera en tiempo real y predicciones de afluencia.",
     "breadcrumbs": {
       "home": "Inicio"
@@ -628,9 +628,10 @@
       "singapore": "Singapur",
       "australia": "Australia",
       "brazil": "Brasil",
-      "singapore": "Singapur"
+      "singapore": "Singapur",
+      "saudi-arabia": "Arabia Saudita"
     },
-    "parksIn": "Parques temáticos en {location}",
+    "parksIn": "Tiempos de espera de Parques Temáticos en {location}",
     "parkCount": "{count, plural, =1 {1 parque} other {# parques}}",
     "exploreByRegion": "Explorar por Región"
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -198,9 +198,9 @@
     "disclaimer": "Toutes les informations sont fournies sans garantie. Les temps d'attente et statuts affichés sont fournis automatiquement et peuvent différer de la situation réelle sur place."
   },
   "explore": {
-    "title": "Parcs d'attractions à {location}",
+    "title": "Temps d'attente des Parcs d'attractions à {location}",
     "parks": "Parcs",
-    "parksTitle": "Parcs dans le Monde",
+    "parksTitle": "Temps d'attente des Parcs d'attractions dans le Monde",
     "description": "Explorez les parcs d'attractions à {location} avec temps d'attente et prédictions d'affluence en temps réel.",
     "breadcrumbs": {
       "home": "Accueil"
@@ -628,9 +628,10 @@
       "singapore": "Singapour",
       "australia": "Australie",
       "brazil": "Brésil",
-      "singapore": "Singapour"
+      "singapore": "Singapour",
+      "saudi-arabia": "Arabie Saoudite"
     },
-    "parksIn": "Parcs d'attractions à {location}",
+    "parksIn": "Temps d'attente des Parcs d'attractions à {location}",
     "parkCount": "{count, plural, =1 {1 parc} other {# parcs}}",
     "exploreByRegion": "Explorer par Région"
   },

--- a/messages/it.json
+++ b/messages/it.json
@@ -198,9 +198,9 @@
     "disclaimer": "Tutte le informazioni sono fornite senza garanzia. I tempi di attesa e le informazioni sullo stato visualizzati sono forniti automaticamente e possono differire dalla situazione reale sul posto."
   },
   "explore": {
-    "title": "Parchi a tema in {location}",
+    "title": "Tempi di attesa dei Parchi a tema in {location}",
     "parks": "Parchi",
-    "parksTitle": "Parchi nel mondo",
+    "parksTitle": "Tempi di attesa dei Parchi a tema nel mondo",
     "description": "Esplora i parchi a tema in {location} con tempi di attesa in tempo reale e previsioni di affluenza.",
     "breadcrumbs": {
       "home": "Home"
@@ -627,9 +627,10 @@
       "south-korea": "Corea del Sud",
       "singapore": "Singapore",
       "australia": "Australia",
-      "brazil": "Brasile"
+      "brazil": "Brasile",
+      "saudi-arabia": "Arabia Saudita"
     },
-    "parksIn": "Parchi a tema in {location}",
+    "parksIn": "Tempi di attesa dei Parchi a tema in {location}",
     "parkCount": "{count, plural, =1 {1 parco} other {# parchi}}",
     "exploreByRegion": "Esplora per regione"
   },

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -198,9 +198,9 @@
     "disclaimer": "Alle informatie wordt verstrekt zonder garantie. De getoonde wachttijden en statusinformatie worden automatisch verstrekt en kunnen afwijken van de actuele situatie ter plaatse."
   },
   "explore": {
-    "title": "Attractieparken in {location}",
+    "title": "Attractiepark Wachttijden in {location}",
     "parks": "Parken",
-    "parksTitle": "Parken Wereldwijd",
+    "parksTitle": "Attractiepark Wachttijden Wereldwijd",
     "description": "Ontdek pretparken in {location} met realtime wachttijden en druktevoorspellingen.",
     "breadcrumbs": {
       "home": "Home"
@@ -628,9 +628,10 @@
       "singapore": "Singapore",
       "australia": "Australië",
       "brazil": "Brazilië",
-      "singapore": "Singapore"
+      "singapore": "Singapore",
+      "saudi-arabia": "Saoedi-Arabië"
     },
-    "parksIn": "Attractieparken in {location}",
+    "parksIn": "Attractiepark Wachttijden in {location}",
     "parkCount": "{count, plural, =1 {1 park} other {# parken}}",
     "exploreByRegion": "Verkennen per Regio"
   },


### PR DESCRIPTION
This pull request addresses two main SEO issues highlighted in the user request:
1. **"Zu kurz" H1 titles**: Lengthened the H1 strings for regional overview pages in all 6 locales (e.g., from "Theme Parks in USA" to "Theme Park Wait Times in USA").
2. **"Generischer Inhalt" on Attraction/Park pages**: The `h1Suffix` (e.g., "– Live Wait Time") was present inside the `<h1>` tag for all attraction and park pages. It has now been moved outside of the `<h1>` into a sibling `<span>`, wrapped in a flex container (`flex flex-wrap items-baseline`) so the visual styling stays identical while the SEO output is cleaner.

Translation sync checks and linting pass successfully with `pnpm release:check`.

---
*PR created automatically by Jules for task [6093776613068602382](https://jules.google.com/task/6093776613068602382) started by @PArns*