### PR TITLE
Medium Glass-Effekt für Park-Statistik-Panels

### DIFF
--- a/components/parks/park-stats-attractions-card.tsx
+++ b/components/parks/park-stats-attractions-card.tsx
@@ -32,7 +32,7 @@ export function ParkStatsAttractionsCard({
   parkSlug,
 }: ParkStatsAttractionsCardProps) {
   return (
-    <GlassCard variant="strong" className="space-y-2 p-4">
+    <GlassCard variant="medium" className="space-y-2 p-4">
       <h3 className="flex items-center gap-2 text-sm font-semibold">
         <Clock className="text-primary h-4 w-4" aria-hidden="true" />
         {title}

--- a/components/parks/park-stats-attractions-card.tsx
+++ b/components/parks/park-stats-attractions-card.tsx
@@ -32,7 +32,7 @@ export function ParkStatsAttractionsCard({
   parkSlug,
 }: ParkStatsAttractionsCardProps) {
   return (
-    <GlassCard variant="light" className="space-y-2 p-4">
+    <GlassCard variant="strong" className="space-y-2 p-4">
       <h3 className="flex items-center gap-2 text-sm font-semibold">
         <Clock className="text-primary h-4 w-4" aria-hidden="true" />
         {title}

--- a/components/parks/park-stats-crowd-card.tsx
+++ b/components/parks/park-stats-crowd-card.tsx
@@ -27,7 +27,7 @@ export function ParkStatsCrowdCard({
   labelP90,
 }: ParkStatsCrowdCardProps) {
   return (
-    <GlassCard variant="light" className="space-y-2 p-4">
+    <GlassCard variant="strong" className="space-y-2 p-4">
       <h3 className="flex items-center gap-2 text-sm font-semibold">
         {iconType === 'calendar' ? (
           <CalendarDays className="text-primary h-4 w-4" aria-hidden="true" />

--- a/components/parks/park-stats-crowd-card.tsx
+++ b/components/parks/park-stats-crowd-card.tsx
@@ -27,7 +27,7 @@ export function ParkStatsCrowdCard({
   labelP90,
 }: ParkStatsCrowdCardProps) {
   return (
-    <GlassCard variant="strong" className="space-y-2 p-4">
+    <GlassCard variant="medium" className="space-y-2 p-4">
       <h3 className="flex items-center gap-2 text-sm font-semibold">
         {iconType === 'calendar' ? (
           <CalendarDays className="text-primary h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
## Summary

- Glass-Effekt der Panels in „Historische Wartezeit-Statistiken" von `light` auf `medium` geändert
- Betrifft `ParkStatsCrowdCard` (Monat / Wochentag) und `ParkStatsAttractionsCard` (Top-Attraktionen)
- `ParkBestDaysSection` („Best Time to Visit") war bereits auf `medium` — keine Änderung nötig
- `medium` = `bg-background/60 backdrop-blur-md`

## Test plan

- [ ] Park-Seite öffnen und zur Sektion „Historische Wartezeit-Statistiken" scrollen
- [ ] Alle drei Panels (Monat, Wochentag, Top-Attraktionen) auf Medium-Glass-Effekt prüfen
- [ ] „Best Time to Visit"-Panel ebenfalls auf einheitliches Erscheinungsbild prüfen
- [ ] Light- und Dark-Mode testen

https://claude.ai/code/session_01SA9HyjvAqSNj6bF6bTLJTy