### PR TITLE
Open-Meteo Attribution für Wetterdaten (CC-BY 4.0)

### DIFF
--- a/app/[locale]/impressum/page.tsx
+++ b/app/[locale]/impressum/page.tsx
@@ -227,6 +227,25 @@ export default async function ImpressumPage({ params }: ImpressumPageProps) {
                     />
                   </a>
                 </li>
+                <li>
+                  <a
+                    href="https://open-meteo.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group flex items-center justify-between py-3"
+                  >
+                    <div>
+                      <span className="group-hover:text-primary font-medium">Open-Meteo.com</span>
+                      <p className="text-muted-foreground text-sm">
+                        Wetterdaten und Vorhersagen (CC-BY 4.0)
+                      </p>
+                    </div>
+                    <ExternalLink
+                      className="text-muted-foreground group-hover:text-primary h-4 w-4 shrink-0"
+                      aria-hidden="true"
+                    />
+                  </a>
+                </li>
               </ul>
 
               <h2 className="border-border mt-12 mb-6 border-b pb-3 text-3xl font-bold">
@@ -405,6 +424,25 @@ export default async function ImpressumPage({ params }: ImpressumPageProps) {
                       <span className="group-hover:text-primary font-medium">Wartezeiten.app</span>
                       <p className="text-muted-foreground text-sm">
                         Wait times for German-speaking parks
+                      </p>
+                    </div>
+                    <ExternalLink
+                      className="text-muted-foreground group-hover:text-primary h-4 w-4 shrink-0"
+                      aria-hidden="true"
+                    />
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://open-meteo.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group flex items-center justify-between py-3"
+                  >
+                    <div>
+                      <span className="group-hover:text-primary font-medium">Open-Meteo.com</span>
+                      <p className="text-muted-foreground text-sm">
+                        Weather data and forecasts (CC-BY 4.0)
                       </p>
                     </div>
                     <ExternalLink

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -78,7 +78,7 @@ export function WeatherCard({ weather, forecast, className }: WeatherCardProps) 
           <WeatherForecastStrip forecast={forecast || (weather.forecast ?? [])} />
         )}
 
-        <p className="text-muted-foreground/70 flex items-center justify-center gap-1 text-center text-[10px]">
+        <p className="text-muted-foreground/70 flex items-center gap-1 text-[10px]">
           <Cloud className="h-3 w-3" aria-hidden="true" />
           <span>
             {t('dataBy')}{' '}

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from 'next-intl';
-import { Wind, Umbrella } from 'lucide-react';
+import { Wind, Umbrella, Cloud } from 'lucide-react';
 import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { GlassCard } from '@/components/common/glass-card';
 import { cn } from '@/lib/utils';
@@ -78,16 +78,19 @@ export function WeatherCard({ weather, forecast, className }: WeatherCardProps) 
           <WeatherForecastStrip forecast={forecast || (weather.forecast ?? [])} />
         )}
 
-        <p className="text-muted-foreground/70 text-[10px]">
-          {t('dataBy')}{' '}
-          <a
-            href="https://open-meteo.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-primary underline-offset-2 hover:underline"
-          >
-            Open-Meteo.com
-          </a>
+        <p className="text-muted-foreground/70 flex items-center justify-center gap-1 text-center text-[10px]">
+          <Cloud className="h-3 w-3" aria-hidden="true" />
+          <span>
+            {t('dataBy')}{' '}
+            <a
+              href="https://open-meteo.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-primary underline-offset-2 hover:underline"
+            >
+              Open-Meteo.com
+            </a>
+          </span>
         </p>
       </CardContent>
     </GlassCard>

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from 'next-intl';
-import { Wind, Umbrella, Cloud } from 'lucide-react';
+import { Wind, Umbrella, Cloud, ExternalLink } from 'lucide-react';
 import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { GlassCard } from '@/components/common/glass-card';
 import { cn } from '@/lib/utils';
@@ -86,9 +86,10 @@ export function WeatherCard({ weather, forecast, className }: WeatherCardProps) 
               href="https://open-meteo.com/"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-primary underline-offset-2 hover:underline"
+              className="hover:text-primary inline-flex items-center gap-0.5 underline-offset-2 hover:underline"
             >
               Open-Meteo.com
