### PR TITLE
perf(links): hover-only prefetch by default (disable viewport prefetch globally)

### DIFF
--- a/i18n/hover-prefetch-link.tsx
+++ b/i18n/hover-prefetch-link.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState, type ComponentProps } from 'react';
+import { BaseLink } from './navigation-internal';
+
+type LinkProps = ComponentProps<typeof BaseLink>;
+
+/**
+ * App-wide Link with viewport prefetching turned off: the route is prefetched
+ * only after the user signals navigation intent (hover / keyboard focus /
+ * touch start), never just because the link scrolled into view. This keeps the
+ * snappy feel of prefetch on real intent while avoiding the flood of RSC
+ * prefetch requests that viewport prefetching triggers for long lists (e.g.
+ * the attraction cards on a park page).
+ *
+ * Pass `prefetch={true}` to opt a specific link back into Next.js' default
+ * viewport prefetch. Any other value (`false`, `null`, omitted) yields the
+ * hover-only behavior.
+ */
+export function Link({ prefetch, onMouseEnter, onFocus, onTouchStart, ...rest }: LinkProps) {
+  const [intent, setIntent] = useState(false);
+  const viewportPrefetch = prefetch === true;
+  // `undefined` lets Next.js apply its default (auto) prefetch; `false` disables it.
+  const effectivePrefetch = viewportPrefetch || intent ? undefined : false;
+
+  return (
+    <BaseLink
+      prefetch={effectivePrefetch}
+      onMouseEnter={(e) => {
+        setIntent(true);
+        onMouseEnter?.(e);
+      }}
+      onFocus={(e) => {
+        setIntent(true);
+        onFocus?.(e);
+      }}
+      onTouchStart={(e) => {
+        setIntent(true);
+        onTouchStart?.(e);
+      }}
+      {...rest}
+    />
+  );
+}

--- a/i18n/navigation-internal.ts
+++ b/i18n/navigation-internal.ts
@@ -1,0 +1,8 @@
+import { createNavigation } from 'next-intl/navigation';
+import { routing } from './routing';
+
+// Raw next-intl navigation primitives. The public `Link` is wrapped in
+// ./hover-prefetch-link to disable viewport prefetching; everything else is
+// re-exported unchanged from ./navigation.
+export const { Link: BaseLink, redirect, usePathname, useRouter, getPathname } =
+  createNavigation(routing);

--- a/i18n/navigation.ts
+++ b/i18n/navigation.ts
@@ -1,4 +1,2 @@
-import { createNavigation } from 'next-intl/navigation';
-import { routing } from './routing';
-
-export const { Link, redirect, usePathname, useRouter, getPathname } = createNavigation(routing);
+export { redirect, usePathname, useRouter, getPathname } from './navigation-internal';
+export { Link } from './hover-prefetch-link';


### PR DESCRIPTION
## Kontext

Untersuchung der Frage, warum die Requests auf Attraktionsseiten nach dem Deaktivieren des Prefetchings nicht zurückgingen.

**Befund des Audits:** Das Prefetch-Handling in den Komponenten war bereits korrekt — alle `<Link>`-Elemente, die auf Attraktionsseiten zeigen (`attraction-card`, `park-stats-attractions-card`, `live-wait-ticker`, `nearby-parks-card`), hatten schon `prefetch={false}`. next-intls `Link` reicht das Prop sauber durch; es gab keinen Wrapper, der es verschluckt. In Next.js 16 deaktiviert `prefetch={false}` Prefetching vollständig (Viewport **und** Hover).

Die verbleibenden Attraktions-Invocations stammen daher sehr wahrscheinlich **nicht** aus Prefetch, sondern aus Crawler-Traffic (robots erlaubt alle Bots; Crawler folgen den gerenderten `<a href>`-Links auf den Park-Seiten) und ISR-Revalidation (`revalidate = 300`).

## Änderung

Auf Wunsch: globaler Mittelweg — **kein Viewport-Prefetch, aber Prefetch bei Hover/Fokus/Touch**. Next.js bietet das nicht nativ (`prefetch={false}` killt auch Hover), daher ein Wrapper im zentralen Navigations-Barrel `@/i18n/navigation`, das alle 29 importierenden Dateien automatisch erfasst:

- `i18n/navigation-internal.ts` — rohe next-intl-Primitives (`BaseLink`, `redirect`, `usePathname`, `useRouter`, `getPathname`).
- `i18n/hover-prefetch-link.tsx` — Client-Wrapper: rendert initial `prefetch={false}` und aktiviert Prefetch erst bei `onMouseEnter` / `onFocus` / `onTouchStart`.
- `i18n/navigation.ts` — re-exportiert nur noch.

Verhalten:
- Standard (kein Prop oder `prefetch={false}`): **Hover-only**.
- `prefetch={true}`: opt-in zu Next.js' Default-Viewport-Prefetch (z. B. die bestehenden `prefetch={park.status === 'OPERATING'}`-Links bleiben für offene Parks erhalten).

Keine Call-Site-Änderungen nötig; die Prop-Typen bleiben identisch (`ComponentProps<typeof BaseLink>`).

## Hinweis / Tradeoff

Gegenüber dem aktuellen Zustand (komplett aus) erzeugt Hover-Prefetch wieder **etwas** Traffic, aber nur bei tatsächlicher Nutzerabsicht (gehoverter Link), nicht für jeden sichtbaren Link. Crawler-/ISR-getriebene Invocations werden dadurch **nicht** reduziert — dafür wären höhere `revalidate`-Werte bzw. Bot-Throttling der Hebel.

## Test plan

- [ ] Build/Lint lokal (konnte in der Remote-Umgebung wegen Supply-Chain-Policy beim `pnpm install` nicht laufen — `es-toolkit@1.47.0` zu jung, vorbestehendes Lockfile-Thema).
- [ ] Im Browser (Prod-Build): Scrollen über Attraktionsliste löst **keine** `?_rsc=`-Prefetch-Requests aus.
- [ ] Hover über einen Attraktions-Link löst genau **einen** Prefetch-Request aus.
- [ ] Navigation fühlt sich nach Hover weiterhin schnell an.
- [ ] `prefetch={true}`-Links (Header „nearby park", Hero-Park-Link) prefetchen weiterhin im Viewport, wenn der Park offen ist.

https://claude.ai/code/session_01MBi4qqwA285fKCNMwYWkjr

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBi4qqwA285fKCNMwYWkjr)_