### PR TITLE
Prevent background scroll when dialog/command palette is open

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -157,6 +157,10 @@
     @apply bg-background text-foreground;
     overflow-x: clip;
   }
+  /* Prevent background scroll when a Radix dialog/command palette is open */
+  body[data-scroll-locked] {
+    overflow: hidden !important;
+  }
 }
 
 /* Hero background: Ken Burns slow zoom + pan */


### PR DESCRIPTION
## Summary
Added CSS rule to prevent background scrolling when a Radix dialog or command palette is open by locking the body overflow when a `data-scroll-locked` attribute is present.

## Changes
- Added `body[data-scroll-locked]` CSS rule that sets `overflow: hidden !important` to prevent scrolling of the page background when modal dialogs or command palettes are displayed
- This rule is placed in the global styles within the `@layer base` directive to ensure proper cascade and specificity

## Implementation Details
- Uses a data attribute selector (`data-scroll-locked`) that can be toggled on the body element when modals open/close
- The `!important` flag ensures this rule takes precedence over other overflow styles
- This is a common UX pattern to prevent body scroll while modal content is displayed, improving accessibility and user experience

https://claude.ai/code/session_011cvkTk4rWCanunYekiqMyT