### PR TITLE
🧪 Add unit tests for getWeatherEmoji

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "validate:translations": "node scripts/validate-translations.js",
+    "test:calendar": "node --experimental-strip-types scripts/test-calendar-utils.mjs",
     "crawl:translations": "node scripts/crawl-translations.js",
     "crawl:translations:live": "node scripts/crawl-translations.js --live",
     "test:translations": "npm run validate:translations && npm run build && npm run crawl:translations",

--- a/scripts/test-calendar-utils.mjs
+++ b/scripts/test-calendar-utils.mjs
@@ -1,0 +1,72 @@
+import { getWeatherEmoji } from '../lib/utils/calendar-utils.ts';
+
+const testCases = [
+  // Numeric codes (WMO)
+  { input: 0, expected: '☀️', name: 'Numeric: Clear sky' },
+  { input: 1, expected: '⛅', name: 'Numeric: Mainly clear' },
+  { input: 2, expected: '⛅', name: 'Numeric: Partly cloudy' },
+  { input: 3, expected: '⛅', name: 'Numeric: Overcast' },
+  { input: 45, expected: '🌫️', name: 'Numeric: Fog (45)' },
+  { input: 48, expected: '🌫️', name: 'Numeric: Fog (48)' },
+  { input: 51, expected: '🌦️', name: 'Numeric: Drizzle (51)' },
+  { input: 57, expected: '🌦️', name: 'Numeric: Drizzle (57)' },
+  { input: 61, expected: '🌧️', name: 'Numeric: Rain (61)' },
+  { input: 67, expected: '🌧️', name: 'Numeric: Rain (67)' },
+  { input: 71, expected: '🌨️', name: 'Numeric: Snow (71)' },
+  { input: 77, expected: '🌨️', name: 'Numeric: Snow (77)' },
+  { input: 80, expected: '🌧️', name: 'Numeric: Rain showers (80)' },
+  { input: 82, expected: '🌧️', name: 'Numeric: Rain showers (82)' },
+  { input: 85, expected: '❄️', name: 'Numeric: Snow showers (85)' },
+  { input: 86, expected: '❄️', name: 'Numeric: Snow showers (86)' },
+  { input: 95, expected: '⛈️', name: 'Numeric: Thunderstorm (95)' },
+  { input: 99, expected: '⛈️', name: 'Numeric: Thunderstorm (99)' },
+  { input: 100, expected: '☁️', name: 'Numeric: Unknown code' },
+
+  // String codes
+  { input: 'clear-day', expected: '☀️', name: 'String: clear-day' },
+  { input: 'clear-night', expected: '🌙', name: 'String: clear-night' },
+  { input: 'cloudy', expected: '☁️', name: 'String: cloudy' },
+  { input: 'partly-cloudy-day', expected: '⛅', name: 'String: partly-cloudy-day' },
+  { input: 'partly-cloudy-night', expected: '☁️', name: 'String: partly-cloudy-night' },
+  { input: 'rain', expected: '🌧️', name: 'String: rain' },
+  { input: 'drizzle', expected: '🌦️', name: 'String: drizzle' },
+  { input: 'snow', expected: '❄️', name: 'String: snow' },
+  { input: 'sleet', expected: '🌨️', name: 'String: sleet' },
+  { input: 'wind', expected: '💨', name: 'String: wind' },
+  { input: 'fog', expected: '🌫️', name: 'String: fog' },
+  { input: 'thunderstorm', expected: '⛈️', name: 'String: thunderstorm' },
+  { input: 'unknown-string', expected: '🌤️', name: 'String: Unknown icon' },
+];
+
+console.log('🧪 Testing getWeatherEmoji\n');
+console.log('='.repeat(80) + '\n');
+
+let passed = 0;
+let failed = 0;
+
+testCases.forEach((testCase, index) => {
+  const result = getWeatherEmoji(testCase.input);
+  const success = result === testCase.expected;
+
+  if (success) {
+    console.log(`✅ PASS: ${testCase.name}`);
+    passed++;
+  } else {
+    console.log(`❌ FAIL: ${testCase.name}`);
+    console.log(`   Input:    ${testCase.input}`);
+    console.log(`   Expected: ${testCase.expected}`);
+    console.log(`   Got:      ${result}`);
+    failed++;
+  }
+});
+
+console.log('\n' + '='.repeat(80));
+console.log(`\n📊 Results: ${passed}/${testCases.length} passed, ${failed} failed\n`);
+
+if (failed === 0) {
+  console.log('🎉 All tests passed!');
+  process.exit(0);
+} else {
+  console.log('⚠️  Some tests failed.');
+  process.exit(1);
+}


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
The `getWeatherEmoji` function in `lib/utils/calendar-utils.ts` lacked automated tests. This function maps WMO weather codes and icon strings to emojis used in the park calendar view.

### 📊 Coverage: What scenarios are now tested
- **Numeric Codes:** All major WMO code ranges (Clear, Cloudy, Fog, Drizzle, Rain, Snow, Thunderstorm) including boundary values (e.g., 1, 3, 45, 48).
- **String Codes:** All mapped icon strings (clear-day, cloudy, rain, wind, etc.).
- **Edge Cases:** Unknown numeric codes and unknown string codes are verified to return their respective default fallback emojis ('☁️' for numbers, '🌤️' for strings).

### ✨ Result: The improvement in test coverage
- Added `scripts/test-calendar-utils.mjs` following the project's established pattern for utility testing.
- Added `pnpm test:calendar` to easily run these tests.
- Verified that the tests correctly import the source code and catch regressions.

---
*PR created automatically by Jules for task [1855023825131669867](https://jules.google.com/task/1855023825131669867) started by @PArns*