### PR TITLE
Disable link prefetching across all card components

### DIFF
--- a/app/[locale]/search/page.tsx
+++ b/app/[locale]/search/page.tsx
@@ -102,7 +102,7 @@ function SearchResultCard({ result }: { result: SearchResultItem; locale: string
   return (
     <Link
       href={href as '/europe'}
-      prefetch={result.type === 'location' ? false : result.status === 'OPERATING'}
+      prefetch={false}
       className="group block h-full"
     >
       <Card className="hover:border-primary/50 relative h-full overflow-hidden transition-all hover:shadow-md">

--- a/components/parks/attraction-card.tsx
+++ b/components/parks/attraction-card.tsx
@@ -112,7 +112,7 @@ export function AttractionCard({
   return (
     <Link
       href={href}
-      prefetch={status === 'OPERATING'} // Only prefetch operating attractions
+      prefetch={false}
       className="group block h-full"
     >
       <Card className="hover:border-primary/50 hover:bg-background/70 relative h-full overflow-hidden transition-all duration-200 hover:scale-[1.02] hover:shadow-md">

--- a/components/parks/nearby-parks-card.tsx
+++ b/components/parks/nearby-parks-card.tsx
@@ -387,7 +387,7 @@ export function NearbyParksCard({ className }: { className?: string }) {
                     <li key={attraction.id}>
                       <Link
                         href={convertApiUrlToFrontendUrl(attraction.url)}
-                        prefetch={attraction.status === 'OPERATING'}
+                        prefetch={false}
                         className="group block"
                       >
                         <div className="bg-background/60 hover:bg-background/80 hover:border-primary/50 relative flex items-center justify-between rounded-lg border p-3 backdrop-blur-md transition-all hover:shadow-sm">

--- a/components/parks/show-card.tsx
+++ b/components/parks/show-card.tsx
@@ -58,7 +58,7 @@ export function ShowCard({
   return (
     <Link
       href={href}
-      prefetch={status === 'OPERATING'} // Only prefetch operating shows
+      prefetch={false}
       className="group block h-full"
     >
       <Card className="hover:border-primary/50 relative h-full transition-all duration-200 hover:scale-[1.02] hover:shadow-md">


### PR DESCRIPTION
## Summary
This PR disables link prefetching across all card components in the application by setting `prefetch={false}` on Link elements. Previously, prefetching was conditionally enabled based on resource status (e.g., only prefetching "OPERATING" attractions, shows, and locations).

## Changes
- **SearchResultCard**: Changed from conditional prefetch logic (`result.type === 'location' ? false : result.status === 'OPERATING'`) to always `prefetch={false}`
- **AttractionCard**: Changed from `prefetch={status === 'OPERATING'}` to `prefetch={false}`
- **NearbyParksCard**: Changed from `prefetch={attraction.status === 'OPERATING'}` to `prefetch={false}`
- **ShowCard**: Changed from `prefetch={status === 'OPERATING'}` to `prefetch={false}`

## Rationale
This change simplifies the prefetching strategy by disabling it universally. This may improve performance by reducing unnecessary network requests for pages that users may not visit, or it could be part of a broader optimization effort to defer resource loading until user interaction.

https://claude.ai/code/session_016ACGEShgBRoCSR4fvtWydA