+              <ExternalLink className="h-2.5 w-2.5" aria-hidden="true" />
             </a>
           </span>
         </p>

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from 'next-intl';
-import { Wind, Umbrella, Cloud, ExternalLink } from 'lucide-react';
+import { Wind, Umbrella, ExternalLink } from 'lucide-react';
 import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { GlassCard } from '@/components/common/glass-card';
 import { cn } from '@/lib/utils';
@@ -78,20 +78,17 @@ export function WeatherCard({ weather, forecast, className }: WeatherCardProps) 
           <WeatherForecastStrip forecast={forecast || (weather.forecast ?? [])} />
         )}
 
-        <p className="text-muted-foreground/70 flex items-center gap-1 text-[10px]">
-          <Cloud className="h-3 w-3" aria-hidden="true" />
-          <span>
-            {t('dataBy')}{' '}
-            <a
-              href="https://open-meteo.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-primary inline-flex items-center gap-0.5 underline-offset-2 hover:underline"
-            >
-              Open-Meteo.com
-              <ExternalLink className="h-2.5 w-2.5" aria-hidden="true" />
-            </a>
-          </span>
+        <p className="text-muted-foreground/70 text-[10px]">
+          {t('dataBy')}{' '}
+          <a
+            href="https://open-meteo.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary inline-flex items-center gap-0.5 align-baseline underline-offset-2 hover:underline"
+          >
+            Open-Meteo.com
+            <ExternalLink className="h-2.5 w-2.5" aria-hidden="true" />
+          </a>
         </p>
       </CardContent>
     </GlassCard>

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -77,6 +77,18 @@ export function WeatherCard({ weather, forecast, className }: WeatherCardProps) 
         {(forecast || (weather.forecast && weather.forecast.length > 0)) && (
           <WeatherForecastStrip forecast={forecast || (weather.forecast ?? [])} />
         )}
+
+        <p className="text-muted-foreground/70 text-[10px]">
+          {t('dataBy')}{' '}
+          <a
+            href="https://open-meteo.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary underline-offset-2 hover:underline"
+          >
+            Open-Meteo.com
+          </a>
+        </p>
       </CardContent>
     </GlassCard>
   );

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -78,7 +78,7 @@ export function WeatherCard({ weather, forecast, className }: WeatherCardProps) 
           <WeatherForecastStrip forecast={forecast || (weather.forecast ?? [])} />
         )}
 
-        <p className="text-muted-foreground/70 flex items-center gap-1 text-[10px]">
+        <p className="text-muted-foreground/70 -mx-6 flex items-center gap-1 text-[10px]">
           <Cloud className="h-3 w-3 shrink-0" aria-hidden="true" />
           <span>
             {t('dataBy')}{' '}

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -79,7 +79,7 @@ export function WeatherCard({ weather, forecast, className }: WeatherCardProps) 
         )}
 
         <p className="text-muted-foreground/70 flex items-center gap-1 text-[10px]">
-          <Cloud className="h-2.5 w-2.5 shrink-0" aria-hidden="true" />
+          <Cloud className="h-3 w-3 shrink-0" aria-hidden="true" />
           <span>
             {t('dataBy')}{' '}
             <a

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from 'next-intl';
-import { Wind, Umbrella, ExternalLink } from 'lucide-react';
+import { Wind, Umbrella, Cloud, ExternalLink } from 'lucide-react';
 import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { GlassCard } from '@/components/common/glass-card';
 import { cn } from '@/lib/utils';
@@ -78,17 +78,20 @@ export function WeatherCard({ weather, forecast, className }: WeatherCardProps) 
           <WeatherForecastStrip forecast={forecast || (weather.forecast ?? [])} />
         )}
 
-        <p className="text-muted-foreground/70 text-[10px]">
-          {t('dataBy')}{' '}
-          <a
-            href="https://open-meteo.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-primary inline-flex items-center gap-0.5 align-baseline underline-offset-2 hover:underline"
-          >
-            Open-Meteo.com
-            <ExternalLink className="h-2.5 w-2.5" aria-hidden="true" />
-          </a>
+        <p className="text-muted-foreground/70 flex items-center gap-1 text-[10px]">
+          <Cloud className="h-2.5 w-2.5 shrink-0" aria-hidden="true" />
+          <span>
+            {t('dataBy')}{' '}
+            <a
+              href="https://open-meteo.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-primary inline-flex items-center gap-0.5 underline-offset-2 hover:underline"
+            >
+              Open-Meteo.com
+              <ExternalLink className="h-2.5 w-2.5" aria-hidden="true" />
+            </a>
+          </span>
         </p>
       </CardContent>
     </GlassCard>

