### PR TITLE
feat: update realtime API types (PRs #38, #40, #41)

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -294,6 +294,7 @@ export default async function HomePage({ params }: HomePageProps) {
                     href={convertApiUrlToFrontendUrl(stats.mostCrowdedPark.url) as '/'}
                     backgroundImage={getParkBackgroundImage(stats.mostCrowdedPark.slug)}
                     status="OPERATING"
+                    timezone={stats.mostCrowdedPark.timezone}
                     crowdLevel={stats.mostCrowdedPark.crowdLevel ?? undefined}
                     averageWaitTime={stats.mostCrowdedPark.averageWaitTime ?? undefined}
                     operatingAttractions={stats.mostCrowdedPark.operatingAttractions}
@@ -316,6 +317,7 @@ export default async function HomePage({ params }: HomePageProps) {
                     href={convertApiUrlToFrontendUrl(stats.leastCrowdedPark.url) as '/'}
                     backgroundImage={getParkBackgroundImage(stats.leastCrowdedPark.slug)}
                     status="OPERATING"
+                    timezone={stats.leastCrowdedPark.timezone}
                     crowdLevel={stats.leastCrowdedPark.crowdLevel ?? undefined}
                     averageWaitTime={stats.leastCrowdedPark.averageWaitTime ?? undefined}
                     operatingAttractions={stats.leastCrowdedPark.operatingAttractions}
@@ -354,15 +356,15 @@ export default async function HomePage({ params }: HomePageProps) {
                           status: 'OPERATING',
                         },
                       ],
-                      statistics: stats.longestWaitRide.sparkline?.length
+                      statistics: stats.longestWaitRide.sparkline.length
                         ? {
-                            avgWaitToday: stats.longestWaitRide.avgWaitToday ?? null,
-                            minWaitToday: stats.longestWaitRide.minWaitToday ?? null,
-                            peakWaitToday: stats.longestWaitRide.peakWaitToday ?? null,
-                            peakWaitTimestamp: stats.longestWaitRide.peakWaitTimestamp ?? null,
-                            typicalWaitThisHour: stats.longestWaitRide.typicalWaitThisHour ?? null,
+                            avgWaitToday: stats.longestWaitRide.avgWaitToday,
+                            minWaitToday: stats.longestWaitRide.minWaitToday,
+                            peakWaitToday: stats.longestWaitRide.peakWaitToday,
+                            peakWaitTimestamp: stats.longestWaitRide.peakWaitTimestamp,
+                            typicalWaitThisHour: stats.longestWaitRide.typicalWaitThisHour,
                             percentile95ThisHour: null,
-                            currentVsTypical: stats.longestWaitRide.currentVsTypical ?? null,
+                            currentVsTypical: stats.longestWaitRide.currentVsTypical,
                             dataPoints: stats.longestWaitRide.sparkline.length,
                             history: stats.longestWaitRide.sparkline,
                             timestamp: new Date().toISOString(),
@@ -372,7 +374,7 @@ export default async function HomePage({ params }: HomePageProps) {
                         id: '',
                         name: stats.longestWaitRide.parkName,
                         slug: stats.longestWaitRide.parkSlug,
-                        timezone: stats.longestWaitRide.parkTimezone ?? '',
+                        timezone: stats.longestWaitRide.parkTimezone,
                         continent: null,
                         country: stats.longestWaitRide.parkCountrySlug,
                         city: stats.longestWaitRide.parkCity,
@@ -408,15 +410,15 @@ export default async function HomePage({ params }: HomePageProps) {
                           status: 'OPERATING',
                         },
                       ],
-                      statistics: stats.shortestWaitRide.sparkline?.length
+                      statistics: stats.shortestWaitRide.sparkline.length
                         ? {
-                            avgWaitToday: stats.shortestWaitRide.avgWaitToday ?? null,
-                            minWaitToday: stats.shortestWaitRide.minWaitToday ?? null,
-                            peakWaitToday: stats.shortestWaitRide.peakWaitToday ?? null,
-                            peakWaitTimestamp: stats.shortestWaitRide.peakWaitTimestamp ?? null,
-                            typicalWaitThisHour: stats.shortestWaitRide.typicalWaitThisHour ?? null,
+                            avgWaitToday: stats.shortestWaitRide.avgWaitToday,
+                            minWaitToday: stats.shortestWaitRide.minWaitToday,
+                            peakWaitToday: stats.shortestWaitRide.peakWaitToday,
+                            peakWaitTimestamp: stats.shortestWaitRide.peakWaitTimestamp,
+                            typicalWaitThisHour: stats.shortestWaitRide.typicalWaitThisHour,
                             percentile95ThisHour: null,
-                            currentVsTypical: stats.shortestWaitRide.currentVsTypical ?? null,
+                            currentVsTypical: stats.shortestWaitRide.currentVsTypical,
                             dataPoints: stats.shortestWaitRide.sparkline.length,
                             history: stats.shortestWaitRide.sparkline,
                             timestamp: new Date().toISOString(),
@@ -426,7 +428,7 @@ export default async function HomePage({ params }: HomePageProps) {
                         id: '',
                         name: stats.shortestWaitRide.parkName,
                         slug: stats.shortestWaitRide.parkSlug,
-                        timezone: stats.shortestWaitRide.parkTimezone ?? '',
+                        timezone: stats.shortestWaitRide.parkTimezone,
                         continent: null,
                         country: stats.shortestWaitRide.parkCountrySlug,
                         city: stats.shortestWaitRide.parkCity,

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -608,6 +608,7 @@ export interface ParkStatsItem {
   crowdLevel: CrowdLevel | null;
   totalAttractions: number;
   operatingAttractions: number;
+  timezone: string;
 }
 
 export interface AttractionStatsItem {
@@ -619,17 +620,17 @@ export interface AttractionStatsItem {
   parkCity: string;
   parkCountry: string;
   parkCountrySlug: string;
-  parkTimezone?: string;
+  parkTimezone: string;
   waitTime: number;
-  url: string;
+  url: string | null;
   crowdLevel: CrowdLevel | null;
-  sparkline?: { timestamp: string; waitTime: number }[];
-  avgWaitToday?: number | null;
-  minWaitToday?: number | null;
-  peakWaitToday?: number | null;
-  peakWaitTimestamp?: string | null;
-  typicalWaitThisHour?: number | null;
-  currentVsTypical?: number | null;
+  sparkline: { timestamp: string; waitTime: number }[];
+  avgWaitToday: number | null;
+  minWaitToday: number | null;
+  peakWaitToday: number | null;
+  peakWaitTimestamp: string | null;
+  typicalWaitThisHour: number | null;
+  currentVsTypical: number | null;
 }
 
 export interface GlobalStats {

--- a/lib/utils/url-utils.ts
+++ b/lib/utils/url-utils.ts
@@ -22,7 +22,7 @@
  * @param apiUrl - The API URL to convert (e.g., from attraction.url, park.url, etc.)
  * @returns The converted frontend URL, or '#' if conversion fails
  */
-export function convertApiUrlToFrontendUrl(apiUrl: string): string {
+export function convertApiUrlToFrontendUrl(apiUrl: string | null | undefined): string {
   if (!apiUrl) return '#';
 
   // Convert /v1/parks/... URLs


### PR DESCRIPTION
## Summary

Frontend type patch matching the updated `GET /v1/analytics/realtime` response shape from backend PRs #38, #40 and #41.

### `ParkStatsItem`
- Added `timezone: string` (IANA, e.g. `"Europe/Paris"`) — wired to `ParkCard.timezone` for opening/closing time display

### `AttractionStatsItem`
- `url: string → string | null`
- `sparkline` — required, non-optional array (empty `[]` when no data)
- `parkTimezone` — required `string` (was `string?`)
- Stats fields (`avgWaitToday`, `minWaitToday`, `peakWaitToday`, `peakWaitTimestamp`, `typicalWaitThisHour`, `currentVsTypical`) — all required (were optional)

### `convertApiUrlToFrontendUrl`
- Signature widened to `string | null | undefined` (already handled falsy internally, TypeScript just didn't allow it)

### `page.tsx`
- `timezone` prop passed to `ParkCard` for most/least crowded park
- `sparkline?.length` → `sparkline.length` (now always an array)
- Removed all `?? null` fallbacks from stats fields
- `parkTimezone ?? ''` → `parkTimezone` (now guaranteed)

https://claude.ai/code/session_01XDgcbvJNHESASKdMViuiTK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDgcbvJNHESASKdMViuiTK)_