### PR TITLE
Refactor: Replace nested loops with functional patterns and optimize lookups

### DIFF
--- a/app/[locale]/datenschutz/page.tsx
+++ b/app/[locale]/datenschutz/page.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/no-unescaped-entities */
-import { getTranslations } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { locales, generateAlternateLanguages, localeToOpenGraphLocale } from '@/i18n/config';
-import { setRequestLocale } from 'next-intl/server';
 import { routing, type Locale } from '@/i18n/routing';
 import type { Metadata } from 'next';
 import { AnalyticsOptOut } from '@/components/common/analytics-opt-out';

--- a/app/api/cron/indexnow/route.ts
+++ b/app/api/cron/indexnow/route.ts
@@ -31,18 +31,18 @@ export async function GET(request: Request) {
   try {
     const geo = await getGeoStructure(86400);
 
-    for (const continent of geo.continents) {
-      for (const country of continent.countries) {
-        for (const city of country.cities) {
-          for (const park of city.parks) {
-            const parkPath = `/parks/${continent.slug}/${country.slug}/${city.slug}/${park.slug}`;
-            for (const locale of locales) {
-              urls.push(`${BASE_URL}/${locale}${parkPath}`);
-            }
-          }
-        }
-      }
-    }
+    urls.push(
+      ...geo.continents.flatMap((continent) =>
+        continent.countries.flatMap((country) =>
+          country.cities.flatMap((city) =>
+            city.parks.flatMap((park) => {
+              const parkPath = `/parks/${continent.slug}/${country.slug}/${city.slug}/${park.slug}`;
+              return locales.map((locale) => `${BASE_URL}/${locale}${parkPath}`);
+            })
+          )
+        )
+      )
+    );
   } catch (error) {
     console.error('[IndexNow] Failed to fetch geo structure:', error);
     return NextResponse.json({ error: 'Failed to fetch geo structure' }, { status: 500 });
@@ -67,9 +67,11 @@ export async function GET(request: Request) {
 
   // IndexNow accepts up to 10 000 URLs per request
   const BATCH_SIZE = 10_000;
+  const batches: Promise<void>[] = [];
   for (let i = 0; i < urls.length; i += BATCH_SIZE) {
-    await submitUrlsToIndexNow(urls.slice(i, i + BATCH_SIZE));
+    batches.push(submitUrlsToIndexNow(urls.slice(i, i + BATCH_SIZE)));
   }
+  await Promise.all(batches);
 
   return NextResponse.json({ submitted: urls.length });
 }

--- a/app/api/og/[...path]/route.tsx
+++ b/app/api/og/[...path]/route.tsx
@@ -260,6 +260,7 @@ export async function GET(
       const randomIndex = Math.floor(Math.random() * HERO_IMAGES.length);
       backgroundImagePath = HERO_IMAGES[randomIndex];
     } else if (['CONTINENT', 'COUNTRY', 'CITY'].includes(type)) {
+      const { getRegionGeoSVG } = await import('@/lib/utils/geo-svg');
       // Resolve Name & Stats based on Type
       if (type === 'CONTINENT' && continentNode) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -274,7 +275,6 @@ export async function GET(
           .filter((c) => continent !== 'europe' || c.code !== 'RU')
           .flatMap((c) => [c.code, c.name].filter(Boolean));
 
-        const { getRegionGeoSVG } = await import('@/lib/utils/geo-svg');
         geoSvg = getRegionGeoSVG(identifiers);
       } else if (type === 'COUNTRY' && countryNode) {
         const normalizedCountry = country.toLowerCase().replace(/\s+/g, '-');
@@ -284,7 +284,6 @@ export async function GET(
         totalParks = countryNode.parkCount;
         openParksCount = countryNode.openParkCount;
 
-        const { getRegionGeoSVG } = await import('@/lib/utils/geo-svg');
         geoSvg = getRegionGeoSVG([countryNode.code, countryNode.name]);
       } else if (type === 'CITY' && cityNode) {
         name = cityNode.name;
@@ -297,7 +296,6 @@ export async function GET(
         // Let's reuse the country map for context, maybe highlights?
         // For now: Country Map.
         if (countryNode) {
-          const { getRegionGeoSVG } = await import('@/lib/utils/geo-svg');
           geoSvg = getRegionGeoSVG([countryNode.code, countryNode.name]);
         }
       }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -83,12 +83,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })
   );
 
+  const termMapsByLocale = new Map<string, Map<string, GlossaryTerm>>();
+  for (const [locale, terms] of termsByLocale) {
+    termMapsByLocale.set(locale, new Map(terms.map((t) => [t.id, t])));
+  }
+
   const enTerms = termsByLocale.get('en')!;
   for (const enTerm of enTerms) {
     const termAlternates: Record<string, string> = {};
     for (const l of locales) {
-      const localTerms = termsByLocale.get(l)!;
-      const localTerm = localTerms.find((term) => term.id === enTerm.id);
+      const localTerm = termMapsByLocale.get(l)!.get(enTerm.id);
       if (localTerm) {
         termAlternates[l] =
           `${BASE_URL}/${l}/${GLOSSARY_SEGMENTS[l as keyof typeof GLOSSARY_SEGMENTS]}/${localTerm.slug}`;
@@ -97,8 +101,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     termAlternates['x-default'] = termAlternates['en'];
 
     for (const locale of locales) {
-      const localTerms = termsByLocale.get(locale)!;
-      const localTerm = localTerms.find((term) => term.id === enTerm.id);
+      const localTerm = termMapsByLocale.get(locale)!.get(enTerm.id);
       if (!localTerm) continue;
 
       routes.push({

--- a/components/glossary/glossary-inject.tsx
+++ b/components/glossary/glossary-inject.tsx
@@ -55,6 +55,7 @@ function parseSegments(text: string, terms: GlossaryTerm[]): Segment[] {
   const entries = buildMatchEntries(terms);
   if (entries.length === 0) return [{ type: 'text', content: text }];
 
+  const entryByPattern = new Map(entries.map((e) => [e.pattern.toLowerCase(), e]));
   const pattern = entries.map((e) => buildPatternFragment(e.pattern)).join('|');
   const regex = new RegExp(`(${pattern})`, 'gi');
 
@@ -66,7 +67,7 @@ function parseSegments(text: string, terms: GlossaryTerm[]): Segment[] {
 
   while ((match = regex.exec(text)) !== null) {
     const matched = match[0];
-    const entry = entries.find((e) => e.pattern.toLowerCase() === matched.toLowerCase());
+    const entry = entryByPattern.get(matched.toLowerCase());
     if (!entry || used.has(matched.toLowerCase())) continue;
 
     // Short patterns (≤ 4 chars) must match exactly — avoids matching common words

--- a/components/home/featured-parks-section.tsx
+++ b/components/home/featured-parks-section.tsx
@@ -87,13 +87,14 @@ export function extractFeaturedParks(geoData: GeoStructure | null, locale: strin
   if (!geoData) return [];
 
   const slugs = FEATURED_PARK_SLUGS[locale] ?? FEATURED_PARK_SLUGS['en'];
+  const slugSet = new Set(slugs);
   const slugMap = new Map<string, FeaturedPark>();
 
   for (const continent of geoData.continents) {
     for (const country of continent.countries) {
       for (const city of country.cities) {
         for (const park of city.parks) {
-          if (slugMap.size < slugs.length && slugs.includes(park.slug) && !slugMap.has(park.slug)) {
+          if (slugMap.size < slugSet.size && slugSet.has(park.slug) && !slugMap.has(park.slug)) {
             slugMap.set(park.slug, {
               name: park.name,
               slug: park.slug,

--- a/next.config.ts
+++ b/next.config.ts
@@ -58,7 +58,8 @@ const nextConfig: NextConfig = {
 
     // 1. Cross-locale wrong segments: /[locale]/[wrong-segment] → /[locale]/[correct-segment]
     //    Covers: EN locale (was missing), /de/glossary (EN segment under DE), old woordenlijst
-    for (const [locale, correctSegment] of Object.entries(localeSegments)) {
+    const localeSegmentEntries = Object.entries(localeSegments);
+    for (const [locale, correctSegment] of localeSegmentEntries) {
       for (const wrongSegment of allSegments) {
         if (wrongSegment === correctSegment) continue;
         rules.push(

--- a/next.config.ts
+++ b/next.config.ts
@@ -58,8 +58,7 @@ const nextConfig: NextConfig = {
 
     // 1. Cross-locale wrong segments: /[locale]/[wrong-segment] → /[locale]/[correct-segment]
     //    Covers: EN locale (was missing), /de/glossary (EN segment under DE), old woordenlijst
-    const localeSegmentEntries = Object.entries(localeSegments);
-    for (const [locale, correctSegment] of localeSegmentEntries) {
+    for (const [locale, correctSegment] of Object.entries(localeSegments)) {
       for (const wrongSegment of allSegments) {
         if (wrongSegment === correctSegment) continue;
         rules.push(


### PR DESCRIPTION
## Summary
This PR refactors several areas of the codebase to improve code readability and performance by replacing nested loops with functional programming patterns and optimizing repeated lookups using Map data structures.

## Key Changes

- **URL Generation Optimization** (`app/api/cron/indexnow/route.ts`):
  - Replaced deeply nested for-loops with `flatMap()` chains for generating park URLs across continents, countries, cities, and locales
  - Converted sequential IndexNow submissions to parallel batch processing using `Promise.all()` for better performance

- **Glossary Term Lookups** (`app/sitemap.ts`):
  - Pre-computed a `termMapsByLocale` Map structure to replace repeated `.find()` calls on term arrays
  - Changed from O(n) array searches to O(1) Map lookups when matching terms by ID across locales

- **Glossary Injection Pattern Matching** (`components/glossary/glossary-inject.tsx`):
  - Created `entryByPattern` Map to cache pattern-to-entry mappings
  - Replaced linear search through entries array with direct Map lookup during regex matching

- **Featured Parks Extraction** (`components/home/featured-parks-section.tsx`):
  - Converted `slugs` array to a `Set` for O(1) membership checking instead of O(n) `.includes()` calls

- **Code Organization** (`app/api/og/[...path]/route.tsx`):
  - Moved `getRegionGeoSVG` import to the top of the conditional block to avoid duplicate imports

- **Import Consolidation** (`app/[locale]/datenschutz/page.tsx`):
  - Combined related imports from `next-intl/server` into a single import statement

## Implementation Details
All changes maintain functional equivalence while improving performance characteristics. The refactoring prioritizes:
- Reducing algorithmic complexity in hot paths (nested loops → flatMap, array searches → Map lookups)
- Enabling parallelization where applicable (sequential awaits → Promise.all)
- Improving code maintainability through functional composition

https://claude.ai/code/session_01Xp4hksg1oDq2Hg1gxZM8bs