### PR TITLE
Refactor geo translation to use safe helper function

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -288,8 +288,9 @@ export default async function HomePage({ params }: HomePageProps) {
                     parkId={stats.mostCrowdedPark.id}
                     city={stats.mostCrowdedPark.city}
                     country={
-                      tGeo(`countries.${stats.mostCrowdedPark.countrySlug}` as string) ||
-                      stats.mostCrowdedPark.country
+                      (tGeo.has(`countries.${stats.mostCrowdedPark.countrySlug}`)
+                        ? tGeo(`countries.${stats.mostCrowdedPark.countrySlug}` as string)
+                        : null) ?? stats.mostCrowdedPark.country
                     }
                     href={convertApiUrlToFrontendUrl(stats.mostCrowdedPark.url) as '/'}
                     backgroundImage={getParkBackgroundImage(stats.mostCrowdedPark.slug)}
@@ -311,8 +312,9 @@ export default async function HomePage({ params }: HomePageProps) {
                     parkId={stats.leastCrowdedPark.id}
                     city={stats.leastCrowdedPark.city}
                     country={
-                      tGeo(`countries.${stats.leastCrowdedPark.countrySlug}` as string) ||
-                      stats.leastCrowdedPark.country
+                      (tGeo.has(`countries.${stats.leastCrowdedPark.countrySlug}`)
+                        ? tGeo(`countries.${stats.leastCrowdedPark.countrySlug}` as string)
+                        : null) ?? stats.leastCrowdedPark.country
                     }
                     href={convertApiUrlToFrontendUrl(stats.leastCrowdedPark.url) as '/'}
                     backgroundImage={getParkBackgroundImage(stats.leastCrowdedPark.slug)}
@@ -509,7 +511,9 @@ export default async function HomePage({ params }: HomePageProps) {
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
               {continents.map((continent) => {
                 const continentName =
-                  tGeo(`continents.${continent.slug}` as string) || continent.name;
+                  tGeo.has(`continents.${continent.slug}`)
+                    ? tGeo(`continents.${continent.slug}` as string)
+                    : continent.name;
 
                 return (
                   <Link

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -16,6 +16,7 @@ import { HERO_IMAGES } from '@/lib/hero-images';
 import { HomepageFAQStructuredData } from '@/components/seo/homepage-faq-structured-data';
 import { OpenStatusProgress } from '@/components/common/open-status-progress';
 import { GlassCard } from '@/components/common/glass-card';
+import { translateGeoSlug } from '@/lib/utils/geo-translate';
 
 const LocationBanner = nextDynamic(
   () => import('@/components/common/location-banner').then((m) => ({ default: m.LocationBanner })),
@@ -287,11 +288,7 @@ export default async function HomePage({ params }: HomePageProps) {
                     slug={stats.mostCrowdedPark.slug}
                     parkId={stats.mostCrowdedPark.id}
                     city={stats.mostCrowdedPark.city}
-                    country={
-                      (tGeo.has(`countries.${stats.mostCrowdedPark.countrySlug}`)
-                        ? tGeo(`countries.${stats.mostCrowdedPark.countrySlug}` as string)
-                        : null) ?? stats.mostCrowdedPark.country
-                    }
+                    country={translateGeoSlug(tGeo, 'countries', stats.mostCrowdedPark.countrySlug, stats.mostCrowdedPark.country)}
                     href={convertApiUrlToFrontendUrl(stats.mostCrowdedPark.url) as '/'}
                     backgroundImage={getParkBackgroundImage(stats.mostCrowdedPark.slug)}
                     status="OPERATING"
@@ -311,11 +308,7 @@ export default async function HomePage({ params }: HomePageProps) {
                     slug={stats.leastCrowdedPark.slug}
                     parkId={stats.leastCrowdedPark.id}
                     city={stats.leastCrowdedPark.city}
-                    country={
-                      (tGeo.has(`countries.${stats.leastCrowdedPark.countrySlug}`)
-                        ? tGeo(`countries.${stats.leastCrowdedPark.countrySlug}` as string)
-                        : null) ?? stats.leastCrowdedPark.country
-                    }
+                    country={translateGeoSlug(tGeo, 'countries', stats.leastCrowdedPark.countrySlug, stats.leastCrowdedPark.country)}
                     href={convertApiUrlToFrontendUrl(stats.leastCrowdedPark.url) as '/'}
                     backgroundImage={getParkBackgroundImage(stats.leastCrowdedPark.slug)}
                     status="OPERATING"
@@ -511,9 +504,7 @@ export default async function HomePage({ params }: HomePageProps) {
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
               {continents.map((continent) => {
                 const continentName =
-                  tGeo.has(`continents.${continent.slug}`)
-                    ? tGeo(`continents.${continent.slug}` as string)
-                    : continent.name;
+                  translateGeoSlug(tGeo, 'continents', continent.slug, continent.name);
 
                 return (
                   <Link

--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -36,6 +36,7 @@ import { ParkStatsSection } from '@/components/parks/park-stats-section';
 import { NearbyParksSection } from '@/components/parks/nearby-parks-section';
 import { groupAttractionsByLand } from '@/lib/utils/park-utils';
 import { generateParkBreadcrumbs } from '@/lib/utils/breadcrumb-utils';
+import { translateGeoSlug } from '@/lib/utils/geo-translate';
 
 interface ParkPageProps {
   params: Promise<{
@@ -269,9 +270,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
                       <MapPin className="h-4 w-4" aria-hidden="true" />
                       <span>{cityName}</span>,{' '}
                       <span>
-                        {tGeo.has(`countries.${country}`)
-                          ? tGeo(`countries.${country}` as 'countries.germany')
-                          : countryName}
+                        {translateGeoSlug(tGeo, 'countries', country, countryName)}
                       </span>
                     </address>
                     {park.timezone && (

--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -269,7 +269,9 @@ export default async function ParkPage({ params }: ParkPageProps) {
                       <MapPin className="h-4 w-4" aria-hidden="true" />
                       <span>{cityName}</span>,{' '}
                       <span>
-                        {tGeo(`countries.${country}` as 'countries.germany') || countryName}
+                        {tGeo.has(`countries.${country}`)
+                          ? tGeo(`countries.${country}` as 'countries.germany')
+                          : countryName}
                       </span>
                     </address>
                     {park.timezone && (

--- a/app/[locale]/search/page.tsx
+++ b/app/[locale]/search/page.tsx
@@ -73,6 +73,7 @@ const typeLabels = {
 import { getParkBackgroundImage } from '@/lib/utils/park-assets';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
+import { translateGeoSlug } from '@/lib/utils/geo-translate';
 
 function SearchResultCard({ result }: { result: SearchResultItem; locale: string }) {
   const t = useTranslations('common');
@@ -140,10 +141,7 @@ function SearchResultCard({ result }: { result: SearchResultItem; locale: string
               {[
                 result.city,
                 result.country
-                  ? (() => {
-                      const key = `countries.${result.country.toLowerCase().replace(/\s+/g, '-')}`;
-                      return tGeo.has(key) ? tGeo(key) : result.country;
-                    })()
+                  ? translateGeoSlug(tGeo, 'countries', result.country, result.country)
                   : null,
               ]
                 .filter(Boolean)

--- a/app/[locale]/search/page.tsx
+++ b/app/[locale]/search/page.tsx
@@ -140,8 +140,10 @@ function SearchResultCard({ result }: { result: SearchResultItem; locale: string
               {[
                 result.city,
                 result.country
-                  ? tGeo(`countries.${result.country.toLowerCase().replace(/\s+/g, '-')}`) ||
-                    result.country
+                  ? (() => {
+                      const key = `countries.${result.country.toLowerCase().replace(/\s+/g, '-')}`;
+                      return tGeo.has(key) ? tGeo(key) : result.country;
+                    })()
                   : null,
               ]
                 .filter(Boolean)

--- a/app/api/og/[...path]/route.tsx
+++ b/app/api/og/[...path]/route.tsx
@@ -5,9 +5,11 @@ import { getParkByGeoPath, getAttractionByGeoPath } from '@/lib/api/parks';
 import { getGeoStructure } from '@/lib/api/discovery';
 import { getParkBackgroundImage, getAttractionBackgroundImage } from '@/lib/utils/park-assets';
 import { stripNewPrefix } from '@/lib/utils';
+import { translateGeoSlug } from '@/lib/utils/geo-translate';
 import { HERO_IMAGES } from '@/lib/hero-images';
 import { ParkAttraction, QueueDataItem } from '@/lib/api/types';
 import { isValidLocale } from '@/i18n/config';
+import { GLOSSARY_SEGMENTS } from '@/lib/glossary/translations';
 import {
   FlagDE,
   FlagGB,
@@ -153,6 +155,12 @@ export async function GET(
     }
 
     // Generic pages configuration
+    const glossaryEntries = Object.fromEntries(
+      Object.values(GLOSSARY_SEGMENTS).map((seg) => [
+        seg,
+        { namespace: 'glossary', key: 'overviewTitle' },
+      ])
+    );
     const genericPages = {
       search: { namespace: 'common', key: 'search' },
       datenschutz: { namespace: 'datenschutz', key: 'title' },
@@ -160,6 +168,7 @@ export async function GET(
       impressum: { namespace: 'impressum', key: 'title' },
       imprint: { namespace: 'impressum', key: 'title' },
       parks: { namespace: 'explore', key: 'parksTitle' },
+      ...glossaryEntries,
     };
 
     const [localeParam, secondSegment] = path;
@@ -262,10 +271,7 @@ export async function GET(
     } else if (['CONTINENT', 'COUNTRY', 'CITY'].includes(type)) {
       // Resolve Name & Stats based on Type
       if (type === 'CONTINENT' && continentNode) {
-        name = tGeo.has(`continents.${continent}`)
-          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            tGeo(`continents.${continent}` as any)
-          : continentNode.name;
+        name = translateGeoSlug(tGeo, 'continents', continent, continentNode.name);
         totalParks = continentNode.parkCount;
         openParksCount = continentNode.openParkCount;
 
@@ -279,10 +285,7 @@ export async function GET(
         geoSvg = getRegionGeoSVG(identifiers);
       } else if (type === 'COUNTRY' && countryNode) {
         const normalizedCountry = country.toLowerCase().replace(/\s+/g, '-');
-        name = tGeo.has(`countries.${normalizedCountry}`)
-          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            tGeo(`countries.${normalizedCountry}` as any)
-          : countryNode.name;
+        name = translateGeoSlug(tGeo, 'countries', normalizedCountry, countryNode.name);
         totalParks = countryNode.parkCount;
         openParksCount = countryNode.openParkCount;
 

--- a/app/api/og/[...path]/route.tsx
+++ b/app/api/og/[...path]/route.tsx
@@ -168,6 +168,7 @@ export async function GET(
       impressum: { namespace: 'impressum', key: 'title' },
       imprint: { namespace: 'impressum', key: 'title' },
       parks: { namespace: 'explore', key: 'parksTitle' },
+      howto: { namespace: 'howto', key: 'title' },
       ...glossaryEntries,
     };
 

--- a/app/api/og/[...path]/route.tsx
+++ b/app/api/og/[...path]/route.tsx
@@ -262,9 +262,10 @@ export async function GET(
     } else if (['CONTINENT', 'COUNTRY', 'CITY'].includes(type)) {
       // Resolve Name & Stats based on Type
       if (type === 'CONTINENT' && continentNode) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        name = tGeo(`continents.${continent}` as any);
-        if (name === `continents.${continent}`) name = continentNode.name;
+        name = tGeo.has(`continents.${continent}`)
+          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            tGeo(`continents.${continent}` as any)
+          : continentNode.name;
         totalParks = continentNode.parkCount;
         openParksCount = continentNode.openParkCount;
 
@@ -278,9 +279,10 @@ export async function GET(
         geoSvg = getRegionGeoSVG(identifiers);
       } else if (type === 'COUNTRY' && countryNode) {
         const normalizedCountry = country.toLowerCase().replace(/\s+/g, '-');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        name = tGeo(`countries.${normalizedCountry}` as any);
-        if (name === `countries.${normalizedCountry}`) name = countryNode.name;
+        name = tGeo.has(`countries.${normalizedCountry}`)
+          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            tGeo(`countries.${normalizedCountry}` as any)
+          : countryNode.name;
         totalParks = countryNode.parkCount;
         openParksCount = countryNode.openParkCount;
 

--- a/components/home/featured-parks-section-client.tsx
+++ b/components/home/featured-parks-section-client.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTranslations, useLocale } from 'next-intl';
 import { ParkCard } from '@/components/parks/park-card';
+import { translateGeoSlug } from '@/lib/utils/geo-translate';
 import { Link } from '@/i18n/navigation';
 import { ChevronRight } from 'lucide-react';
 import type { FeaturedPark } from './featured-parks-section';
@@ -17,10 +18,7 @@ function getTranslatedCountry(
   tGeo: ReturnType<typeof useTranslations>,
   park: FeaturedPark
 ): string {
-  const key = `countries.${park.countrySlug.toLowerCase().replace(/\s+/g, '-')}`;
-  return tGeo.has(key as Parameters<typeof tGeo>[0])
-    ? tGeo(key as Parameters<typeof tGeo>[0])
-    : park.countryName;
+  return translateGeoSlug(tGeo, 'countries', park.countrySlug, park.countryName);
 }
 
 /** Skeleton placeholder while parks load */

--- a/components/home/featured-parks-section-client.tsx
+++ b/components/home/featured-parks-section-client.tsx
@@ -18,8 +18,9 @@ function getTranslatedCountry(
   park: FeaturedPark
 ): string {
   const key = `countries.${park.countrySlug.toLowerCase().replace(/\s+/g, '-')}`;
-  const result = tGeo(key as Parameters<typeof tGeo>[0]);
-  return result === key ? park.countryName : result;
+  return tGeo.has(key as Parameters<typeof tGeo>[0])
+    ? tGeo(key as Parameters<typeof tGeo>[0])
+    : park.countryName;
 }
 
 /** Skeleton placeholder while parks load */

--- a/components/parks/attraction-card.tsx
+++ b/components/parks/attraction-card.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { cn, stripNewPrefix } from '@/lib/utils';
 import { convertApiUrlToFrontendUrl } from '@/lib/utils/url-utils';
+import { translateGeoSlug } from '@/lib/utils/geo-translate';
 import { formatDistance } from '@/lib/utils/distance-utils';
 import type { ParkAttraction, AttractionStatus, ParkStatus, BestVisitSlot } from '@/lib/api/types';
 import type { ReactNode } from 'react';
@@ -323,8 +324,7 @@ export function AttractionCard({
             const rawCountry = park && 'country' in park ? park.country : null;
             const country = rawCountry
               ? (() => {
-                  const key = `countries.${rawCountry.toLowerCase().replace(/\s+/g, '-')}`;
-                  return tGeo.has(key) ? tGeo(key) : rawCountry;
+                  return translateGeoSlug(tGeo, 'countries', rawCountry, rawCountry);
                 })()
               : null;
             const place = [city, country].filter(Boolean).join(', ');

--- a/components/parks/attraction-card.tsx
+++ b/components/parks/attraction-card.tsx
@@ -324,8 +324,7 @@ export function AttractionCard({
             const country = rawCountry
               ? (() => {
                   const key = `countries.${rawCountry.toLowerCase().replace(/\s+/g, '-')}`;
-                  const translated = tGeo(key);
-                  return translated !== key ? translated : rawCountry;
+                  return tGeo.has(key) ? tGeo(key) : rawCountry;
                 })()
               : null;
             const place = [city, country].filter(Boolean).join(', ');

--- a/components/parks/park-card.tsx
+++ b/components/parks/park-card.tsx
@@ -108,8 +108,8 @@ export function ParkCard({
   const displayCountry = translateCountry
     ? (() => {
         const normalized = country.toLowerCase().replace(/\s+/g, '-');
-        const translated = tGeo(`countries.${normalized}` as string);
-        return translated !== `countries.${normalized}` ? translated : country;
+        const key = `countries.${normalized}`;
+        return tGeo.has(key) ? tGeo(key as string) : country;
       })()
     : country;
 

--- a/components/parks/park-card.tsx
+++ b/components/parks/park-card.tsx
@@ -14,6 +14,7 @@ import { getScheduleMessage } from '@/lib/utils/schedule-utils';
 import type { ScheduleSummary } from '@/lib/api/types';
 import { GlossaryTermLink } from '@/components/glossary/glossary-term-link';
 import { convertApiUrlToFrontendUrl } from '@/lib/utils/url-utils';
+import { translateGeoSlug } from '@/lib/utils/geo-translate';
 
 // Lazily loaded server-side only — avoids bundling `fs` into the client
 /* eslint-disable @typescript-eslint/no-require-imports */
@@ -107,9 +108,7 @@ export function ParkCard({
 
   const displayCountry = translateCountry
     ? (() => {
-        const normalized = country.toLowerCase().replace(/\s+/g, '-');
-        const key = `countries.${normalized}`;
-        return tGeo.has(key) ? tGeo(key as string) : country;
+        return translateGeoSlug(tGeo, 'countries', country, country);
       })()
     : country;
 

--- a/components/search/search-bar.tsx
+++ b/components/search/search-bar.tsx
@@ -381,7 +381,10 @@ export function SearchCommand({
                     {[
                       result.city,
                       result.country
-                        ? tGeo(`countries.${result.country.toLowerCase().replace(/\s+/g, '-')}`)
+                        ? (() => {
+                            const key = `countries.${result.country.toLowerCase().replace(/\s+/g, '-')}`;
+                            return tGeo.has(key) ? tGeo(key) : result.country;
+                          })()
                         : null,
                     ]
                       .filter(Boolean)

--- a/components/search/search-bar.tsx
+++ b/components/search/search-bar.tsx
@@ -29,6 +29,7 @@ import { CrowdLevelBadge } from '@/components/parks/crowd-level-badge';
 import { ParkStatusBadge } from '@/components/parks/park-status-badge';
 import { stripNewPrefix } from '@/lib/utils';
 import { convertApiUrlToFrontendUrl } from '@/lib/utils/url-utils';
+import { translateGeoSlug } from '@/lib/utils/geo-translate';
 import type { SearchResult, SearchResultItem, ParkStatus, CrowdLevel } from '@/lib/api/types';
 import {
   trackSearchOpened,
@@ -381,10 +382,7 @@ export function SearchCommand({
                     {[
                       result.city,
                       result.country
-                        ? (() => {
-                            const key = `countries.${result.country.toLowerCase().replace(/\s+/g, '-')}`;
-                            return tGeo.has(key) ? tGeo(key) : result.country;
-                          })()
+                        ? translateGeoSlug(tGeo, 'countries', result.country, result.country)
                         : null,
                     ]
                       .filter(Boolean)

--- a/lib/utils/geo-translate.ts
+++ b/lib/utils/geo-translate.ts
@@ -1,0 +1,19 @@
+type GeoTranslator = {
+  has: (key: string) => boolean;
+  (key: string): string;
+};
+
+/**
+ * Safely translates a geo slug (country or continent) using next-intl.
+ * tGeo() throws on missing keys, so we guard with has() first.
+ * Normalizes the slug to lowercase-hyphenated form before lookup.
+ */
+export function translateGeoSlug(
+  t: GeoTranslator,
+  namespace: 'countries' | 'continents',
+  slug: string,
+  fallback: string
+): string {
+  const key = `${namespace}.${slug.toLowerCase().replace(/\s+/g, '-')}`;
+  return t.has(key) ? t(key) : fallback;
+}


### PR DESCRIPTION
## Summary
Introduces a new `translateGeoSlug()` utility function to safely handle geographical translations (countries and continents) across the codebase, replacing repetitive inline translation logic with a consistent, type-safe approach.

## Key Changes
- **New utility function**: Added `lib/utils/geo-translate.ts` with `translateGeoSlug()` that:
  - Safely checks for translation key existence before attempting translation
  - Normalizes slugs to lowercase-hyphenated format
  - Returns a fallback value if translation is unavailable
  - Eliminates the need for `as any` type assertions and manual key existence checks

- **Refactored translation calls** across 9 files:
  - `app/api/og/[...path]/route.tsx`: Continent and country name resolution in OG image generation
  - `app/[locale]/page.tsx`: Homepage continent and park country displays
  - `app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx`: Park detail page location display
  - `app/[locale]/search/page.tsx`: Search results country display
  - `components/home/featured-parks-section-client.tsx`: Featured parks country translation
  - `components/parks/attraction-card.tsx`: Attraction card location display
  - `components/parks/park-card.tsx`: Park card country display
  - `components/search/search-bar.tsx`: Search command results country display

- **Added glossary entries** to OG route generic pages configuration for improved metadata generation

## Implementation Details
- The helper function accepts a `GeoTranslator` type that matches the `next-intl` translation function interface
- Slug normalization (whitespace to hyphens, lowercase conversion) is centralized in the utility
- Removes ~15 instances of duplicated translation logic and type assertion workarounds
- Maintains backward compatibility with existing fallback behavior

https://claude.ai/code/session_01BTU8HmgPCSnVsETb1Y1Sx5