--- a/messages/de.json
+++ b/messages/de.json
@@ -273,7 +273,8 @@
       "thunderstorm": "Gewitter",
       "cloudy": "Bewölkt",
       "mist": "Nebel",
-      "feelsLike": "Gefühlt"
+      "feelsLike": "Gefühlt",
+      "dataBy": "Wetterdaten von"
     },
     "crowdLevel": "Auslastung",
     "crowdLevels": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -420,7 +420,8 @@
       "thunderstorm": "Thunderstorm",
       "cloudy": "Cloudy",
       "mist": "Mist",
-      "feelsLike": "Feels like"
+      "feelsLike": "Feels like",
+      "dataBy": "Weather data by"
     },
     "h1Suffix": "Live Wait Times",
     "stats": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -420,7 +420,8 @@
       "thunderstorm": "Tormenta",
       "cloudy": "Nublado",
       "mist": "Neblina",
-      "feelsLike": "Sensación"
+      "feelsLike": "Sensación",
+      "dataBy": "Datos meteorológicos de"
     },
     "h1Suffix": "Tiempos de espera en vivo",
     "stats": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -420,7 +420,8 @@
       "thunderstorm": "Orage",
       "cloudy": "Nuageux",
       "mist": "Brume",
-      "feelsLike": "Ressenti"
+      "feelsLike": "Ressenti",
+      "dataBy": "Données météo par"
     },
     "h1Suffix": "Temps d'attente en direct",
     "stats": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -420,7 +420,8 @@
       "thunderstorm": "Temporale",
       "cloudy": "Nuvoloso",
       "mist": "Foschia",
-      "feelsLike": "Percepita"
+      "feelsLike": "Percepita",
+      "dataBy": "Dati meteo da"
     },
     "h1Suffix": "Tempi di attesa in diretta",
     "stats": {

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -420,7 +420,8 @@
       "thunderstorm": "Onweer",
       "cloudy": "Bewolkt",
       "mist": "Nevel",
-      "feelsLike": "Voelt als"
+      "feelsLike": "Voelt als",
+      "dataBy": "Weergegevens van"
     },
     "h1Suffix": "Live wachttijden",
     "stats": {


### PR DESCRIPTION
## Hintergrund

Open-Meteo stellt seine Wetterdaten unter der **Creative Commons CC-BY 4.0** Lizenz bereit (siehe https://open-meteo.com/en/license). Diese Lizenz verpflichtet uns, die Datenquelle bei jeder Nutzung sichtbar zu kennzeichnen. Empfohlene Form von Open-Meteo: `Weather data by Open-Meteo.com`.

Bisher wurden die Open-Meteo Wetterdaten ohne Attribution angezeigt — das wird mit diesem PR behoben.

## Änderungen

**Attribution direkt am Datenpunkt** (`components/parks/weather-card.tsx`)
- Kleiner, dezenter Hinweis am Fuß der `WeatherCard`: `<locale>: Wetterdaten von Open-Meteo.com` mit Link auf https://open-meteo.com/
- Erscheint überall dort, wo `WeatherCard` gerendert wird (aktuell: Park-Detailseite)

**Datenquellen-Liste im Impressum** (`app/[locale]/impressum/page.tsx`)
- Open-Meteo.com als zusätzlichen Eintrag in der "Datenquellen" / "Data Sources" Liste (DE + EN), inkl. Hinweis auf CC-BY 4.0 Lizenz

**Übersetzungen** (`messages/{de,en,es,fr,it,nl}.json`)
- Neuer Key `parks.weather.dataBy` für die "Wetterdaten von"-Vorzeile in allen 6 Sprachen
- Der Markenname "Open-Meteo.com" bleibt sprachübergreifend identisch und wird vom Component gerendert

## Test plan

- [ ] Park-Detailseite öffnen → Attribution unter WeatherCard sichtbar, Link öffnet open-meteo.com
- [ ] Impressum in DE + EN öffnen → Open-Meteo.com erscheint in Datenquellen
- [ ] Sprachen durchschalten (de/en/es/fr/it/nl) → Vorzeile ist korrekt übersetzt
- [ ] UI-Showcase (`/ui`) → WeatherCard-Demos zeigen ebenfalls die Attribution


---
_Generated by [Claude Code](https://claude.ai/code/session_01HYsfa2JPibCE1QNa81smND)_