### PR TITLE
feat(admin): popular parks + multi-page dashboard redesign

### DIFF
--- a/app/admin/_components/admin-shell.tsx
+++ b/app/admin/_components/admin-shell.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useCallback, useState, useSyncExternalStore, type FormEvent } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import {
+  Activity,
+  AlertTriangle,
+  Brain,
+  KeyRound,
+  LayoutDashboard,
+  ListChecks,
+  Loader2,
+  LogOut,
+  MapPin,
+  RefreshCw,
+  Server,
+  ShieldCheck,
+  Wrench,
+  type LucideIcon,
+} from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { AdminProvider, SESSION_KEY, useAdmin } from '../_lib/admin-context';
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+const NAV: NavItem[] = [
+  { href: '/admin', label: 'Overview', icon: LayoutDashboard },
+  { href: '/admin/system', label: 'System', icon: Server },
+  { href: '/admin/queues', label: 'Queues', icon: ListChecks },
+  { href: '/admin/ml', label: 'ML Models', icon: Brain },
+  { href: '/admin/analytics', label: 'Analytics', icon: Activity },
+  { href: '/admin/parks', label: 'Parks', icon: MapPin },
+  { href: '/admin/actions', label: 'Maintenance', icon: Wrench },
+];
+
+function navTitle(pathname: string): string {
+  const match = [...NAV].sort((a, b) => b.href.length - a.href.length).find((n) =>
+    n.href === '/admin' ? pathname === '/admin' : pathname.startsWith(n.href)
+  );
+  return match?.label ?? 'Admin';
+}
+
+// ─── login ────────────────────────────────────────────────────────────────────
+
+function LoginScreen({
+  onLogin,
+  error,
+  loading,
+}: {
+  onLogin: (pass: string) => void;
+  error: string | null;
+  loading: boolean;
+}) {
+  const [value, setValue] = useState('');
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (value.trim()) onLogin(value.trim());
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="space-y-2 text-center">
+          <div className="bg-primary/15 border-primary/20 mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border">
+            <ShieldCheck className="text-primary h-7 w-7" />
+          </div>
+          <div>
+            <p className="text-muted-foreground text-sm font-medium tracking-widest uppercase">
+              park.fan
+            </p>
+            <h1 className="text-2xl font-bold">Admin Dashboard</h1>
+          </div>
+        </div>
+
+        <Card className="border-border/60">
+          <CardContent className="space-y-4 pt-6 pb-6">
+            <form onSubmit={handleSubmit} className="space-y-3">
+              <div className="relative">
+                <KeyRound className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+                <Input
+                  type="password"
+                  placeholder="Admin password"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                  className="pl-9"
+                  autoFocus
+                  autoComplete="current-password"
+                />
+              </div>
+              <Button type="submit" className="w-full" disabled={loading || !value.trim()}>
+                {loading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Loading…
+                  </>
+                ) : (
+                  'Sign In'
+                )}
+              </Button>
+            </form>
+            {error && (
+              <div className="bg-destructive/10 border-destructive/20 text-destructive flex items-center gap-2 rounded-lg border px-3 py-2 text-sm">
+                <AlertTriangle className="h-4 w-4 shrink-0" />
+                {error}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+// ─── sidebar ──────────────────────────────────────────────────────────────────
+
+function Sidebar() {
+  const pathname = usePathname();
+  return (
+    <aside className="border-border/40 bg-card/30 sticky top-0 hidden h-screen w-56 shrink-0 flex-col border-r md:flex">
+      <div className="flex items-center gap-2.5 px-5 py-4">
+        <div className="bg-primary/15 border-primary/20 flex h-8 w-8 items-center justify-center rounded-lg border">
+          <ShieldCheck className="text-primary h-4 w-4" />
+        </div>
+        <div className="leading-tight">
+          <p className="text-muted-foreground text-[10px] font-medium tracking-widest uppercase">
+            park.fan
+          </p>
+          <p className="text-sm font-semibold">Admin</p>
+        </div>
+      </div>
+      <nav className="flex-1 space-y-0.5 px-3 py-2">
+        {NAV.map(({ href, label, icon: Icon }) => {
+          const active = href === '/admin' ? pathname === '/admin' : pathname.startsWith(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={cn(
+                'flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                active
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-foreground/70 hover:bg-card hover:text-foreground'
+              )}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}
+
+// ─── topbar ───────────────────────────────────────────────────────────────────
+
+function Topbar() {
+  const pathname = usePathname();
+  const { refreshing, lastUpdated, triggerRefresh, logout } = useAdmin();
+  return (
+    <header className="border-border/40 bg-background/80 sticky top-0 z-10 flex items-center justify-between gap-3 border-b px-6 py-3 backdrop-blur-md">
+      <h1 className="text-lg font-semibold">{navTitle(pathname)}</h1>
+      <div className="flex items-center gap-3">
+        <span className="text-muted-foreground hidden items-center gap-2 text-xs sm:flex">
+          {refreshing && (
+            <span className="bg-primary inline-block h-1.5 w-1.5 animate-pulse rounded-full" />
+          )}
+          {lastUpdated && (
+            <span className="tabular-nums">Updated {lastUpdated.toLocaleTimeString('en-GB')}</span>
+          )}
+        </span>
+        <button
+          onClick={triggerRefresh}
+          className="border-border/60 hover:border-primary/40 hover:text-primary text-foreground/70 flex h-8 w-8 items-center justify-center rounded-lg border transition-colors"
+          title="Refresh"
+        >
+          <RefreshCw className={cn('h-4 w-4', refreshing && 'animate-spin')} />
+        </button>
+        <button
+          onClick={logout}
+          className="border-border/60 hover:border-red-500/40 hover:text-red-400 text-foreground/70 flex h-8 items-center gap-1.5 rounded-lg border px-3 text-sm transition-colors"
+          title="Sign out"
+        >
+          <LogOut className="h-3.5 w-3.5" /> Logout
+        </button>
+      </div>
+    </header>
+  );
+}
+
+// ─── shell ────────────────────────────────────────────────────────────────────
+
+const emptySubscribe = () => () => {};
+function useHydrated() {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
+}
+
+export function AdminShell({ children }: { children: React.ReactNode }) {
+  const hydrated = useHydrated();
+  const [savedPass, setSavedPass] = useState<string | null>(() =>
+    typeof window !== 'undefined' ? sessionStorage.getItem(SESSION_KEY) : null
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleLogin = useCallback(async (pass: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/system-health?pass=${encodeURIComponent(pass)}`);
+      if (res.status === 401 || res.status === 403) {
+        setError('Wrong password.');
+        return;
+      }
+      if (!res.ok) {
+        setError(`API error: ${res.status}`);
+        return;
+      }
+      sessionStorage.setItem(SESSION_KEY, pass);
+      setSavedPass(pass);
+    } catch {
+      setError('Connection error.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleLogout = useCallback(() => {
+    sessionStorage.removeItem(SESSION_KEY);
+    setSavedPass(null);
+  }, []);
+
+  if (!hydrated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loader2 className="text-primary h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (!savedPass) {
+    return <LoginScreen onLogin={handleLogin} error={error} loading={loading} />;
+  }
+
+  return (
+    <AdminProvider pass={savedPass} onLogout={handleLogout}>
+      <div className="flex min-h-screen">
+        <Sidebar />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <Topbar />
+          <main className="mx-auto w-full max-w-6xl flex-1 space-y-8 px-6 py-8">{children}</main>
+        </div>
+      </div>
+    </AdminProvider>
+  );
+}

--- a/app/admin/_components/admin-shell.tsx
+++ b/app/admin/_components/admin-shell.tsx
@@ -31,20 +31,43 @@ interface NavItem {
   icon: LucideIcon;
 }
 
-const NAV: NavItem[] = [
-  { href: '/admin', label: 'Overview', icon: LayoutDashboard },
-  { href: '/admin/system', label: 'System', icon: Server },
-  { href: '/admin/queues', label: 'Queues', icon: ListChecks },
-  { href: '/admin/ml', label: 'ML Models', icon: Brain },
-  { href: '/admin/analytics', label: 'Analytics', icon: Activity },
-  { href: '/admin/parks', label: 'Parks', icon: MapPin },
-  { href: '/admin/actions', label: 'Maintenance', icon: Wrench },
+interface NavGroup {
+  label?: string;
+  items: NavItem[];
+}
+
+const NAV_GROUPS: NavGroup[] = [
+  {
+    items: [{ href: '/admin', label: 'Overview', icon: LayoutDashboard }],
+  },
+  {
+    label: 'Monitoring',
+    items: [
+      { href: '/admin/system', label: 'System', icon: Server },
+      { href: '/admin/queues', label: 'Queues', icon: ListChecks },
+      { href: '/admin/analytics', label: 'Analytics', icon: Activity },
+    ],
+  },
+  {
+    label: 'Machine Learning',
+    items: [{ href: '/admin/ml', label: 'ML Models', icon: Brain }],
+  },
+  {
+    label: 'Management',
+    items: [{ href: '/admin/parks', label: 'Parks', icon: MapPin }],
+  },
+  {
+    label: 'Operations',
+    items: [{ href: '/admin/actions', label: 'Maintenance', icon: Wrench }],
+  },
 ];
 
+const NAV_ITEMS: NavItem[] = NAV_GROUPS.flatMap((g) => g.items);
+
 function navTitle(pathname: string): string {
-  const match = [...NAV].sort((a, b) => b.href.length - a.href.length).find((n) =>
-    n.href === '/admin' ? pathname === '/admin' : pathname.startsWith(n.href)
-  );
+  const match = [...NAV_ITEMS]
+    .sort((a, b) => b.href.length - a.href.length)
+    .find((n) => (n.href === '/admin' ? pathname === '/admin' : pathname.startsWith(n.href)));
   return match?.label ?? 'Admin';
 }
 
@@ -137,25 +160,34 @@ function Sidebar() {
           <p className="text-sm font-semibold">Admin</p>
         </div>
       </div>
-      <nav className="flex-1 space-y-0.5 px-3 py-2">
-        {NAV.map(({ href, label, icon: Icon }) => {
-          const active = href === '/admin' ? pathname === '/admin' : pathname.startsWith(href);
-          return (
-            <Link
-              key={href}
-              href={href}
-              className={cn(
-                'flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                active
-                  ? 'bg-primary/10 text-primary'
-                  : 'text-foreground/70 hover:bg-card hover:text-foreground'
-              )}
-            >
-              <Icon className="h-4 w-4 shrink-0" />
-              {label}
-            </Link>
-          );
-        })}
+      <nav className="flex-1 space-y-4 overflow-y-auto px-3 py-2">
+        {NAV_GROUPS.map((group, i) => (
+          <div key={group.label ?? i} className="space-y-0.5">
+            {group.label && (
+              <p className="text-muted-foreground/70 px-3 pt-1 pb-1 text-[10px] font-semibold tracking-widest uppercase">
+                {group.label}
+              </p>
+            )}
+            {group.items.map(({ href, label, icon: Icon }) => {
+              const active = href === '/admin' ? pathname === '/admin' : pathname.startsWith(href);
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  className={cn(
+                    'flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                    active
+                      ? 'bg-primary/10 text-primary'
+                      : 'text-foreground/70 hover:bg-card hover:text-foreground'
+                  )}
+                >
+                  <Icon className="h-4 w-4 shrink-0" />
+                  {label}
+                </Link>
+              );
+            })}
+          </div>
+        ))}
       </nav>
     </aside>
   );

--- a/app/admin/_lib/admin-context.tsx
+++ b/app/admin/_lib/admin-context.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export const SESSION_KEY = 'parkfan_admin_pass';
+const REFRESH_INTERVAL_MS = 15_000;
+
+interface AdminContextValue {
+  pass: string;
+  refreshTick: number;
+  refreshing: boolean;
+  lastUpdated: Date | null;
+  triggerRefresh: () => void;
+  logout: () => void;
+  beginFetch: () => void;
+  endFetch: () => void;
+}
+
+const AdminContext = createContext<AdminContextValue | null>(null);
+
+export function useAdmin(): AdminContextValue {
+  const ctx = useContext(AdminContext);
+  if (!ctx) throw new Error('useAdmin must be used within AdminProvider');
+  return ctx;
+}
+
+export function AdminProvider({
+  pass,
+  onLogout,
+  children,
+}: {
+  pass: string;
+  onLogout: () => void;
+  children: ReactNode;
+}) {
+  const [refreshTick, setRefreshTick] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const inFlight = useRef(0);
+
+  const triggerRefresh = useCallback(() => setRefreshTick((t) => t + 1), []);
+
+  const beginFetch = useCallback(() => {
+    inFlight.current += 1;
+    setRefreshing(true);
+  }, []);
+
+  const endFetch = useCallback(() => {
+    inFlight.current = Math.max(0, inFlight.current - 1);
+    if (inFlight.current === 0) {
+      setRefreshing(false);
+      setLastUpdated(new Date());
+    }
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => setRefreshTick((t) => t + 1), REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <AdminContext.Provider
+      value={{
+        pass,
+        refreshTick,
+        refreshing,
+        lastUpdated,
+        triggerRefresh,
+        logout: onLogout,
+        beginFetch,
+        endFetch,
+      }}
+    >
+      {children}
+    </AdminContext.Provider>
+  );
+}
+
+interface FetchState<T> {
+  data: T | null;
+  error: string | null;
+  loading: boolean;
+}
+
+/**
+ * Fetches an admin endpoint on mount and on every refresh tick (auto-refresh
+ * + manual). Pass-protected endpoints get the `pass` query param appended.
+ * Refetches whenever `endpoint` changes (e.g. pagination/search state).
+ */
+export function useAdminFetch<T>(endpoint: string | null, needsPass = false): FetchState<T> {
+  const { pass, refreshTick, beginFetch, endFetch } = useAdmin();
+  const [state, setState] = useState<FetchState<T>>({
+    data: null,
+    error: null,
+    loading: endpoint != null,
+  });
+
+  useEffect(() => {
+    if (!endpoint) return;
+    let cancelled = false;
+    const url = needsPass
+      ? `${endpoint}${endpoint.includes('?') ? '&' : '?'}pass=${encodeURIComponent(pass)}`
+      : endpoint;
+
+    beginFetch();
+    fetch(url, { cache: 'no-store' })
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = (await res.json()) as T;
+        if (!cancelled) setState({ data: json, error: null, loading: false });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setState((prev) => ({
+            ...prev,
+            error: err instanceof Error ? err.message : 'Request failed',
+            loading: false,
+          }));
+        }
+      })
+      .finally(() => {
+        endFetch();
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [endpoint, needsPass, pass, refreshTick, beginFetch, endFetch]);
+
+  return state;
+}

--- a/app/admin/_lib/ui.tsx
+++ b/app/admin/_lib/ui.tsx
@@ -148,10 +148,13 @@ export function CrowdBadge({ level }: { level: string }) {
 }
 
 export function StatusBadge({ status }: { status: string }) {
-  const ok = ['healthy', 'connected', 'operational', 'active', 'good'].includes(
-    status?.toLowerCase()
-  );
-  const warn = ['warning', 'degraded'].includes(status?.toLowerCase());
+  const lower = status?.toLowerCase() ?? '';
+  const warn = ['warning', 'degraded', 'pending'].some((k) => lower.includes(k));
+  const ok =
+    !warn &&
+    ['healthy', 'connected', 'operational', 'active', 'good', 'online', 'ok'].some((k) =>
+      lower.includes(k)
+    );
   const style = ok
     ? 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20'
     : warn

--- a/app/admin/_lib/ui.tsx
+++ b/app/admin/_lib/ui.tsx
@@ -1,0 +1,192 @@
+import { AlertTriangle, Loader2, type LucideIcon } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import type { HostDisk } from '@/lib/api/admin';
+
+// ─── formatting ───────────────────────────────────────────────────────────────
+
+export function formatUptime(hours: number) {
+  const h = Math.floor(hours);
+  const m = Math.floor((hours - h) * 60);
+  if (h >= 24) return `${Math.floor(h / 24)}d ${h % 24}h`;
+  return `${h}h ${m}m`;
+}
+
+export function formatCompact(n: number) {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+export function formatAge(age: { days: number; hours: number; minutes: number }) {
+  if (age.days > 0) return `${age.days}d ${age.hours}h`;
+  if (age.hours > 0) return `${age.hours}h ${age.minutes}m`;
+  return `${age.minutes}m`;
+}
+
+export function isDisk(d: HostDisk | { error: string }): d is HostDisk {
+  return 'usedPct' in d;
+}
+
+export function maeColor(mae: number) {
+  if (mae < 10) return 'text-emerald-400';
+  if (mae < 15) return 'text-amber-400';
+  return 'text-red-400';
+}
+
+// ─── primitives ─────────────────────────────────────────────────────────────
+
+export function statusDot(ok: boolean) {
+  return (
+    <span className={`inline-block h-2 w-2 rounded-full ${ok ? 'bg-emerald-500' : 'bg-red-500'}`} />
+  );
+}
+
+export function Section({
+  icon: Icon,
+  title,
+  action,
+  children,
+}: {
+  icon: LucideIcon;
+  title: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Icon className="text-primary h-4 w-4" />
+        <h2 className="text-foreground/70 text-sm font-semibold tracking-wide uppercase">
+          {title}
+        </h2>
+        {action && <div className="ml-auto">{action}</div>}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function StatCard({
+  icon: Icon,
+  label,
+  value,
+  sub,
+  valueClass,
+}: {
+  icon?: LucideIcon;
+  label: string;
+  value: React.ReactNode;
+  sub?: React.ReactNode;
+  valueClass?: string;
+}) {
+  return (
+    <Card className="border-border/60">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-muted-foreground flex items-center gap-2 text-xs font-medium tracking-wide uppercase">
+          {Icon && <Icon className="h-3.5 w-3.5" />} {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        <span className={cn('text-3xl font-bold tabular-nums', valueClass)}>{value}</span>
+        {sub && <p className="text-muted-foreground text-xs">{sub}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function KeyVal({
+  label,
+  value,
+  valueClass,
+}: {
+  label: string;
+  value: React.ReactNode;
+  valueClass?: string;
+}) {
+  return (
+    <div>
+      <p className="text-muted-foreground text-xs">{label}</p>
+      <p className={cn('font-semibold tabular-nums', valueClass)}>{value}</p>
+    </div>
+  );
+}
+
+// ─── badges ───────────────────────────────────────────────────────────────────
+
+const SEVERITY_STYLES: Record<string, string> = {
+  low: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+  medium: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+  high: 'bg-orange-500/15 text-orange-400 border-orange-500/20',
+  critical: 'bg-red-500/15 text-red-400 border-red-500/20',
+};
+
+export function SeverityBadge({ severity }: { severity: string }) {
+  const style = SEVERITY_STYLES[severity.toLowerCase()] ?? 'bg-zinc-500/15 text-zinc-400 border-zinc-500/20';
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${style}`}>
+      {severity}
+    </span>
+  );
+}
+
+const CROWD_STYLES: Record<string, string> = {
+  very_low: 'bg-emerald-500/15 text-emerald-400',
+  low: 'bg-emerald-500/15 text-emerald-400',
+  moderate: 'bg-amber-500/15 text-amber-400',
+  high: 'bg-orange-500/15 text-orange-400',
+  very_high: 'bg-red-500/15 text-red-400',
+};
+
+export function CrowdBadge({ level }: { level: string }) {
+  const style = CROWD_STYLES[level?.toLowerCase()] ?? 'bg-zinc-500/15 text-zinc-400';
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${style}`}>
+      {level?.replace(/_/g, ' ') ?? '—'}
+    </span>
+  );
+}
+
+export function StatusBadge({ status }: { status: string }) {
+  const ok = ['healthy', 'connected', 'operational', 'active', 'good'].includes(
+    status?.toLowerCase()
+  );
+  const warn = ['warning', 'degraded'].includes(status?.toLowerCase());
+  const style = ok
+    ? 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20'
+    : warn
+      ? 'bg-amber-500/15 text-amber-400 border-amber-500/20'
+      : 'bg-red-500/15 text-red-400 border-red-500/20';
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium ${style}`}>
+      {statusDot(ok)} {status}
+    </span>
+  );
+}
+
+// ─── states ─────────────────────────────────────────────────────────────────
+
+export function LoadingPanel({ label = 'Loading…' }: { label?: string }) {
+  return (
+    <div className="text-muted-foreground flex items-center justify-center gap-2 rounded-lg border border-border/40 bg-card/40 py-12 text-sm">
+      <Loader2 className="h-4 w-4 animate-spin" /> {label}
+    </div>
+  );
+}
+
+export function ErrorPanel({ message }: { message: string }) {
+  return (
+    <div className="bg-destructive/10 border-destructive/20 text-destructive flex items-center gap-2 rounded-lg border px-3 py-2 text-sm">
+      <AlertTriangle className="h-4 w-4 shrink-0" />
+      {message}
+    </div>
+  );
+}
+
+export function EmptyPanel({ label }: { label: string }) {
+  return (
+    <div className="text-muted-foreground rounded-lg border border-border/40 bg-card/40 py-8 text-center text-sm">
+      {label}
+    </div>
+  );
+}

--- a/app/admin/actions/page.tsx
+++ b/app/admin/actions/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  AlertTriangle,
+  CalendarCheck,
+  CalendarClock,
+  CheckCircle2,
+  Loader2,
+  Play,
+  RotateCcw,
+  Sigma,
+  Snowflake,
+  Sparkles,
+  Trash2,
+  Wrench,
+  type LucideIcon,
+} from 'lucide-react';
+import { useAdmin } from '../_lib/admin-context';
+import { Section } from '../_lib/ui';
+
+interface ActionDef {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  path: string;
+  description: string;
+}
+
+const ACTIONS: ActionDef[] = [
+  { key: 'flush', label: 'Flush Cache', icon: Trash2, path: 'flush-cache', description: 'Clear the Redis response cache.' },
+  { key: 'train', label: 'Train ML', icon: Play, path: 'train-ml-model', description: 'Kick off a CatBoost training run.' },
+  { key: 'sync', label: 'Sync Parks', icon: RotateCcw, path: 'sync-parks', description: 'Re-sync parks from upstream providers.' },
+  { key: 'enrich', label: 'Enrich Parks', icon: Sparkles, path: 'enrich-parks', description: 'Backfill park metadata and geocoding.' },
+  { key: 'validate', label: 'Validate & Repair', icon: Wrench, path: 'validate-and-repair-parks', description: 'Validate and repair park records.' },
+  { key: 'gaps', label: 'Fill Schedule Gaps', icon: CalendarClock, path: 'fill-schedule-gaps', description: 'Fill missing operating-schedule entries.' },
+  { key: 'holidays', label: 'Sync Holidays', icon: CalendarCheck, path: 'sync-holidays', description: 'Refresh public-holiday data.' },
+  { key: 'seasonal', label: 'Detect Seasonal', icon: Snowflake, path: 'detect-seasonal', description: 'Re-run seasonal pattern detection.' },
+  { key: 'accuracy', label: 'Aggregate Accuracy', icon: Sigma, path: 'aggregate-accuracy-stats', description: 'Recompute ML accuracy aggregates.' },
+];
+
+export default function ActionsPage() {
+  const { pass } = useAdmin();
+  const [loading, setLoading] = useState<Record<string, boolean>>({});
+  const [result, setResult] = useState<Record<string, 'ok' | 'err'>>({});
+
+  async function trigger(action: ActionDef) {
+    setLoading((p) => ({ ...p, [action.key]: true }));
+    setResult((p) => {
+      const next = { ...p };
+      delete next[action.key];
+      return next;
+    });
+    try {
+      const res = await fetch(`/api/admin/${action.path}?pass=${encodeURIComponent(pass)}`, {
+        method: 'POST',
+      });
+      setResult((p) => ({ ...p, [action.key]: res.ok ? 'ok' : 'err' }));
+    } catch {
+      setResult((p) => ({ ...p, [action.key]: 'err' }));
+    } finally {
+      setLoading((p) => ({ ...p, [action.key]: false }));
+    }
+  }
+
+  return (
+    <Section icon={Wrench} title="Maintenance actions">
+      <p className="text-muted-foreground text-sm">
+        Non-destructive jobs run asynchronously on the backend. Triggering only queues the job.
+      </p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {ACTIONS.map((action) => {
+          const Icon = action.icon;
+          const state = result[action.key];
+          return (
+            <button
+              key={action.key}
+              onClick={() => trigger(action)}
+              disabled={loading[action.key]}
+              className={`flex flex-col items-start gap-1 rounded-lg border p-4 text-left transition-all ${
+                state === 'ok'
+                  ? 'border-emerald-500/40 bg-emerald-500/10'
+                  : state === 'err'
+                    ? 'border-red-500/40 bg-red-500/10'
+                    : 'border-border/60 bg-card hover:border-primary/40 hover:bg-primary/5'
+              } disabled:cursor-not-allowed disabled:opacity-60`}
+            >
+              <span className="flex items-center gap-2 font-medium">
+                {loading[action.key] ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : state === 'ok' ? (
+                  <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+                ) : state === 'err' ? (
+                  <AlertTriangle className="h-4 w-4 text-red-400" />
+                ) : (
+                  <Icon className="text-primary h-4 w-4" />
+                )}
+                {action.label}
+              </span>
+              <span className="text-muted-foreground text-xs">{action.description}</span>
+            </button>
+          );
+        })}
+      </div>
+    </Section>
+  );
+}

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import Link from 'next/link';
+import { Activity, Globe, Radio } from 'lucide-react';
+import { useAdminFetch } from '../_lib/admin-context';
+import { CrowdBadge, ErrorPanel, LoadingPanel, Section, StatCard } from '../_lib/ui';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { AnalyticsGeoLive, AnalyticsRealtime, AnalyticsTicker } from '@/lib/api/admin-stats';
+
+const TREND_ICON: Record<string, string> = { rising: '▲', falling: '▼', stable: '·' };
+const TREND_COLOR: Record<string, string> = {
+  rising: 'text-red-400',
+  falling: 'text-emerald-400',
+  stable: 'text-muted-foreground',
+};
+
+export default function AnalyticsPage() {
+  const realtime = useAdminFetch<AnalyticsRealtime>('/api/analytics/realtime');
+  const ticker = useAdminFetch<AnalyticsTicker>('/api/analytics/ticker');
+  const geo = useAdminFetch<AnalyticsGeoLive>('/api/analytics/geo-live');
+
+  if (realtime.error) return <ErrorPanel message={`Realtime: ${realtime.error}`} />;
+  if (!realtime.data) return <LoadingPanel label="Loading analytics…" />;
+
+  const c = realtime.data.counts;
+
+  return (
+    <>
+      <Section icon={Activity} title="Realtime counts">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+          <StatCard label="Open parks" value={c.openParks} sub={`of ${c.parks}`} />
+          <StatCard label="Open rides" value={c.openAttractions} sub={`of ${c.attractions}`} />
+          <StatCard label="Shows" value={c.shows} />
+          <StatCard label="Restaurants" value={c.restaurants} />
+          <StatCard label="Total wait" value={`${c.totalWaitTime.toLocaleString('en-GB')}'`} />
+          <StatCard label="Queue records" value={c.queueDataRecords.toLocaleString('en-GB')} />
+        </div>
+      </Section>
+
+      <Section icon={Globe} title="Geographic activity">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {(geo.data?.continents ?? []).map((cont) => (
+            <Card key={cont.slug} className="border-border/60">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center justify-between text-sm capitalize">
+                  {cont.slug.replace(/-/g, ' ')}
+                  <span className="text-primary font-mono tabular-nums">{cont.openParkCount}</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-1">
+                {cont.countries
+                  .slice()
+                  .sort((a, b) => b.openParkCount - a.openParkCount)
+                  .slice(0, 6)
+                  .map((country) => (
+                    <div
+                      key={country.slug}
+                      className="flex items-center justify-between text-xs"
+                    >
+                      <span className="text-muted-foreground capitalize">
+                        {country.slug.replace(/-/g, ' ')}
+                      </span>
+                      <span className="font-mono tabular-nums">{country.openParkCount}</span>
+                    </div>
+                  ))}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <Section icon={Radio} title="Live ticker">
+        <Card className="border-border/60">
+          <CardContent className="divide-border/40 divide-y pt-2">
+            {(ticker.data?.items ?? []).slice(0, 25).map((item, i) => (
+              <Link
+                key={`${item.attractionSlug}-${i}`}
+                href={item.url}
+                className="hover:bg-card/60 -mx-2 flex items-center gap-3 px-2 py-1.5 text-sm"
+              >
+                <span className={`w-4 shrink-0 text-center ${TREND_COLOR[item.trend] ?? ''}`}>
+                  {TREND_ICON[item.trend] ?? '·'}
+                </span>
+                <span className="min-w-0 flex-1 truncate">{item.attractionName}</span>
+                <span className="text-muted-foreground hidden truncate text-xs sm:block sm:w-40">
+                  {item.parkName}
+                </span>
+                <span className="w-12 shrink-0 text-right font-mono tabular-nums">
+                  {item.waitTime}&apos;
+                </span>
+                <span className="hidden shrink-0 sm:block">
+                  <CrowdBadge level={item.crowdLevel} />
+                </span>
+              </Link>
+            ))}
+          </CardContent>
+        </Card>
+        {ticker.data && (
+          <p className="text-muted-foreground text-right text-xs">
+            Generated {new Date(ticker.data.generatedAt).toLocaleTimeString('en-GB')}
+          </p>
+        )}
+      </Section>
+    </>
+  );
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import '../globals.css';
+import { AdminShell } from './_components/admin-shell';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -25,7 +26,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
       <body
         className={`${geistSans.variable} ${geistMono.variable} bg-background text-foreground min-h-screen font-sans antialiased`}
       >
-        {children}
+        <AdminShell>{children}</AdminShell>
       </body>
     </html>
   );

--- a/app/admin/ml/page.tsx
+++ b/app/admin/ml/page.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  AlertTriangle,
+  Bell,
+  Brain,
+  GitCompare,
+  Play,
+  Sparkles,
+  TrendingDown,
+  TrendingUp,
+} from 'lucide-react';
+import { useAdminFetch } from '../_lib/admin-context';
+import { TrainingStatusBadge, type TrainingState } from '@/components/common/training-status-badge';
+import type { SystemHealthResponse } from '@/lib/api/admin';
+import {
+  EmptyPanel,
+  ErrorPanel,
+  KeyVal,
+  LoadingPanel,
+  Section,
+  SeverityBadge,
+  StatCard,
+  StatusBadge,
+  formatAge,
+  maeColor,
+} from '../_lib/ui';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type {
+  MlAlert,
+  MlAnomalyStats,
+  MlDashboard,
+  MlMetrics,
+  MlPerformer,
+} from '@/lib/api/admin-stats';
+
+const TYPICAL_TRAINING_SECONDS = 850;
+
+function TrainingProgress({ startedAt }: { startedAt: string }) {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    const tick = () => setElapsed(Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000));
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [startedAt]);
+
+  const pct = Math.min(Math.round((elapsed / TYPICAL_TRAINING_SECONDS) * 100), 99);
+  const m = Math.floor(elapsed / 60);
+  const s = elapsed % 60;
+  const remaining = Math.max(TYPICAL_TRAINING_SECONDS - elapsed, 0);
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between text-xs">
+        <span className="font-medium text-blue-400">
+          Elapsed {m}m {s}s
+        </span>
+        {remaining > 0 && (
+          <span className="text-muted-foreground">
+            ~{Math.floor(remaining / 60)}m {remaining % 60}s left
+          </span>
+        )}
+      </div>
+      <div className="bg-secondary h-2 w-full overflow-hidden rounded-full">
+        <div
+          className="h-full rounded-full bg-blue-500 transition-all duration-1000"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function MetricsRow({ label, m }: { label: string; m: MlMetrics }) {
+  return (
+    <div className="grid grid-cols-5 gap-2 border-b border-border/40 py-2 text-sm last:border-0">
+      <span className="text-muted-foreground">{label}</span>
+      <span className={`text-right font-mono tabular-nums ${maeColor(m.mae)}`}>{m.mae.toFixed(2)}</span>
+      <span className="text-right font-mono tabular-nums">{m.rmse.toFixed(2)}</span>
+      <span className="text-right font-mono tabular-nums">{m.mape.toFixed(1)}%</span>
+      <span className="text-right font-mono tabular-nums">{m.r2Score.toFixed(3)}</span>
+    </div>
+  );
+}
+
+function PerformerList({
+  title,
+  icon: Icon,
+  performers,
+}: {
+  title: string;
+  icon: typeof TrendingUp;
+  performers: MlPerformer[];
+}) {
+  return (
+    <Card className="border-border/60">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-muted-foreground flex items-center gap-2 text-xs font-medium tracking-wide uppercase">
+          <Icon className="h-3.5 w-3.5" /> {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1.5">
+        {performers.map((p) => (
+          <div key={p.attractionId} className="flex items-center justify-between gap-2 text-sm">
+            <div className="min-w-0">
+              <p className="truncate">{p.attractionName}</p>
+              <p className="text-muted-foreground truncate text-xs">{p.parkName}</p>
+            </div>
+            <span className={`shrink-0 font-mono tabular-nums ${maeColor(p.mae)}`}>
+              {p.mae.toFixed(1)} MAE
+            </span>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function MlPage() {
+  const dash = useAdminFetch<MlDashboard>('/api/ml/dashboard');
+  const alerts = useAdminFetch<MlAlert[]>('/api/ml/monitoring/alerts');
+  const anomalies = useAdminFetch<MlAnomalyStats>('/api/ml/monitoring/anomalies/stats');
+  const health = useAdminFetch<SystemHealthResponse>('/api/admin/system-health', true);
+
+  if (dash.error) return <ErrorPanel message={`ML dashboard: ${dash.error}`} />;
+  if (!dash.data) return <LoadingPanel label="Loading ML metrics…" />;
+
+  const d = dash.data;
+  const { model, performance: perf, insights } = d;
+  const activeAlerts = (alerts.data ?? []).filter((a) => a.status === 'active');
+
+  const catboost = health.data?.ml.catboost;
+  const tft = health.data?.ml.tft;
+  const cbState: TrainingState = catboost?.training.is_training ? 'training' : 'idle';
+  const tftState: TrainingState = tft?.training.is_training
+    ? 'training'
+    : tft?.training.error
+      ? 'error'
+      : 'idle';
+
+  return (
+    <>
+      {health.data && (
+        <Section icon={Play} title="Training jobs">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <Card className="border-border/60">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center justify-between text-sm">
+                  CatBoost
+                  <TrainingStatusBadge state={cbState} label={catboost?.activeModel?.version} />
+                </CardTitle>
+              </CardHeader>
+              {catboost?.training.is_training && catboost.training.started_at && (
+                <CardContent>
+                  <TrainingProgress startedAt={catboost.training.started_at} />
+                </CardContent>
+              )}
+            </Card>
+            <Card className="border-border/60">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center justify-between text-sm">
+                  TFT
+                  <TrainingStatusBadge state={tftState} label={tft?.health?.status} />
+                </CardTitle>
+              </CardHeader>
+              {tft?.training.error && (
+                <CardContent>
+                  <p className="text-xs text-red-400">{tft.training.error}</p>
+                </CardContent>
+              )}
+            </Card>
+          </div>
+        </Section>
+      )}
+
+      <Section icon={Brain} title="Active model">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+          <StatCard label="Version" value={<span className="text-xl">{model.current.version}</span>} sub={model.current.modelType} />
+          <StatCard label="Model age" value={formatAge(d.system.modelAge)} sub={`${model.current.fileSizeMB.toFixed(1)} MB`} />
+          <StatCard
+            label="Live MAE"
+            value={perf.live.mae.toFixed(2)}
+            valueClass={maeColor(perf.live.mae)}
+            sub={
+              <span className={perf.improvement.isImproving ? 'text-emerald-400' : 'text-red-400'}>
+                {perf.improvement.maePercentChange > 0 ? '+' : ''}
+                {perf.improvement.maePercentChange.toFixed(1)}% vs prev
+              </span>
+            }
+          />
+          <StatCard
+            label="Coverage"
+            value={`${perf.live.coveragePercent.toFixed(1)}%`}
+            sub={`${perf.live.matchedPredictions.toLocaleString('en-GB')} matched`}
+          />
+          <StatCard label="Features" value={model.configuration.featureCount} sub="inputs used" />
+        </div>
+      </Section>
+
+      <Section icon={GitCompare} title="Accuracy (training vs live)">
+        <Card className="border-border/60">
+          <CardContent className="pt-5">
+            <div className="grid grid-cols-5 gap-2 border-b border-border/60 pb-2 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              <span />
+              <span className="text-right">MAE</span>
+              <span className="text-right">RMSE</span>
+              <span className="text-right">MAPE</span>
+              <span className="text-right">R²</span>
+            </div>
+            <MetricsRow label="Training" m={perf.training} />
+            <MetricsRow
+              label="Live"
+              m={{ mae: perf.live.mae, rmse: perf.live.rmse, mape: perf.live.mape, r2Score: perf.live.r2Score }}
+            />
+            <div className="grid grid-cols-2 gap-3 pt-3 text-sm sm:grid-cols-4">
+              <KeyVal label="Predictions" value={perf.live.totalPredictions.toLocaleString('en-GB')} />
+              <KeyVal label="Unique parks" value={perf.live.uniqueParks} />
+              <KeyVal label="Unique rides" value={perf.live.uniqueAttractions} />
+              <KeyVal label="Train samples" value={model.trainingData.trainSamples.toLocaleString('en-GB')} />
+            </div>
+          </CardContent>
+        </Card>
+      </Section>
+
+      <Section icon={TrendingDown} title="Drift">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Card className="border-border/60 sm:col-span-1">
+            <CardContent className="space-y-1 pt-5">
+              <StatusBadge status={perf.drift.status} />
+              <p className="text-muted-foreground pt-1 text-xs">
+                drift {perf.drift.currentDrift.toFixed(2)} / threshold {perf.drift.threshold}
+              </p>
+            </CardContent>
+          </Card>
+          <div className="grid grid-cols-2 gap-3 sm:col-span-3 sm:grid-cols-3">
+            <Card className="border-border/60">
+              <CardContent className="pt-5">
+                <KeyVal label="Training MAE" value={perf.drift.trainingMae.toFixed(2)} valueClass={maeColor(perf.drift.trainingMae)} />
+              </CardContent>
+            </Card>
+            <Card className="border-border/60">
+              <CardContent className="pt-5">
+                <KeyVal label="Live MAE" value={perf.drift.liveMae.toFixed(2)} valueClass={maeColor(perf.drift.liveMae)} />
+              </CardContent>
+            </Card>
+            <Card className="border-border/60">
+              <CardContent className="pt-5">
+                <KeyVal label="Tracked days" value={perf.drift.dailyMetrics.length} />
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </Section>
+
+      <Section icon={Sparkles} title="Per-attraction accuracy">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <PerformerList title="Best predictions" icon={TrendingUp} performers={insights.topPerformers} />
+          <PerformerList title="Worst predictions" icon={TrendingDown} performers={insights.bottomPerformers} />
+        </div>
+      </Section>
+
+      <Section icon={Bell} title="Monitoring">
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+          <Card className="border-border/60">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                Anomalies
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {anomalies.data ? (
+                <>
+                  <span className="text-3xl font-bold tabular-nums">{anomalies.data.totalAnomalies}</span>
+                  <div className="flex flex-wrap gap-1.5">
+                    {Object.entries(anomalies.data.bySeverity).map(([sev, n]) => (
+                      <span key={sev} className="flex items-center gap-1">
+                        <SeverityBadge severity={sev} />
+                        <span className="text-muted-foreground text-xs tabular-nums">{n}</span>
+                      </span>
+                    ))}
+                  </div>
+                  <p className="text-muted-foreground text-xs">
+                    avg score {anomalies.data.avgAnomalyScore.toFixed(2)}
+                  </p>
+                </>
+              ) : (
+                <span className="text-muted-foreground text-sm">…</span>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="border-border/60 lg:col-span-2">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-muted-foreground flex items-center gap-2 text-xs font-medium tracking-wide uppercase">
+                <AlertTriangle className="h-3.5 w-3.5" /> Active alerts
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {activeAlerts.length === 0 ? (
+                <EmptyPanel label="No active alerts." />
+              ) : (
+                activeAlerts.map((a) => (
+                  <div key={a.id} className="rounded-lg border border-border/60 bg-card px-3 py-2">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-medium">{a.title}</span>
+                      <SeverityBadge severity={a.severity} />
+                    </div>
+                    <p className="text-muted-foreground mt-1 text-xs">{a.message}</p>
+                  </div>
+                ))
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </Section>
+
+      <p className="text-muted-foreground text-center text-xs">
+        Trained {new Date(model.current.trainedAt).toLocaleString('en-GB')} · next training{' '}
+        {new Date(d.system.nextTraining).toLocaleString('en-GB')} ·{' '}
+        {model.trainingData.totalSamples.toLocaleString('en-GB')} samples over{' '}
+        {model.trainingData.dataDurationDays} days
+      </p>
+    </>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,1106 +1,188 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef, FormEvent } from 'react';
+import Link from 'next/link';
 import {
-  RefreshCw,
-  ShieldCheck,
-  LogOut,
-  Cpu,
-  HardDrive,
-  Database,
-  Zap,
-  Brain,
-  AlertTriangle,
-  CheckCircle2,
-  Server,
-  Clock,
   Activity,
-  Loader2,
-  MemoryStick,
-  KeyRound,
+  Brain,
+  Cpu,
+  FerrisWheel,
   Gauge,
-  BarChart3,
-  Play,
-  Trash2,
-  RotateCcw,
-  ListChecks,
-  Sparkles,
-  Wrench,
-  CalendarClock,
-  CalendarCheck,
-  Snowflake,
-  Sigma,
-  Trophy,
+  MapPin,
+  TimerReset,
+  TrendingUp,
+  Zap,
 } from 'lucide-react';
+import { useAdminFetch } from './_lib/admin-context';
+import {
+  CrowdBadge,
+  ErrorPanel,
+  KeyVal,
+  LoadingPanel,
+  Section,
+  StatCard,
+  StatusBadge,
+  maeColor,
+} from './_lib/ui';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import { MetricBar } from '@/components/common/metric-bar';
-import { TrainingStatusBadge, type TrainingState } from '@/components/common/training-status-badge';
-import type {
-  SystemHealthResponse,
-  HostDisk,
-  QueueStatusResponse,
-  QueueEntry,
-} from '@/lib/api/admin';
-import type { PopularPark } from '@/lib/api/types';
+import type { SystemHealthResponse } from '@/lib/api/admin';
+import type { AnalyticsRealtime, MlHealth, RealtimeRide } from '@/lib/api/admin-stats';
 
-const SESSION_KEY = 'parkfan_admin_pass';
-const REFRESH_INTERVAL = 5;
-// Typical CatBoost training duration in seconds (from historical data)
-const TYPICAL_TRAINING_SECONDS = 850;
-
-// ─── helpers ──────────────────────────────────────────────────────────────────
-
-function formatUptime(hours: number) {
-  const h = Math.floor(hours);
-  const m = Math.floor((hours - h) * 60);
-  if (h >= 24) return `${Math.floor(h / 24)}d ${h % 24}h`;
-  return `${h}h ${m}m`;
-}
-
-function formatCompact(n: number) {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return String(n);
-}
-
-function isDisk(d: HostDisk | { error: string }): d is HostDisk {
-  return 'usedPct' in d;
-}
-
-function statusDot(ok: boolean) {
+function RidePanel({ title, ride }: { title: string; ride: RealtimeRide }) {
   return (
-    <span className={`inline-block h-2 w-2 rounded-full ${ok ? 'bg-emerald-500' : 'bg-red-500'}`} />
-  );
-}
-
-function maeColor(mae: number) {
-  if (mae < 10) return 'text-emerald-400';
-  if (mae < 15) return 'text-amber-400';
-  return 'text-red-400';
-}
-
-// ─── training progress ────────────────────────────────────────────────────────
-
-function TrainingProgress({ startedAt }: { startedAt: string }) {
-  const [elapsed, setElapsed] = useState(0);
-
-  useEffect(() => {
-    const tick = () => {
-      setElapsed(Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000));
-    };
-    tick();
-    const id = setInterval(tick, 1000);
-    return () => clearInterval(id);
-  }, [startedAt]);
-
-  const pct = Math.min(Math.round((elapsed / TYPICAL_TRAINING_SECONDS) * 100), 99);
-  const h = Math.floor(elapsed / 3600);
-  const m = Math.floor((elapsed % 3600) / 60);
-  const s = elapsed % 60;
-  const elapsedStr = h > 0 ? `${h}h ${m}m` : m > 0 ? `${m}m ${s}s` : `${s}s`;
-  const remaining = Math.max(TYPICAL_TRAINING_SECONDS - elapsed, 0);
-  const remM = Math.floor(remaining / 60);
-  const remS = remaining % 60;
-
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between text-xs">
-        <span className="font-medium text-blue-400">Elapsed: {elapsedStr}</span>
-        {remaining > 0 && (
-          <span className="text-muted-foreground">
-            ~{remM}m {remS}s left
-          </span>
-        )}
-      </div>
-      <div className="bg-secondary h-2 w-full overflow-hidden rounded-full">
-        <div
-          className="h-full rounded-full bg-blue-500 transition-all duration-1000"
-          style={{ width: `${pct}%` }}
-        />
-      </div>
-      <p className="text-muted-foreground text-right text-xs">{pct}% estimated</p>
-    </div>
-  );
-}
-
-// ─── password gate ─────────────────────────────────────────────────────────────
-
-function LoginScreen({
-  onLogin,
-  error,
-  loading,
-}: {
-  onLogin: (pass: string) => void;
-  error: string | null;
-  loading: boolean;
-}) {
-  const [value, setValue] = useState('');
-
-  function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    if (value.trim()) onLogin(value.trim());
-  }
-
-  return (
-    <div className="flex min-h-screen items-center justify-center p-4">
-      <div className="w-full max-w-sm space-y-6">
-        <div className="space-y-2 text-center">
-          <div className="bg-primary/15 border-primary/20 mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border">
-            <ShieldCheck className="text-primary h-7 w-7" />
-          </div>
-          <div>
-            <p className="text-muted-foreground text-sm font-medium tracking-widest uppercase">
-              park.fan
-            </p>
-            <h1 className="text-2xl font-bold">Admin Dashboard</h1>
-          </div>
-        </div>
-
-        <Card className="border-border/60">
-          <CardContent className="space-y-4 pt-6 pb-6">
-            <form onSubmit={handleSubmit} className="space-y-3">
-              <div className="relative">
-                <KeyRound className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-                <Input
-                  type="password"
-                  placeholder="Admin password"
-                  value={value}
-                  onChange={(e) => setValue(e.target.value)}
-                  className="pl-9"
-                  autoFocus
-                  autoComplete="current-password"
-                />
-              </div>
-              <Button type="submit" className="w-full" disabled={loading || !value.trim()}>
-                {loading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Loading…
-                  </>
-                ) : (
-                  'Sign In'
-                )}
-              </Button>
-            </form>
-
-            {error && (
-              <div className="bg-destructive/10 border-destructive/20 text-destructive flex items-center gap-2 rounded-lg border px-3 py-2 text-sm">
-                <AlertTriangle className="h-4 w-4 shrink-0" />
-                {error}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
-    </div>
-  );
-}
-
-// ─── status bar ───────────────────────────────────────────────────────────────
-
-function StatusBar({
-  data,
-  lastUpdated,
-  refreshing,
-}: {
-  data: SystemHealthResponse;
-  lastUpdated: Date | null;
-  refreshing: boolean;
-}) {
-  const pgOk = data.postgres.status === 'connected';
-  const redisOk = data.redis.status === 'connected';
-  const cbTraining = data.ml.catboost.training.is_training;
-  const tftHealthy = data.ml.tft.health?.status === 'healthy';
-
-  const items = [
-    { icon: <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />, label: 'API', ok: true },
-    { icon: statusDot(pgOk), label: 'PostgreSQL', ok: pgOk },
-    { icon: statusDot(redisOk), label: 'Redis', ok: redisOk },
-    {
-      icon: cbTraining ? (
-        <span className="relative flex h-2 w-2 shrink-0">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-500 opacity-75" />
-          <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-500" />
-        </span>
-      ) : (
-        statusDot(true)
-      ),
-      label: 'CatBoost',
-      ok: true,
-    },
-    { icon: statusDot(tftHealthy), label: 'TFT', ok: tftHealthy },
-  ];
-
-  return (
-    <div className="border-border/40 bg-card/40 flex flex-wrap items-center gap-x-5 gap-y-2 border-b px-6 py-2.5 backdrop-blur-sm">
-      {items.map(({ icon, label, ok }) => (
-        <span
-          key={label}
-          className={`flex items-center gap-1.5 text-xs font-medium ${ok ? 'text-foreground/80' : 'text-red-400'}`}
-        >
-          {icon}
-          {label}
-        </span>
-      ))}
-      <span className="text-muted-foreground ml-auto flex items-center gap-2 text-xs">
-        {refreshing && (
-          <span className="bg-primary inline-block h-1.5 w-1.5 animate-pulse rounded-full" />
-        )}
-        {lastUpdated && (
-          <span className="tabular-nums">Updated {lastUpdated.toLocaleTimeString('en-GB')}</span>
-        )}
-      </span>
-    </div>
-  );
-}
-
-function PopularParkRow({ park }: { park: PopularPark }) {
-  const location = [park.city, park.country].filter(Boolean).join(', ');
-  const content = (
-    <div className="border-border/60 bg-card hover:border-primary/40 flex items-center gap-3 rounded-lg border px-3 py-2 text-sm transition-colors">
-      <span className="bg-primary/15 text-primary flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-mono text-xs font-semibold tabular-nums">
-        {park.rank}
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="text-foreground truncate font-medium">{park.name}</div>
-        {location && <div className="text-muted-foreground truncate text-xs">{location}</div>}
-      </div>
-      <span className="text-muted-foreground shrink-0 font-mono text-xs tabular-nums">
-        {park.requests.toLocaleString()}
-      </span>
-    </div>
-  );
-  return park.url ? (
-    <a href={park.url} target="_blank" rel="noopener noreferrer" className="block">
-      {content}
-    </a>
-  ) : (
-    content
-  );
-}
-
-// ─── section heading ──────────────────────────────────────────────────────────
-
-function Section({
-  icon: Icon,
-  title,
-  children,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="space-y-3">
-      <div className="flex items-center gap-2">
-        <Icon className="text-primary h-4 w-4" />
-        <h2 className="text-foreground/70 text-sm font-semibold tracking-wide uppercase">
+    <Card className="border-border/60">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
           {title}
-        </h2>
-      </div>
-      {children}
-    </section>
-  );
-}
-
-// ─── dashboard ────────────────────────────────────────────────────────────────
-
-function QueueBadge({
-  count,
-  variant,
-}: {
-  count: number;
-  variant: 'active' | 'pending' | 'failed' | 'delayed';
-}) {
-  if (count === 0) return null;
-  const colors: Record<typeof variant, string> = {
-    active: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
-    pending: 'bg-zinc-500/15 text-zinc-400 border-zinc-500/20',
-    failed: 'bg-red-500/15 text-red-400 border-red-500/20',
-    delayed: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
-  };
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-1.5 py-0.5 font-mono text-xs tabular-nums ${colors[variant]}`}
-    >
-      {count} {variant}
-    </span>
-  );
-}
-
-function QueueRow({ q }: { q: QueueEntry }) {
-  const hasActivity = q.active + q.pending + q.failed + q.delayed > 0;
-  return (
-    <div
-      className={`flex items-center justify-between gap-2 rounded-lg border px-3 py-2 text-sm transition-colors ${hasActivity ? 'border-border/60 bg-card' : 'border-border/30 bg-card/40'}`}
-    >
-      <span
-        className={`font-mono text-xs ${hasActivity ? 'text-foreground' : 'text-muted-foreground'}`}
-      >
-        {q.name}
-      </span>
-      <div className="flex items-center gap-1">
-        {q.active === 0 && q.pending === 0 && q.failed === 0 && q.delayed === 0 ? (
-          <span className="text-muted-foreground text-xs">idle</span>
-        ) : (
-          <>
-            <QueueBadge count={q.active} variant="active" />
-            <QueueBadge count={q.pending} variant="pending" />
-            <QueueBadge count={q.failed} variant="failed" />
-            <QueueBadge count={q.delayed} variant="delayed" />
-          </>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function Dashboard({
-  data,
-  queueData,
-  popularData,
-  savedPass,
-  onLogout,
-  onRefresh,
-  loading,
-  refreshing,
-  lastUpdated,
-}: {
-  data: SystemHealthResponse;
-  queueData: QueueStatusResponse | null;
-  popularData: PopularPark[] | null;
-  savedPass: string;
-  onLogout: () => void;
-  onRefresh: () => void;
-  loading: boolean;
-  refreshing: boolean;
-  lastUpdated: Date | null;
-}) {
-  const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({});
-  const [actionResult, setActionResult] = useState<Record<string, 'ok' | 'err'>>({});
-
-  async function triggerAction(key: string, path: string) {
-    setActionLoading((p) => ({ ...p, [key]: true }));
-    setActionResult((p) => ({ ...p, [key]: undefined as unknown as 'ok' | 'err' }));
-    try {
-      const res = await fetch(`/api/admin/${path}?pass=${encodeURIComponent(savedPass)}`, {
-        method: 'POST',
-      });
-      setActionResult((p) => ({ ...p, [key]: res.ok ? 'ok' : 'err' }));
-    } catch {
-      setActionResult((p) => ({ ...p, [key]: 'err' }));
-    } finally {
-      setActionLoading((p) => ({ ...p, [key]: false }));
-    }
-  }
-
-  const disk = data.host.disk;
-  const diskValid = isDisk(disk);
-
-  const cbTraining = data.ml.catboost.training.is_training;
-  const cbState: TrainingState = cbTraining ? 'training' : 'idle';
-  const tftState: TrainingState = data.ml.tft.training.is_training
-    ? 'training'
-    : data.ml.tft.training.error
-      ? 'error'
-      : 'idle';
-
-  const maxLoad = data.host.cpu.cores;
-
-  const actions = [
-    { key: 'flush', label: 'Flush Cache', icon: Trash2, path: 'flush-cache' },
-    { key: 'train', label: 'Train ML', icon: Play, path: 'train-ml-model' },
-    { key: 'sync', label: 'Sync Parks', icon: RotateCcw, path: 'sync-parks' },
-    { key: 'enrich', label: 'Enrich Parks', icon: Sparkles, path: 'enrich-parks' },
-    {
-      key: 'validate',
-      label: 'Validate & Repair',
-      icon: Wrench,
-      path: 'validate-and-repair-parks',
-    },
-    { key: 'gaps', label: 'Fill Schedule Gaps', icon: CalendarClock, path: 'fill-schedule-gaps' },
-    { key: 'holidays', label: 'Sync Holidays', icon: CalendarCheck, path: 'sync-holidays' },
-    { key: 'seasonal', label: 'Detect Seasonal', icon: Snowflake, path: 'detect-seasonal' },
-    {
-      key: 'accuracy',
-      label: 'Aggregate Accuracy',
-      icon: Sigma,
-      path: 'aggregate-accuracy-stats',
-    },
-  ];
-
-  return (
-    <div className="flex min-h-screen flex-col">
-      {/* Header */}
-      <header className="border-border/40 bg-background/80 sticky top-0 z-10 border-b backdrop-blur-md">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-3">
-          <div className="flex items-center gap-2.5">
-            <div className="bg-primary/15 border-primary/20 flex h-8 w-8 items-center justify-center rounded-lg border">
-              <ShieldCheck className="text-primary h-4 w-4" />
-            </div>
-            <span className="font-semibold">
-              <span className="text-primary">park.fan</span>
-              <span className="text-muted-foreground mx-1.5">/</span>
-              <span>Admin</span>
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onRefresh}
-              disabled={loading}
-              className="h-8 gap-1.5 px-3"
-            >
-              <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
-              <span className="hidden sm:inline">Refresh</span>
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={onLogout}
-              className="text-muted-foreground hover:text-foreground h-8 w-8"
-            >
-              <LogOut className="h-3.5 w-3.5" />
-            </Button>
-          </div>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        <Link href={ride.url} className="hover:text-primary block truncate font-semibold">
+          {ride.name}
+        </Link>
+        <p className="text-muted-foreground truncate text-xs">{ride.parkName}</p>
+        <div className="flex items-center justify-between pt-1">
+          <span className="text-2xl font-bold tabular-nums">{ride.waitTime}&apos;</span>
+          <CrowdBadge level={ride.crowdLevel} />
         </div>
-        <StatusBar data={data} lastUpdated={lastUpdated} refreshing={refreshing} />
-      </header>
-
-      {/* Main content */}
-      <main className="mx-auto w-full max-w-6xl flex-1 space-y-8 px-6 py-8">
-        {/* System Resources */}
-        <Section icon={Server} title="System">
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            {/* CPU */}
-            <Card className="border-border/60">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-muted-foreground flex items-center gap-2 text-xs font-medium tracking-wide uppercase">
-                  <Cpu className="h-3.5 w-3.5" /> CPU
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <div>
-                  <span
-                    className={`text-3xl font-bold tabular-nums ${(data.host.cpu.loadPct ?? 0) >= 80 ? 'text-red-400' : (data.host.cpu.loadPct ?? 0) >= 60 ? 'text-amber-400' : 'text-foreground'}`}
-                  >
-                    {data.host.cpu.loadPct ?? '—'}%
-                  </span>
-                  <p className="text-muted-foreground mt-0.5 text-xs">
-                    {data.host.cpu.cores} Cores
-                  </p>
-                  <p className="text-muted-foreground truncate text-xs" title={data.host.cpu.model}>
-                    {data.host.cpu.model.split(' ').slice(0, 3).join(' ')}
-                  </p>
-                </div>
-                <div className="space-y-1.5">
-                  <MetricBar
-                    label="1m"
-                    value={data.host.cpu.load['1m']}
-                    max={maxLoad}
-                    unit=""
-                    thresholds={[60, 80]}
-                  />
-                  <MetricBar
-                    label="5m"
-                    value={data.host.cpu.load['5m']}
-                    max={maxLoad}
-                    unit=""
-                    thresholds={[60, 80]}
-                  />
-                  <MetricBar
-                    label="15m"
-                    value={data.host.cpu.load['15m']}
-                    max={maxLoad}
-                    unit=""
-                    thresholds={[60, 80]}
-                  />
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Memory */}
-            <Card className="border-border/60">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-muted-foreground flex items-center gap-2 text-xs font-medium tracking-wide uppercase">
-                  <MemoryStick className="h-3.5 w-3.5" /> Memory
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <div>
-                  <span className="text-3xl font-bold tabular-nums">
-                    {data.host.memory.usedGB.toFixed(1)}
-                    <span className="text-muted-foreground text-lg font-normal"> GB</span>
-                  </span>
-                  <p className="text-muted-foreground mt-0.5 text-xs">
-                    of {data.host.memory.totalGB.toFixed(1)} GB
-                  </p>
-                </div>
-                <MetricBar
-                  label="Usage"
-                  value={data.host.memory.usedGB}
-                  max={data.host.memory.totalGB}
-                  unit=" GB"
-                  pct={data.host.memory.usedPct}
-                />
-              </CardContent>
-            </Card>
-
-            {/* Disk */}
-            <Card className="border-border/60">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-muted-foreground flex items-center gap-2 text-xs font-medium tracking-wide uppercase">
-                  <HardDrive className="h-3.5 w-3.5" /> Disk
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {diskValid ? (
-                  <>
-                    <div>
-                      <span className="text-3xl font-bold tabular-nums">
-                        {(disk.totalGB - disk.freeGB).toFixed(0)}
-                        <span className="text-muted-foreground text-lg font-normal"> GB</span>
-                      </span>
-                      <p className="text-muted-foreground mt-0.5 text-xs">
-                        of {disk.totalGB.toFixed(0)} GB · {disk.freeGB.toFixed(0)} GB free
-                      </p>
-                    </div>
-                    <MetricBar
-                      label="Used"
-                      value={disk.totalGB - disk.freeGB}
-                      max={disk.totalGB}
-                      unit=" GB"
-                      pct={disk.usedPct}
-                      thresholds={[75, 90]}
-                    />
-                  </>
-                ) : (
-                  <p className="text-muted-foreground text-sm">N/A</p>
-                )}
-              </CardContent>
-            </Card>
-
-            {/* Uptime */}
-            <Card className="border-border/60">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-muted-foreground flex items-center gap-2 text-xs font-medium tracking-wide uppercase">
-                  <Clock className="h-3.5 w-3.5" /> Uptime
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-1">
-                <span className="text-3xl font-bold tabular-nums">
-                  {formatUptime(data.host.uptimeHours)}
-                </span>
-                <p className="text-muted-foreground text-xs">
-                  API v4 · {data.host.cpu.cores}-core server
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-        </Section>
-
-        {/* Database */}
-        <Section icon={Database} title="Database">
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            {/* PostgreSQL */}
-            <Card className="border-border/60">
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center justify-between text-base">
-                  <span className="flex items-center gap-2">
-                    <Database className="text-primary h-4 w-4" />
-                    PostgreSQL
-                  </span>
-                  <span className="flex items-center gap-1.5 text-sm font-normal">
-                    {statusDot(data.postgres.status === 'connected')}
-                    <span
-                      className={
-                        data.postgres.status === 'connected' ? 'text-emerald-400' : 'text-red-400'
-                      }
-                    >
-                      {data.postgres.status === 'connected' ? 'Connected' : data.postgres.status}
-                    </span>
-                  </span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <MetricBar
-                  label={`Connections (active: ${data.postgres.activeQueries})`}
-                  value={data.postgres.connections}
-                  max={data.postgres.maxConnections}
-                  unit=""
-                  pct={data.postgres.connectionsPct ?? undefined}
-                  thresholds={[60, 80]}
-                />
-                <div className="grid grid-cols-2 gap-3 pt-1 text-sm">
-                  <div>
-                    <p className="text-muted-foreground text-xs">DB Size</p>
-                    <p className="font-semibold tabular-nums">
-                      {data.postgres.dbSizeGB.toFixed(2)} GB
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-muted-foreground text-xs">Cache Hit</p>
-                    <p
-                      className={`font-semibold tabular-nums ${(data.postgres.cacheHitPct ?? 0) >= 99 ? 'text-emerald-400' : 'text-amber-400'}`}
-                    >
-                      {data.postgres.cacheHitPct?.toFixed(1) ?? '—'}%
-                    </p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Redis */}
-            <Card className="border-border/60">
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center justify-between text-base">
-                  <span className="flex items-center gap-2">
-                    <Zap className="text-primary h-4 w-4" />
-                    Redis
-                  </span>
-                  <span className="flex items-center gap-1.5 text-sm font-normal">
-                    {statusDot(data.redis.status === 'connected')}
-                    <span
-                      className={
-                        data.redis.status === 'connected' ? 'text-emerald-400' : 'text-red-400'
-                      }
-                    >
-                      {data.redis.status === 'connected' ? 'Connected' : data.redis.status}
-                    </span>
-                  </span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <MetricBar
-                  label="Memory"
-                  value={data.redis.usedMemoryMB}
-                  max={data.redis.maxMemoryMB ?? data.redis.usedMemoryMB * 2}
-                  unit=" MB"
-                  thresholds={[60, 80]}
-                />
-                <div className="grid grid-cols-3 gap-3 pt-1 text-sm">
-                  <div>
-                    <p className="text-muted-foreground text-xs">Keys</p>
-                    <p className="font-semibold tabular-nums">{formatCompact(data.redis.keys)}</p>
-                  </div>
-                  <div>
-                    <p className="text-muted-foreground text-xs">Clients</p>
-                    <p className="font-semibold tabular-nums">{data.redis.connectedClients}</p>
-                  </div>
-                  <div>
-                    <p className="text-muted-foreground text-xs">Hit Rate</p>
-                    <p
-                      className={`font-semibold tabular-nums ${(data.redis.hitRatePct ?? 0) >= 80 ? 'text-emerald-400' : 'text-amber-400'}`}
-                    >
-                      {data.redis.hitRatePct?.toFixed(1) ?? '—'}%
-                    </p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </Section>
-
-        {/* ML Models */}
-        <Section icon={Brain} title="ML Models">
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            {/* CatBoost */}
-            <Card className="border-border/60">
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center justify-between text-base">
-                  <span className="flex items-center gap-2">
-                    <Activity className="text-primary h-4 w-4" />
-                    CatBoost
-                  </span>
-                  <TrainingStatusBadge state={cbState} />
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {cbTraining && data.ml.catboost.training.started_at && (
-                  <div className="space-y-3 rounded-lg border border-blue-500/20 bg-blue-500/10 px-3 py-3">
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs font-medium text-blue-400">
-                        Training: {data.ml.catboost.training.current_version}
-                      </span>
-                    </div>
-                    <TrainingProgress startedAt={data.ml.catboost.training.started_at} />
-                  </div>
-                )}
-                {data.ml.catboost.activeModel && (
-                  <div className="space-y-2">
-                    <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-                      Active Model
-                    </p>
-                    <p className="text-muted-foreground font-mono text-xs">
-                      {data.ml.catboost.activeModel.version}
-                    </p>
-                    <div className="grid grid-cols-2 gap-2 text-sm">
-                      <div className="bg-card border-border/40 rounded-lg border px-3 py-2">
-                        <p className="text-muted-foreground text-xs">MAE</p>
-                        <p className="font-bold tabular-nums">
-                          {data.ml.catboost.activeModel.mae?.toFixed(2) ?? '—'}
-                          <span className="text-muted-foreground ml-0.5 text-xs font-normal">
-                            min
-                          </span>
-                        </p>
-                      </div>
-                      <div className="bg-card border-border/40 rounded-lg border px-3 py-2">
-                        <p className="text-muted-foreground text-xs">RMSE</p>
-                        <p className="font-bold tabular-nums">
-                          {data.ml.catboost.activeModel.rmse?.toFixed(2) ?? '—'}
-                        </p>
-                      </div>
-                      <div className="bg-card border-border/40 rounded-lg border px-3 py-2">
-                        <p className="text-muted-foreground text-xs">R²</p>
-                        <p
-                          className={`font-bold tabular-nums ${(data.ml.catboost.activeModel.r2 ?? 0) >= 0.75 ? 'text-emerald-400' : 'text-amber-400'}`}
-                        >
-                          {data.ml.catboost.activeModel.r2?.toFixed(4) ?? '—'}
-                        </p>
-                      </div>
-                      <div className="bg-card border-border/40 rounded-lg border px-3 py-2">
-                        <p className="text-muted-foreground text-xs">Samples</p>
-                        <p className="font-bold tabular-nums">
-                          {formatCompact(data.ml.catboost.activeModel.trainSamples)}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-
-            {/* TFT */}
-            <Card className="border-border/60">
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center justify-between text-base">
-                  <span className="flex items-center gap-2">
-                    <Gauge className="text-primary h-4 w-4" />
-                    TFT
-                    <span className="text-muted-foreground text-xs font-normal">
-                      NeuralForecast
-                    </span>
-                  </span>
-                  <TrainingStatusBadge state={tftState} />
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <p className="text-muted-foreground font-mono text-xs">
-                  {data.ml.tft.training.version ?? '—'}
-                </p>
-                {data.ml.tft.training.error && (
-                  <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
-                    <AlertTriangle className="mr-1 inline h-3.5 w-3.5" />
-                    {data.ml.tft.training.error}
-                  </div>
-                )}
-                {data.ml.tft.training.is_training && data.ml.tft.training.started_at && (
-                  <div className="rounded-lg border border-blue-500/20 bg-blue-500/10 px-3 py-3">
-                    <TrainingProgress startedAt={data.ml.tft.training.started_at} />
-                  </div>
-                )}
-                {data.ml.tft.health && (
-                  <div className="grid grid-cols-2 gap-2 text-sm">
-                    <div className="bg-card border-border/40 rounded-lg border px-3 py-2">
-                      <p className="text-muted-foreground text-xs">Status</p>
-                      <p
-                        className={`font-medium ${data.ml.tft.health.status === 'healthy' ? 'text-emerald-400' : 'text-red-400'}`}
-                      >
-                        {data.ml.tft.health.status}
-                      </p>
-                    </div>
-                    <div className="bg-card border-border/40 rounded-lg border px-3 py-2">
-                      <p className="text-muted-foreground text-xs">Model trained</p>
-                      <p
-                        className={`font-medium ${data.ml.tft.health.model_trained ? 'text-emerald-400' : 'text-muted-foreground'}`}
-                      >
-                        {data.ml.tft.health.model_trained ? 'Yes' : 'No'}
-                      </p>
-                    </div>
-                    <div className="bg-card border-border/40 rounded-lg border px-3 py-2">
-                      <p className="text-muted-foreground text-xs">Scope</p>
-                      <p className="font-medium">{data.ml.tft.health.park_scope}</p>
-                    </div>
-                    <div className="bg-card border-border/40 rounded-lg border px-3 py-2">
-                      <p className="text-muted-foreground text-xs">Horizon</p>
-                      <p className="font-medium tabular-nums">{data.ml.tft.health.horizon}d</p>
-                    </div>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </div>
-        </Section>
-
-        {/* Prediction Accuracy */}
-        {data.ml.comparison.rows.length > 0 && (
-          <Section icon={BarChart3} title="Prediction Accuracy">
-            <Card className="border-border/60">
-              <CardContent className="px-0 pt-4 pb-2">
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="border-border/40 border-b">
-                        <th className="text-muted-foreground px-4 pb-2 text-left text-xs font-medium tracking-wide uppercase">
-                          Date
-                        </th>
-                        <th className="text-muted-foreground px-4 pb-2 text-left text-xs font-medium tracking-wide uppercase">
-                          Model
-                        </th>
-                        <th className="text-muted-foreground px-4 pb-2 text-right text-xs font-medium tracking-wide uppercase">
-                          n
-                        </th>
-                        <th className="text-muted-foreground px-4 pb-2 text-right text-xs font-medium tracking-wide uppercase">
-                          MAE
-                        </th>
-                        <th className="text-muted-foreground px-4 pb-2 text-right text-xs font-medium tracking-wide uppercase">
-                          Bias
-                        </th>
-                        <th className="text-muted-foreground px-4 pb-2 text-right text-xs font-medium tracking-wide uppercase">
-                          Lead
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {data.ml.comparison.rows.map((row, i) => {
-                        const mae = parseFloat(String(row.mae));
-                        const bias = parseFloat(String(row.bias));
-                        return (
-                          <tr
-                            key={i}
-                            className="border-border/20 hover:bg-muted/30 border-b transition-colors last:border-0"
-                          >
-                            <td className="text-muted-foreground px-4 py-2 font-mono text-xs tabular-nums">
-                              {new Date(row.targetDate).toLocaleDateString('en-GB', {
-                                day: '2-digit',
-                                month: '2-digit',
-                              })}
-                            </td>
-                            <td className="px-4 py-2">
-                              <Badge variant="secondary" className="font-mono text-xs">
-                                {row.model}
-                              </Badge>
-                            </td>
-                            <td className="text-muted-foreground px-4 py-2 text-right font-mono text-xs tabular-nums">
-                              {row.n}
-                            </td>
-                            <td
-                              className={`px-4 py-2 text-right font-mono text-xs font-medium tabular-nums ${maeColor(mae)}`}
-                            >
-                              {mae.toFixed(1)}
-                              <span className="text-muted-foreground ml-0.5">min</span>
-                            </td>
-                            <td
-                              className={`px-4 py-2 text-right font-mono text-xs tabular-nums ${bias < 0 ? 'text-amber-400' : 'text-emerald-400'}`}
-                            >
-                              {bias > 0 ? '+' : ''}
-                              {bias.toFixed(1)}
-                            </td>
-                            <td className="text-muted-foreground px-4 py-2 text-right font-mono text-xs tabular-nums">
-                              {row.avgLeadDays}d
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-              </CardContent>
-            </Card>
-          </Section>
-        )}
-
-        {/* Queue Status */}
-        {queueData && queueData.queues.length > 0 && (
-          <Section icon={ListChecks} title="Queues">
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
-              {queueData.queues.map((q) => (
-                <QueueRow key={q.name} q={q} />
-              ))}
-            </div>
-          </Section>
-        )}
-
-        {/* Popular Parks */}
-        {popularData && popularData.length > 0 && (
-          <Section icon={Trophy} title="Popular Parks">
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-              {popularData.map((park) => (
-                <PopularParkRow key={park.id} park={park} />
-              ))}
-            </div>
-          </Section>
-        )}
-
-        {/* Quick Actions */}
-        <Section icon={Activity} title="Quick Actions">
-          <div className="flex flex-wrap gap-3">
-            {actions.map(({ key, label, icon: Icon, path }) => (
-              <button
-                key={key}
-                onClick={() => triggerAction(key, path)}
-                disabled={actionLoading[key]}
-                className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
-                  actionResult[key] === 'ok'
-                    ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-400'
-                    : actionResult[key] === 'err'
-                      ? 'border-red-500/40 bg-red-500/10 text-red-400'
-                      : 'border-border/60 bg-card hover:border-primary/40 hover:bg-primary/5 hover:text-primary text-foreground/80'
-                } disabled:cursor-not-allowed disabled:opacity-50`}
-              >
-                {actionLoading[key] ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : actionResult[key] === 'ok' ? (
-                  <CheckCircle2 className="h-3.5 w-3.5" />
-                ) : actionResult[key] === 'err' ? (
-                  <AlertTriangle className="h-3.5 w-3.5" />
-                ) : (
-                  <Icon className="h-3.5 w-3.5" />
-                )}
-                {label}
-              </button>
-            ))}
-          </div>
-        </Section>
-      </main>
-
-      <footer className="border-border/20 text-muted-foreground border-t px-6 py-4 text-center text-xs">
-        park.fan Admin · {new Date(data.timestamp).toLocaleString('en-GB')}
-      </footer>
-    </div>
+      </CardContent>
+    </Card>
   );
 }
 
-// ─── main page ────────────────────────────────────────────────────────────────
+export default function OverviewPage() {
+  const health = useAdminFetch<SystemHealthResponse>('/api/admin/system-health', true);
+  const realtime = useAdminFetch<AnalyticsRealtime>('/api/analytics/realtime');
+  const ml = useAdminFetch<MlHealth>('/api/ml/health');
 
-export default function AdminPage() {
-  const [savedPass, setSavedPass] = useState<string | null>(() =>
-    typeof window !== 'undefined' ? sessionStorage.getItem(SESSION_KEY) : null
-  );
-  const [data, setData] = useState<SystemHealthResponse | null>(null);
-  const [queueData, setQueueData] = useState<QueueStatusResponse | null>(null);
-  const [popularData, setPopularData] = useState<PopularPark[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  if (health.error) return <ErrorPanel message={`System health: ${health.error}`} />;
+  if (!health.data || !realtime.data) return <LoadingPanel label="Loading dashboard…" />;
 
-  const fetchData = useCallback(async (pass: string, background = false) => {
-    if (background) setRefreshing(true);
-    else setLoading(true);
-    if (!background) setError(null);
-
-    try {
-      const passParam = encodeURIComponent(pass);
-      const [healthRes, queueRes, popularRes] = await Promise.all([
-        fetch(`/api/admin/system-health?pass=${passParam}`),
-        fetch(`/api/admin/queue-status?pass=${passParam}`),
-        fetch(`/api/parks/popular?limit=20`),
-      ]);
-
-      if (healthRes.status === 401 || healthRes.status === 403) {
-        sessionStorage.removeItem(SESSION_KEY);
-        setSavedPass(null);
-        setData(null);
-        setError('Wrong password.');
-        return;
-      }
-      if (!healthRes.ok) {
-        if (!background) setError(`API error: ${healthRes.status}`);
-        return;
-      }
-      const [healthJson, queueJson, popularJson] = await Promise.all([
-        healthRes.json() as Promise<SystemHealthResponse>,
-        queueRes.ok ? (queueRes.json() as Promise<QueueStatusResponse>) : Promise.resolve(null),
-        popularRes.ok ? (popularRes.json() as Promise<PopularPark[]>) : Promise.resolve(null),
-      ]);
-      setData(healthJson);
-      setQueueData(queueJson);
-      setPopularData(popularJson);
-      setLastUpdated(new Date());
-    } catch {
-      if (!background) setError('Connection error.');
-    } finally {
-      if (background) setRefreshing(false);
-      else setLoading(false);
-    }
-  }, []);
-
-  // Initial fetch when savedPass available (deferred to avoid sync setState-in-effect)
-  useEffect(() => {
-    if (!savedPass) return;
-    const id = setTimeout(() => void fetchData(savedPass), 0);
-    return () => clearTimeout(id);
-  }, [savedPass, fetchData]);
-
-  // Auto-refresh every REFRESH_INTERVAL seconds (silent background)
-  useEffect(() => {
-    if (!savedPass) return;
-
-    if (intervalRef.current) clearInterval(intervalRef.current);
-    intervalRef.current = setInterval(() => {
-      if (!document.hidden) void fetchData(savedPass, true);
-    }, REFRESH_INTERVAL * 1000);
-
-    const handleVisibility = () => {
-      if (!document.hidden) void fetchData(savedPass, true);
-    };
-    document.addEventListener('visibilitychange', handleVisibility);
-
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-      document.removeEventListener('visibilitychange', handleVisibility);
-    };
-  }, [savedPass, fetchData]);
-
-  function handleLogin(pass: string) {
-    sessionStorage.setItem(SESSION_KEY, pass);
-    setSavedPass(pass);
-  }
-
-  function handleLogout() {
-    sessionStorage.removeItem(SESSION_KEY);
-    setSavedPass(null);
-    setData(null);
-    setQueueData(null);
-    setError(null);
-    if (intervalRef.current) clearInterval(intervalRef.current);
-  }
-
-  function handleRefresh() {
-    if (savedPass) void fetchData(savedPass);
-  }
-
-  if (!savedPass || (!data && !loading)) {
-    return <LoginScreen onLogin={handleLogin} error={error} loading={loading} />;
-  }
-
-  if (loading && !data) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Loader2 className="text-primary h-8 w-8 animate-spin" />
-      </div>
-    );
-  }
-
-  if (!data) return null;
+  const h = health.data;
+  const rt = realtime.data;
+  const counts = rt.counts;
 
   return (
-    <Dashboard
-      data={data}
-      queueData={queueData}
-      popularData={popularData}
-      savedPass={savedPass}
-      onLogout={handleLogout}
-      onRefresh={handleRefresh}
-      loading={loading}
-      refreshing={refreshing}
-      lastUpdated={lastUpdated}
-    />
+    <>
+      <Section icon={Gauge} title="At a glance">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+          <StatCard
+            icon={MapPin}
+            label="Open Parks"
+            value={counts.openParks}
+            sub={`of ${counts.parks} total`}
+          />
+          <StatCard
+            icon={FerrisWheel}
+            label="Open Rides"
+            value={counts.openAttractions}
+            sub={`of ${counts.attractions} total`}
+          />
+          <StatCard
+            icon={TimerReset}
+            label="Total Wait"
+            value={`${counts.totalWaitTime.toLocaleString('en-GB')}'`}
+            sub="across open rides"
+          />
+          <StatCard
+            icon={Brain}
+            label="Model MAE"
+            value={ml.data ? ml.data.model.metrics.mae.toFixed(1) : '—'}
+            valueClass={ml.data ? maeColor(ml.data.model.metrics.mae) : undefined}
+            sub={ml.data ? `v${ml.data.model.version}` : 'loading'}
+          />
+          <StatCard
+            icon={Activity}
+            label="Queue Records"
+            value={counts.queueDataRecords.toLocaleString('en-GB')}
+            sub="live samples"
+          />
+        </div>
+      </Section>
+
+      <Section icon={Cpu} title="Health">
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusBadge status="API operational" />
+          <StatusBadge status={h.postgres.status} />
+          <StatusBadge status={`Redis ${h.redis.status}`} />
+          {ml.data && <StatusBadge status={ml.data.status} />}
+          <span className="text-muted-foreground ml-1 text-xs">
+            CPU {h.host.cpu.loadPct ?? '—'}% · Mem {h.host.memory.usedPct}%
+          </span>
+          <Link
+            href="/admin/system"
+            className="text-primary ml-auto text-xs font-medium hover:underline"
+          >
+            System details →
+          </Link>
+        </div>
+      </Section>
+
+      <Section icon={TrendingUp} title="Live extremes">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Card className="border-border/60">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                Most crowded park
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-1">
+              <Link
+                href={rt.mostCrowdedPark.url}
+                className="hover:text-primary block truncate font-semibold"
+              >
+                {rt.mostCrowdedPark.name}
+              </Link>
+              <p className="text-muted-foreground truncate text-xs">
+                {rt.mostCrowdedPark.city}, {rt.mostCrowdedPark.country}
+              </p>
+              <div className="flex items-center justify-between pt-1">
+                <span className="text-2xl font-bold tabular-nums">
+                  {rt.mostCrowdedPark.averageWaitTime}&apos;
+                </span>
+                <CrowdBadge level={rt.mostCrowdedPark.crowdLevel} />
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="border-border/60">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                Least crowded park
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-1">
+              <Link
+                href={rt.leastCrowdedPark.url}
+                className="hover:text-primary block truncate font-semibold"
+              >
+                {rt.leastCrowdedPark.name}
+              </Link>
+              <p className="text-muted-foreground truncate text-xs">
+                {rt.leastCrowdedPark.city}, {rt.leastCrowdedPark.country}
+              </p>
+              <div className="flex items-center justify-between pt-1">
+                <span className="text-2xl font-bold tabular-nums">
+                  {rt.leastCrowdedPark.averageWaitTime}&apos;
+                </span>
+                <CrowdBadge level={rt.leastCrowdedPark.crowdLevel} />
+              </div>
+            </CardContent>
+          </Card>
+          <RidePanel title="Longest wait ride" ride={rt.longestWaitRide} />
+          <RidePanel title="Shortest wait ride" ride={rt.shortestWaitRide} />
+        </div>
+      </Section>
+
+      <Section icon={Zap} title="Throughput">
+        <div className="grid grid-cols-2 gap-3 rounded-lg border border-border/60 bg-card p-4 sm:grid-cols-4">
+          <KeyVal label="Shows" value={counts.shows.toLocaleString('en-GB')} />
+          <KeyVal label="Restaurants" value={counts.restaurants.toLocaleString('en-GB')} />
+          <KeyVal label="DB Cache Hit" value={`${h.postgres.cacheHitPct?.toFixed(1) ?? '—'}%`} />
+          <KeyVal
+            label="Redis Hit Rate"
+            value={`${h.redis.hitRatePct?.toFixed(1) ?? '—'}%`}
+          />
+        </div>
+      </Section>
+    </>
   );
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -30,6 +30,7 @@ import {
   CalendarCheck,
   Snowflake,
   Sigma,
+  Trophy,
 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -43,6 +44,7 @@ import type {
   QueueStatusResponse,
   QueueEntry,
 } from '@/lib/api/admin';
+import type { PopularPark } from '@/lib/api/types';
 
 const SESSION_KEY = 'parkfan_admin_pass';
 const REFRESH_INTERVAL = 5;
@@ -255,6 +257,31 @@ function StatusBar({
   );
 }
 
+function PopularParkRow({ park }: { park: PopularPark }) {
+  const location = [park.city, park.country].filter(Boolean).join(', ');
+  const content = (
+    <div className="border-border/60 bg-card hover:border-primary/40 flex items-center gap-3 rounded-lg border px-3 py-2 text-sm transition-colors">
+      <span className="bg-primary/15 text-primary flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-mono text-xs font-semibold tabular-nums">
+        {park.rank}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="text-foreground truncate font-medium">{park.name}</div>
+        {location && <div className="text-muted-foreground truncate text-xs">{location}</div>}
+      </div>
+      <span className="text-muted-foreground shrink-0 font-mono text-xs tabular-nums">
+        {park.requests.toLocaleString()}
+      </span>
+    </div>
+  );
+  return park.url ? (
+    <a href={park.url} target="_blank" rel="noopener noreferrer" className="block">
+      {content}
+    </a>
+  ) : (
+    content
+  );
+}
+
 // ─── section heading ──────────────────────────────────────────────────────────
 
 function Section({
@@ -334,6 +361,7 @@ function QueueRow({ q }: { q: QueueEntry }) {
 function Dashboard({
   data,
   queueData,
+  popularData,
   savedPass,
   onLogout,
   onRefresh,
@@ -343,6 +371,7 @@ function Dashboard({
 }: {
   data: SystemHealthResponse;
   queueData: QueueStatusResponse | null;
+  popularData: PopularPark[] | null;
   savedPass: string;
   onLogout: () => void;
   onRefresh: () => void;
@@ -896,6 +925,17 @@ function Dashboard({
           </Section>
         )}
 
+        {/* Popular Parks */}
+        {popularData && popularData.length > 0 && (
+          <Section icon={Trophy} title="Popular Parks">
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+              {popularData.map((park) => (
+                <PopularParkRow key={park.id} park={park} />
+              ))}
+            </div>
+          </Section>
+        )}
+
         {/* Quick Actions */}
         <Section icon={Activity} title="Quick Actions">
           <div className="flex flex-wrap gap-3">
@@ -943,6 +983,7 @@ export default function AdminPage() {
   );
   const [data, setData] = useState<SystemHealthResponse | null>(null);
   const [queueData, setQueueData] = useState<QueueStatusResponse | null>(null);
+  const [popularData, setPopularData] = useState<PopularPark[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
@@ -956,9 +997,10 @@ export default function AdminPage() {
 
     try {
       const passParam = encodeURIComponent(pass);
-      const [healthRes, queueRes] = await Promise.all([
+      const [healthRes, queueRes, popularRes] = await Promise.all([
         fetch(`/api/admin/system-health?pass=${passParam}`),
         fetch(`/api/admin/queue-status?pass=${passParam}`),
+        fetch(`/api/parks/popular?limit=20`),
       ]);
 
       if (healthRes.status === 401 || healthRes.status === 403) {
@@ -972,12 +1014,14 @@ export default function AdminPage() {
         if (!background) setError(`API error: ${healthRes.status}`);
         return;
       }
-      const [healthJson, queueJson] = await Promise.all([
+      const [healthJson, queueJson, popularJson] = await Promise.all([
         healthRes.json() as Promise<SystemHealthResponse>,
         queueRes.ok ? (queueRes.json() as Promise<QueueStatusResponse>) : Promise.resolve(null),
+        popularRes.ok ? (popularRes.json() as Promise<PopularPark[]>) : Promise.resolve(null),
       ]);
       setData(healthJson);
       setQueueData(queueJson);
+      setPopularData(popularJson);
       setLastUpdated(new Date());
     } catch {
       if (!background) setError('Connection error.');
@@ -1050,6 +1094,7 @@ export default function AdminPage() {
     <Dashboard
       data={data}
       queueData={queueData}
+      popularData={popularData}
       savedPass={savedPass}
       onLogout={handleLogout}
       onRefresh={handleRefresh}

--- a/app/admin/parks/page.tsx
+++ b/app/admin/parks/page.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  ChevronLeft,
+  ChevronRight,
+  ExternalLink,
+  Loader2,
+  MapPin,
+  Pencil,
+  Search,
+  X,
+} from 'lucide-react';
+import { useAdminFetch } from '../_lib/admin-context';
+import { CrowdBadge, EmptyPanel, ErrorPanel, LoadingPanel, Section } from '../_lib/ui';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import type { ParksListResponse, SearchResponse, SearchResult } from '@/lib/api/admin-stats';
+
+const PAGE_SIZE = 25;
+
+const TYPE_STYLES: Record<string, string> = {
+  park: 'bg-primary/15 text-primary',
+  attraction: 'bg-blue-500/15 text-blue-400',
+  show: 'bg-purple-500/15 text-purple-400',
+  restaurant: 'bg-amber-500/15 text-amber-400',
+  location: 'bg-zinc-500/15 text-zinc-400',
+};
+
+function StatusPill({ status }: { status: string }) {
+  const operating = status === 'OPERATING';
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+        operating ? 'bg-emerald-500/15 text-emerald-400' : 'bg-zinc-500/15 text-zinc-400'
+      )}
+    >
+      {operating ? 'Open' : 'Closed'}
+    </span>
+  );
+}
+
+function SearchResults({ results }: { results: SearchResult[] }) {
+  if (results.length === 0) return <EmptyPanel label="No matches." />;
+  return (
+    <div className="space-y-1">
+      {results.map((r) => (
+        <Link
+          key={`${r.type}-${r.id}`}
+          href={r.url}
+          className="hover:border-primary/40 flex items-center gap-3 rounded-lg border border-border/60 bg-card px-3 py-2"
+        >
+          <span
+            className={cn(
+              'w-20 shrink-0 rounded-full px-2 py-0.5 text-center text-xs font-medium capitalize',
+              TYPE_STYLES[r.type] ?? TYPE_STYLES.location
+            )}
+          >
+            {r.type}
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{r.name}</p>
+            <p className="text-muted-foreground truncate text-xs">
+              {r.parentPark ? `${r.parentPark.name} · ` : ''}
+              {[r.city, r.country].filter(Boolean).join(', ')}
+            </p>
+          </div>
+          {r.status && <StatusPill status={r.status} />}
+          <ExternalLink className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+export default function ParksPage() {
+  const [query, setQuery] = useState('');
+  const [debounced, setDebounced] = useState('');
+  const [page, setPage] = useState(1);
+  const [searchData, setSearchData] = useState<SearchResponse | null>(null);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(query.trim()), 300);
+    return () => clearTimeout(id);
+  }, [query]);
+
+  const searchActive = debounced.length >= 3;
+  // Derived loading flag — true until the latest query has fresh results.
+  const searching = searchActive && searchData?.query !== debounced;
+
+  useEffect(() => {
+    if (!searchActive) return;
+    let cancelled = false;
+    fetch(`/api/search?q=${encodeURIComponent(debounced)}`, { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((d: SearchResponse) => {
+        if (!cancelled) setSearchData(d);
+      })
+      .catch(() => {
+        if (!cancelled) setSearchData(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [debounced, searchActive]);
+
+  const listEndpoint = searchActive ? null : `/api/parks-list?page=${page}&limit=${PAGE_SIZE}`;
+  const list = useAdminFetch<ParksListResponse>(listEndpoint);
+
+  const totalParks = list.data?.pagination.total;
+  const totalPages = list.data?.pagination.totalPages ?? 1;
+
+  const searchCount = useMemo(
+    () =>
+      searchData
+        ? Object.values(searchData.counts).reduce((sum, c) => sum + (c?.total ?? 0), 0)
+        : 0,
+    [searchData]
+  );
+
+  return (
+    <Section
+      icon={MapPin}
+      title="Parks"
+      action={
+        totalParks != null && !searchActive ? (
+          <span className="text-muted-foreground text-xs tabular-nums">{totalParks} parks</span>
+        ) : undefined
+      }
+    >
+      <div className="relative">
+        <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search parks, rides, shows…"
+          className="pl-9"
+        />
+        {query && (
+          <button
+            onClick={() => setQuery('')}
+            className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {searchActive ? (
+        searching ? (
+          <LoadingPanel label="Searching…" />
+        ) : (
+          <>
+            <p className="text-muted-foreground text-xs">
+              {searchCount} result{searchCount === 1 ? '' : 's'} for “{debounced}”
+            </p>
+            <SearchResults results={searchData?.results ?? []} />
+          </>
+        )
+      ) : list.error ? (
+        <ErrorPanel message={list.error} />
+      ) : !list.data ? (
+        <LoadingPanel label="Loading parks…" />
+      ) : (
+        <>
+          <Card className="border-border/60">
+            <CardContent className="p-0">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-border/60 text-muted-foreground border-b text-left text-xs uppercase">
+                      <th className="px-4 py-2 font-medium">Park</th>
+                      <th className="px-4 py-2 font-medium">Location</th>
+                      <th className="px-4 py-2 font-medium">Status</th>
+                      <th className="px-4 py-2 text-right font-medium">Avg wait</th>
+                      <th className="px-4 py-2 text-right font-medium">Rides</th>
+                      <th className="px-4 py-2 text-right font-medium">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {list.data.data.map((park) => {
+                      const stats = park.analytics?.statistics;
+                      return (
+                        <tr
+                          key={park.id}
+                          className="border-border/30 hover:bg-card/60 border-b last:border-0"
+                        >
+                          <td className="px-4 py-2">
+                            <Link href={park.url} className="hover:text-primary font-medium">
+                              {park.name}
+                            </Link>
+                          </td>
+                          <td className="text-muted-foreground px-4 py-2">
+                            {[park.city, park.country].filter(Boolean).join(', ') || '—'}
+                          </td>
+                          <td className="px-4 py-2">
+                            <div className="flex items-center gap-1.5">
+                              <StatusPill status={park.status} />
+                              {stats && <CrowdBadge level={stats.crowdLevel} />}
+                            </div>
+                          </td>
+                          <td className="px-4 py-2 text-right font-mono tabular-nums">
+                            {stats ? `${stats.avgWaitTime}'` : '—'}
+                          </td>
+                          <td className="text-muted-foreground px-4 py-2 text-right font-mono tabular-nums">
+                            {stats ? `${stats.operatingAttractions}/${stats.totalAttractions}` : '—'}
+                          </td>
+                          <td className="px-4 py-2 text-right">
+                            <button
+                              disabled
+                              title="Editing requires backend write endpoints (coming soon)"
+                              className="text-muted-foreground/50 inline-flex cursor-not-allowed items-center gap-1 rounded-md border border-border/40 px-2 py-1 text-xs"
+                            >
+                              <Pencil className="h-3 w-3" /> Edit
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-muted-foreground text-xs tabular-nums">
+              Page {page} of {totalPages}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={!list.data.pagination.hasPrevious || list.loading}
+                className="border-border/60 hover:border-primary/40 flex h-8 items-center gap-1 rounded-lg border px-3 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <ChevronLeft className="h-4 w-4" /> Prev
+              </button>
+              <button
+                onClick={() => setPage((p) => p + 1)}
+                disabled={!list.data.pagination.hasNext || list.loading}
+                className="border-border/60 hover:border-primary/40 flex h-8 items-center gap-1 rounded-lg border px-3 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {list.loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null} Next
+                <ChevronRight className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </Section>
+  );
+}

--- a/app/admin/parks/page.tsx
+++ b/app/admin/parks/page.tsx
@@ -3,10 +3,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
   ChevronLeft,
   ChevronRight,
   ExternalLink,
-  Loader2,
   MapPin,
   Pencil,
   Search,
@@ -17,9 +19,27 @@ import { CrowdBadge, EmptyPanel, ErrorPanel, LoadingPanel, Section } from '../_l
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
-import type { ParksListResponse, SearchResponse, SearchResult } from '@/lib/api/admin-stats';
+import type { ParkListItem, ParksListResponse, SearchResponse, SearchResult } from '@/lib/api/admin-stats';
 
 const PAGE_SIZE = 25;
+
+type SortKey = 'name' | 'location' | 'status' | 'avgWait' | 'rides';
+
+function sortValue(park: ParkListItem, key: SortKey): string | number {
+  const stats = park.analytics?.statistics;
+  switch (key) {
+    case 'name':
+      return park.name.toLowerCase();
+    case 'location':
+      return [park.country, park.city].filter(Boolean).join(' ').toLowerCase();
+    case 'status':
+      return park.status;
+    case 'avgWait':
+      return stats?.avgWaitTime ?? -1;
+    case 'rides':
+      return stats?.totalAttractions ?? -1;
+  }
+}
 
 const TYPE_STYLES: Record<string, string> = {
   park: 'bg-primary/15 text-primary',
@@ -89,11 +109,53 @@ function SearchResults({ results }: { results: SearchResult[] }) {
   );
 }
 
+function SortHeader({
+  label,
+  column,
+  active,
+  dir,
+  onSort,
+  align = 'left',
+}: {
+  label: string;
+  column: SortKey;
+  active: boolean;
+  dir: 'asc' | 'desc';
+  onSort: (key: SortKey) => void;
+  align?: 'left' | 'right';
+}) {
+  const Icon = !active ? ArrowUpDown : dir === 'asc' ? ArrowUp : ArrowDown;
+  return (
+    <th className={cn('px-4 py-2 font-medium', align === 'right' && 'text-right')}>
+      <button
+        onClick={() => onSort(column)}
+        className={cn(
+          'hover:text-foreground inline-flex items-center gap-1 transition-colors',
+          align === 'right' && 'flex-row-reverse',
+          active && 'text-foreground'
+        )}
+      >
+        {label}
+        <Icon className={cn('h-3 w-3', !active && 'opacity-40')} />
+      </button>
+    </th>
+  );
+}
+
 export default function ParksPage() {
   const [query, setQuery] = useState('');
   const [debounced, setDebounced] = useState('');
   const [page, setPage] = useState(1);
+  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({
+    key: 'name',
+    dir: 'asc',
+  });
   const [searchData, setSearchData] = useState<SearchResponse | null>(null);
+
+  function toggleSort(key: SortKey) {
+    setSort((s) => (s.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'asc' }));
+    setPage(1);
+  }
 
   useEffect(() => {
     const id = setTimeout(() => setDebounced(query.trim()), 300);
@@ -120,11 +182,26 @@ export default function ParksPage() {
     };
   }, [debounced, searchActive]);
 
-  const listEndpoint = searchActive ? null : `/api/parks-list?page=${page}&limit=${PAGE_SIZE}`;
+  // The dataset is small (~155 parks), so load it all once and sort/paginate
+  // client-side — the API only supports sorting by name/openStatus.
+  const listEndpoint = searchActive ? null : '/api/parks-list?page=1&limit=500';
   const list = useAdminFetch<ParksListResponse>(listEndpoint);
 
   const totalParks = list.data?.pagination.total;
-  const totalPages = list.data?.pagination.totalPages ?? 1;
+
+  const sorted = useMemo(() => {
+    const rows = list.data?.data ?? [];
+    const factor = sort.dir === 'asc' ? 1 : -1;
+    return [...rows].sort((a, b) => {
+      const av = sortValue(a, sort.key);
+      const bv = sortValue(b, sort.key);
+      if (typeof av === 'number' && typeof bv === 'number') return (av - bv) * factor;
+      return String(av).localeCompare(String(bv)) * factor;
+    });
+  }, [list.data, sort]);
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const pageItems = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   const searchCount = useMemo(
     () =>
@@ -185,16 +262,16 @@ export default function ParksPage() {
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-border/60 text-muted-foreground border-b text-left text-xs uppercase">
-                      <th className="px-4 py-2 font-medium">Park</th>
-                      <th className="px-4 py-2 font-medium">Location</th>
-                      <th className="px-4 py-2 font-medium">Status</th>
-                      <th className="px-4 py-2 text-right font-medium">Avg wait</th>
-                      <th className="px-4 py-2 text-right font-medium">Rides</th>
+                      <SortHeader label="Park" column="name" active={sort.key === 'name'} dir={sort.dir} onSort={toggleSort} />
+                      <SortHeader label="Location" column="location" active={sort.key === 'location'} dir={sort.dir} onSort={toggleSort} />
+                      <SortHeader label="Status" column="status" active={sort.key === 'status'} dir={sort.dir} onSort={toggleSort} />
+                      <SortHeader label="Avg wait" column="avgWait" active={sort.key === 'avgWait'} dir={sort.dir} onSort={toggleSort} align="right" />
+                      <SortHeader label="Rides" column="rides" active={sort.key === 'rides'} dir={sort.dir} onSort={toggleSort} align="right" />
                       <th className="px-4 py-2 text-right font-medium">Actions</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {list.data.data.map((park) => {
+                    {pageItems.map((park) => {
                       const stats = park.analytics?.statistics;
                       return (
                         <tr
@@ -246,17 +323,17 @@ export default function ParksPage() {
             <div className="flex items-center gap-2">
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={!list.data.pagination.hasPrevious || list.loading}
+                disabled={page <= 1}
                 className="border-border/60 hover:border-primary/40 flex h-8 items-center gap-1 rounded-lg border px-3 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-40"
               >
                 <ChevronLeft className="h-4 w-4" /> Prev
               </button>
               <button
-                onClick={() => setPage((p) => p + 1)}
-                disabled={!list.data.pagination.hasNext || list.loading}
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
                 className="border-border/60 hover:border-primary/40 flex h-8 items-center gap-1 rounded-lg border px-3 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-40"
               >
-                {list.loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null} Next
+                Next
                 <ChevronRight className="h-4 w-4" />
               </button>
             </div>

--- a/app/admin/parks/page.tsx
+++ b/app/admin/parks/page.tsx
@@ -43,34 +43,47 @@ function StatusPill({ status }: { status: string }) {
   );
 }
 
+function SearchResultRow({ r }: { r: SearchResult }) {
+  // Shows/restaurants have no own page — fall back to the parent park.
+  const target = r.url ?? r.parentPark?.url ?? null;
+  const inner = (
+    <>
+      <span
+        className={cn(
+          'w-20 shrink-0 rounded-full px-2 py-0.5 text-center text-xs font-medium capitalize',
+          TYPE_STYLES[r.type] ?? TYPE_STYLES.location
+        )}
+      >
+        {r.type}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{r.name}</p>
+        <p className="text-muted-foreground truncate text-xs">
+          {r.parentPark ? `${r.parentPark.name} · ` : ''}
+          {[r.city, r.country].filter(Boolean).join(', ')}
+        </p>
+      </div>
+      {r.status && <StatusPill status={r.status} />}
+      {target && <ExternalLink className="text-muted-foreground h-3.5 w-3.5 shrink-0" />}
+    </>
+  );
+  const className =
+    'flex items-center gap-3 rounded-lg border border-border/60 bg-card px-3 py-2';
+  return target ? (
+    <Link href={target} className={cn(className, 'hover:border-primary/40')}>
+      {inner}
+    </Link>
+  ) : (
+    <div className={className}>{inner}</div>
+  );
+}
+
 function SearchResults({ results }: { results: SearchResult[] }) {
   if (results.length === 0) return <EmptyPanel label="No matches." />;
   return (
     <div className="space-y-1">
       {results.map((r) => (
-        <Link
-          key={`${r.type}-${r.id}`}
-          href={r.url}
-          className="hover:border-primary/40 flex items-center gap-3 rounded-lg border border-border/60 bg-card px-3 py-2"
-        >
-          <span
-            className={cn(
-              'w-20 shrink-0 rounded-full px-2 py-0.5 text-center text-xs font-medium capitalize',
-              TYPE_STYLES[r.type] ?? TYPE_STYLES.location
-            )}
-          >
-            {r.type}
-          </span>
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium">{r.name}</p>
-            <p className="text-muted-foreground truncate text-xs">
-              {r.parentPark ? `${r.parentPark.name} · ` : ''}
-              {[r.city, r.country].filter(Boolean).join(', ')}
-            </p>
-          </div>
-          {r.status && <StatusPill status={r.status} />}
-          <ExternalLink className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-        </Link>
+        <SearchResultRow key={`${r.type}-${r.id}`} r={r} />
       ))}
     </div>
   );

--- a/app/admin/queues/page.tsx
+++ b/app/admin/queues/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { ListChecks } from 'lucide-react';
+import { useAdminFetch } from '../_lib/admin-context';
+import { EmptyPanel, ErrorPanel, LoadingPanel, Section } from '../_lib/ui';
+import type { QueueEntry, QueueStatusResponse } from '@/lib/api/admin';
+
+function QueueBadge({
+  count,
+  variant,
+}: {
+  count: number;
+  variant: 'active' | 'pending' | 'failed' | 'delayed';
+}) {
+  if (count === 0) return null;
+  const colors: Record<typeof variant, string> = {
+    active: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+    pending: 'bg-zinc-500/15 text-zinc-400 border-zinc-500/20',
+    failed: 'bg-red-500/15 text-red-400 border-red-500/20',
+    delayed: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-1.5 py-0.5 font-mono text-xs tabular-nums ${colors[variant]}`}
+    >
+      {count} {variant}
+    </span>
+  );
+}
+
+function QueueRow({ q }: { q: QueueEntry }) {
+  const hasActivity = q.active + q.pending + q.failed + q.delayed > 0;
+  return (
+    <div
+      className={`flex items-center justify-between gap-2 rounded-lg border px-3 py-2 text-sm transition-colors ${hasActivity ? 'border-border/60 bg-card' : 'border-border/30 bg-card/40'}`}
+    >
+      <span className={`font-mono text-xs ${hasActivity ? 'text-foreground' : 'text-muted-foreground'}`}>
+        {q.name}
+      </span>
+      <div className="flex items-center gap-1">
+        {hasActivity ? (
+          <>
+            <QueueBadge count={q.active} variant="active" />
+            <QueueBadge count={q.pending} variant="pending" />
+            <QueueBadge count={q.failed} variant="failed" />
+            <QueueBadge count={q.delayed} variant="delayed" />
+          </>
+        ) : (
+          <span className="text-muted-foreground text-xs">idle</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function QueuesPage() {
+  const { data, error } = useAdminFetch<QueueStatusResponse>('/api/admin/queue-status', true);
+
+  if (error) return <ErrorPanel message={error} />;
+  if (!data) return <LoadingPanel label="Loading queues…" />;
+
+  return (
+    <Section icon={ListChecks} title="Queues">
+      {data.queues.length === 0 ? (
+        <EmptyPanel label="No queues reported." />
+      ) : (
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {data.queues.map((q) => (
+            <QueueRow key={q.name} q={q} />
+          ))}
+        </div>
+      )}
+    </Section>
+  );
+}

--- a/app/admin/system/page.tsx
+++ b/app/admin/system/page.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { Clock, Cpu, Database, HardDrive, MemoryStick, Server, Zap } from 'lucide-react';
+import { useAdminFetch } from '../_lib/admin-context';
+import {
+  ErrorPanel,
+  KeyVal,
+  LoadingPanel,
+  Section,
+  formatUptime,
+  isDisk,
+  statusDot,
+} from '../_lib/ui';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { MetricBar } from '@/components/common/metric-bar';
+import type { SystemHealthResponse } from '@/lib/api/admin';
+
+export default function SystemPage() {
+  const { data, error } = useAdminFetch<SystemHealthResponse>('/api/admin/system-health', true);
+
+  if (error) return <ErrorPanel message={error} />;
+  if (!data) return <LoadingPanel label="Loading system metrics…" />;
+
+  const disk = data.host.disk;
+  const diskValid = isDisk(disk);
+  const maxLoad = data.host.cpu.cores;
+  const pgOk = data.postgres.status === 'connected';
+  const redisOk = data.redis.status === 'connected';
+
+  return (
+    <>
+      <Section icon={Server} title="Host">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Card className="border-border/60">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-muted-foreground flex items-center gap-2 text-xs font-medium tracking-wide uppercase">
+                <Cpu className="h-3.5 w-3.5" /> CPU
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <span
+                  className={`text-3xl font-bold tabular-nums ${(data.host.cpu.loadPct ?? 0) >= 80 ? 'text-red-400' : (data.host.cpu.loadPct ?? 0) >= 60 ? 'text-amber-400' : 'text-foreground'}`}
+                >
+                  {data.host.cpu.loadPct ?? '—'}%
+                </span>
+                <p className="text-muted-foreground mt-0.5 text-xs">{data.host.cpu.cores} Cores</p>
+                <p className="text-muted-foreground truncate text-xs" title={data.host.cpu.model}>
+                  {data.host.cpu.model.split(' ').slice(0, 3).join(' ')}
+                </p>
+              </div>
+              <div className="space-y-1.5">
+                <MetricBar label="1m" value={data.host.cpu.load['1m']} max={maxLoad} unit="" thresholds={[60, 80]} />
+                <MetricBar label="5m" value={data.host.cpu.load['5m']} max={maxLoad} unit="" thresholds={[60, 80]} />
+                <MetricBar label="15m" value={data.host.cpu.load['15m']} max={maxLoad} unit="" thresholds={[60, 80]} />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="border-border/60">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-muted-foreground flex items-center gap-2 text-xs font-medium tracking-wide uppercase">
+                <MemoryStick className="h-3.5 w-3.5" /> Memory
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <span className="text-3xl font-bold tabular-nums">
+                  {data.host.memory.usedGB.toFixed(1)}
+                  <span className="text-muted-foreground text-lg font-normal"> GB</span>
+                </span>
+                <p className="text-muted-foreground mt-0.5 text-xs">
+                  of {data.host.memory.totalGB.toFixed(1)} GB
+                </p>
+              </div>
+              <MetricBar
+                label="Usage"
+                value={data.host.memory.usedGB}
+                max={data.host.memory.totalGB}
+                unit=" GB"
+                pct={data.host.memory.usedPct}
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="border-border/60">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-muted-foreground flex items-center gap-2 text-xs font-medium tracking-wide uppercase">
+                <HardDrive className="h-3.5 w-3.5" /> Disk
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {diskValid ? (
+                <>
+                  <div>
+                    <span className="text-3xl font-bold tabular-nums">
+                      {(disk.totalGB - disk.freeGB).toFixed(0)}
+                      <span className="text-muted-foreground text-lg font-normal"> GB</span>
+                    </span>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      of {disk.totalGB.toFixed(0)} GB · {disk.freeGB.toFixed(0)} GB free
+                    </p>
+                  </div>
+                  <MetricBar
+                    label="Used"
+                    value={disk.totalGB - disk.freeGB}
+                    max={disk.totalGB}
+                    unit=" GB"
+                    pct={disk.usedPct}
+                    thresholds={[75, 90]}
+                  />
+                </>
+              ) : (
+                <p className="text-muted-foreground text-sm">N/A</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="border-border/60">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-muted-foreground flex items-center gap-2 text-xs font-medium tracking-wide uppercase">
+                <Clock className="h-3.5 w-3.5" /> Uptime
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-1">
+              <span className="text-3xl font-bold tabular-nums">
+                {formatUptime(data.host.uptimeHours)}
+              </span>
+              <p className="text-muted-foreground text-xs">
+                API v4 · {data.host.cpu.cores}-core server
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </Section>
+
+      <Section icon={Database} title="Database & Cache">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Card className="border-border/60">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center justify-between text-base">
+                <span className="flex items-center gap-2">
+                  <Database className="text-primary h-4 w-4" /> PostgreSQL
+                </span>
+                <span className="flex items-center gap-1.5 text-sm font-normal">
+                  {statusDot(pgOk)}
+                  <span className={pgOk ? 'text-emerald-400' : 'text-red-400'}>
+                    {pgOk ? 'Connected' : data.postgres.status}
+                  </span>
+                </span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <MetricBar
+                label={`Connections (active: ${data.postgres.activeQueries})`}
+                value={data.postgres.connections}
+                max={data.postgres.maxConnections}
+                unit=""
+                pct={data.postgres.connectionsPct ?? undefined}
+                thresholds={[60, 80]}
+              />
+              <div className="grid grid-cols-2 gap-3 pt-1 text-sm">
+                <KeyVal label="DB Size" value={`${data.postgres.dbSizeGB.toFixed(2)} GB`} />
+                <KeyVal
+                  label="Cache Hit"
+                  value={`${data.postgres.cacheHitPct?.toFixed(1) ?? '—'}%`}
+                  valueClass={(data.postgres.cacheHitPct ?? 0) >= 99 ? 'text-emerald-400' : 'text-amber-400'}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="border-border/60">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center justify-between text-base">
+                <span className="flex items-center gap-2">
+                  <Zap className="text-primary h-4 w-4" /> Redis
+                </span>
+                <span className="flex items-center gap-1.5 text-sm font-normal">
+                  {statusDot(redisOk)}
+                  <span className={redisOk ? 'text-emerald-400' : 'text-red-400'}>
+                    {redisOk ? 'Connected' : data.redis.status}
+                  </span>
+                </span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <MetricBar
+                label="Memory"
+                value={data.redis.usedMemoryMB}
+                max={data.redis.maxMemoryMB ?? data.redis.usedMemoryMB * 2}
+                unit=" MB"
+                thresholds={[60, 80]}
+              />
+              <div className="grid grid-cols-3 gap-3 pt-1 text-sm">
+                <KeyVal label="Keys" value={data.redis.keys.toLocaleString('en-GB')} />
+                <KeyVal label="Clients" value={data.redis.connectedClients} />
+                <KeyVal
+                  label="Hit Rate"
+                  value={`${data.redis.hitRatePct?.toFixed(1) ?? '—'}%`}
+                  valueClass={(data.redis.hitRatePct ?? 0) >= 80 ? 'text-emerald-400' : 'text-amber-400'}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/app/api/analytics/[...path]/route.ts
+++ b/app/api/analytics/[...path]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.park.fan';
+
+// Read-only passthrough for the public /v1/analytics/* endpoints.
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await params;
+  const incoming = new URL(request.url);
+  const apiUrl = new URL(`${API_BASE}/v1/analytics/${path.join('/')}`);
+  incoming.searchParams.forEach((value, key) => apiUrl.searchParams.set(key, value));
+
+  try {
+    const response = await fetch(apiUrl.toString(), { cache: 'no-store' });
+    const data = await response.json();
+    return NextResponse.json(data, {
+      status: response.status,
+      headers: { 'Cache-Control': 'no-store, must-revalidate' },
+    });
+  } catch (error) {
+    console.error('[Analytics proxy] Error:', error);
+    return NextResponse.json({ error: 'Failed to fetch analytics data' }, { status: 502 });
+  }
+}

--- a/app/api/ml/[...path]/route.ts
+++ b/app/api/ml/[...path]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.park.fan';
+
+// Read-only passthrough for the public /v1/ml/* stats endpoints, so the
+// client-side admin dashboard can fetch them without cross-origin requests.
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await params;
+  const incoming = new URL(request.url);
+  const apiUrl = new URL(`${API_BASE}/v1/ml/${path.join('/')}`);
+  incoming.searchParams.forEach((value, key) => apiUrl.searchParams.set(key, value));
+
+  try {
+    const response = await fetch(apiUrl.toString(), { cache: 'no-store' });
+    const data = await response.json();
+    return NextResponse.json(data, {
+      status: response.status,
+      headers: { 'Cache-Control': 'no-store, must-revalidate' },
+    });
+  } catch (error) {
+    console.error('[ML proxy] Error:', error);
+    return NextResponse.json({ error: 'Failed to fetch ML data' }, { status: 502 });
+  }
+}

--- a/app/api/parks-list/route.ts
+++ b/app/api/parks-list/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.park.fan';
+
+const ALLOWED_PARAMS = new Set([
+  'page',
+  'limit',
+  'sort',
+  'continent',
+  'country',
+  'city',
+  'continentSlug',
+  'countrySlug',
+  'citySlug',
+]);
+
+// Paginated park list for the admin parks table (proxy to /v1/parks).
+export async function GET(request: NextRequest) {
+  const incoming = new URL(request.url);
+  const apiUrl = new URL(`${API_BASE}/v1/parks`);
+  incoming.searchParams.forEach((value, key) => {
+    if (ALLOWED_PARAMS.has(key)) apiUrl.searchParams.set(key, value);
+  });
+
+  try {
+    const response = await fetch(apiUrl.toString(), { cache: 'no-store' });
+    const data = await response.json();
+    return NextResponse.json(data, {
+      status: response.status,
+      headers: { 'Cache-Control': 'no-store, must-revalidate' },
+    });
+  } catch (error) {
+    console.error('[Parks list proxy] Error:', error);
+    return NextResponse.json({ error: 'Failed to fetch parks' }, { status: 502 });
+  }
+}

--- a/app/api/parks/popular/route.ts
+++ b/app/api/parks/popular/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPopularParks } from '@/lib/api/parks';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const limitParam = new URL(request.url).searchParams.get('limit');
+  const parsed = limitParam ? Number.parseInt(limitParam, 10) : 20;
+  const limit = Number.isFinite(parsed) ? Math.min(Math.max(parsed, 1), 100) : 20;
+
+  try {
+    const data = await getPopularParks(limit);
+    return NextResponse.json(data, {
+      headers: { 'Cache-Control': 'no-store, must-revalidate' },
+    });
+  } catch (error) {
+    console.error('[Popular Parks API] Error:', error);
+    return NextResponse.json({ error: 'Failed to fetch popular parks' }, { status: 500 });
+  }
+}

--- a/lib/api/admin-stats.ts
+++ b/lib/api/admin-stats.ts
@@ -234,7 +234,7 @@ export interface SearchResult {
   id: string;
   name: string;
   slug: string;
-  url: string;
+  url?: string;
   continent?: string;
   country?: string;
   city?: string;

--- a/lib/api/admin-stats.ts
+++ b/lib/api/admin-stats.ts
@@ -1,0 +1,251 @@
+// Types for the read-only stats endpoints surfaced in the admin dashboard.
+// Sources: /v1/ml/*, /v1/analytics/*, /v1/parks (list).
+
+// ─── ML ─────────────────────────────────────────────────────────────────────
+
+export interface MlMetrics {
+  mae: number;
+  rmse: number;
+  mape: number;
+  r2Score: number;
+}
+
+export interface MlHealth {
+  timestamp: string;
+  status: string;
+  mlService: { status: string; url: string };
+  model: {
+    version: string;
+    trainedAt: string;
+    age: { days: number; hours: number; minutes: number };
+    isActive: boolean;
+    metrics: { mae: number; rmse: number; mape: number; r2: number };
+  };
+  message: string;
+}
+
+export interface MlLivePerformance extends MlMetrics {
+  totalPredictions: number;
+  matchedPredictions: number;
+  coveragePercent: number;
+  uniqueAttractions: number;
+  uniqueParks: number;
+  badge: string;
+}
+
+export interface MlPerformer {
+  attractionId: string;
+  attractionName: string;
+  parkName: string;
+  mae: number;
+  predictionsCount: number;
+}
+
+export interface MlDriftDaily {
+  date: string;
+  mae: number;
+  predictionsCount: number;
+}
+
+export interface MlDrift {
+  currentDrift: number;
+  threshold: number;
+  status: string;
+  trainingMae: number;
+  liveMae: number;
+  dailyMetrics: MlDriftDaily[];
+}
+
+export interface MlDashboard {
+  model: {
+    current: {
+      version: string;
+      trainedAt: string;
+      trainingDurationSeconds: number;
+      modelType: string;
+      fileSizeMB: number;
+    };
+    previous: { version: string; mae: number; r2: number; trainedAt: string };
+    configuration: { featureCount: number };
+    trainingData: {
+      startDate: string;
+      endDate: string;
+      totalSamples: number;
+      trainSamples: number;
+      validationSamples: number;
+      dataDurationDays: number;
+    };
+  };
+  performance: {
+    training: MlMetrics;
+    live: MlLivePerformance;
+    drift: MlDrift;
+    improvement: { maeDelta: number; maePercentChange: number; isImproving: boolean };
+  };
+  insights: {
+    topPerformers: MlPerformer[];
+    bottomPerformers: MlPerformer[];
+  };
+  system: {
+    nextTraining: string;
+    modelAge: { days: number; hours: number; minutes: number };
+    lastAccuracyCheck: { completedAt: string; newComparisonsAdded: number };
+  };
+}
+
+export interface MlAlert {
+  id: string;
+  alertType: string;
+  severity: string;
+  status: string;
+  title: string;
+  message: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MlAnomalyStats {
+  totalAnomalies: number;
+  byType: Record<string, number>;
+  bySeverity: Record<string, number>;
+  avgAnomalyScore: number;
+}
+
+// ─── Analytics ────────────────────────────────────────────────────────────────
+
+export interface RealtimePark {
+  id: string;
+  name: string;
+  slug: string;
+  city: string;
+  country: string;
+  averageWaitTime: number;
+  url: string;
+  totalAttractions: number;
+  operatingAttractions: number;
+  crowdLevel: string;
+}
+
+export interface RealtimeRide {
+  id: string;
+  name: string;
+  parkName: string;
+  parkCity: string;
+  parkCountry: string;
+  waitTime: number;
+  url: string;
+  crowdLevel: string;
+}
+
+export interface AnalyticsRealtime {
+  counts: {
+    openParks: number;
+    parks: number;
+    openAttractions: number;
+    attractions: number;
+    shows: number;
+    restaurants: number;
+    queueDataRecords: number;
+    totalWaitTime: number;
+  };
+  mostCrowdedPark: RealtimePark;
+  leastCrowdedPark: RealtimePark;
+  longestWaitRide: RealtimeRide;
+  shortestWaitRide: RealtimeRide;
+}
+
+export interface TickerItem {
+  parkName: string;
+  parkSlug: string;
+  country: string;
+  city: string;
+  attractionName: string;
+  attractionSlug: string;
+  waitTime: number;
+  trend: string;
+  crowdLevel: string;
+  url: string;
+}
+
+export interface AnalyticsTicker {
+  items: TickerItem[];
+  generatedAt: string;
+}
+
+export interface GeoLiveCountry {
+  slug: string;
+  openParkCount: number;
+}
+
+export interface GeoLiveContinent {
+  slug: string;
+  openParkCount: number;
+  countries: GeoLiveCountry[];
+}
+
+export interface AnalyticsGeoLive {
+  continents: GeoLiveContinent[];
+}
+
+// ─── Parks list  (GET /v1/parks) ────────────────────────────────────────────
+
+export interface ParkListItem {
+  id: string;
+  name: string;
+  slug: string;
+  url: string;
+  country: string | null;
+  city: string | null;
+  region: string | null;
+  continent: string | null;
+  timezone: string | null;
+  status: string;
+  hasOperatingSchedule: boolean;
+  analytics?: {
+    statistics?: {
+      avgWaitTime: number;
+      crowdLevel: string;
+      totalAttractions: number;
+      operatingAttractions: number;
+    };
+  };
+}
+
+export interface ParksPagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+}
+
+export interface ParksListResponse {
+  data: ParkListItem[];
+  pagination: ParksPagination;
+}
+
+// ─── Search  (GET /v1/search) ────────────────────────────────────────────────
+
+export type SearchResultType = 'park' | 'attraction' | 'show' | 'restaurant' | 'location';
+
+export interface SearchResult {
+  type: SearchResultType;
+  id: string;
+  name: string;
+  slug: string;
+  url: string;
+  continent?: string;
+  country?: string;
+  city?: string;
+  resort?: string;
+  status?: string;
+  load?: string;
+  parentPark?: { id: string; name: string; slug: string; url: string };
+}
+
+export interface SearchResponse {
+  query: string;
+  results: SearchResult[];
+  counts: Record<string, { returned: number; total: number }>;
+}

--- a/lib/api/parks.ts
+++ b/lib/api/parks.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
 import { api } from './client';
 import { withServerCache } from './server-cache';
-import type { ParkWithAttractions, AttractionResponse } from './types';
+import type { ParkWithAttractions, AttractionResponse, PopularPark } from './types';
 
 const PARK_MAX_AGE = 300; // 5 min — matches API Redis/Cloudflare cache
 
@@ -52,3 +52,15 @@ export const getAttractionByGeoPath = cache(
     );
   }
 );
+
+/**
+ * Get the most-requested parks, ranked by tracked request volume.
+ * Mirrors the popularity signal that drives cache prewarming.
+ * @param limit clamped to 1–100 by the API (default 20)
+ */
+export const getPopularParks = cache(async (limit = 20): Promise<PopularPark[]> => {
+  return api.get<PopularPark[]>('/v1/parks/popular', {
+    params: { limit },
+    cache: 'no-store',
+  });
+});

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -1130,3 +1130,20 @@ export interface CountrySummary {
   avgPeakMonths: number[];
   avgQuietMonths: number[];
 }
+
+// ============================================================================
+// Popular Parks  (GET /v1/parks/popular)
+// Parks ranked by tracked request volume — mirrors the cache-prewarm signal.
+// ============================================================================
+
+export interface PopularPark {
+  rank: number;
+  requests: number;
+  id: string;
+  name: string;
+  slug: string;
+  url: string | null;
+  country: string | null;
+  city: string | null;
+  continent: string | null;
+}


### PR DESCRIPTION
## Summary

Two related pieces of work on the admin dashboard:

### 1. Popular parks ranking
Wires the new backend endpoint from [v4.api.park.fan#59](https://github.com/PArns/v4.api.park.fan/pull/59) (`GET /v1/parks/popular` — most-requested parks, the signal that drives cache prewarming). Verified live via curl before integrating.

### 2. Multi-page admin redesign
Restructures the ~1080-line single-page admin into routed sub-pages behind a shared sidebar shell:

- **Shell** — a client provider holds the password gate (sessionStorage) and a global auto-refresh tick, so each page fetches only its own data. Sidebar nav + topbar (refresh/last-updated/logout).
- **Overview** — at-a-glance counts, health badges, live extremes (most/least crowded park, longest/shortest wait ride).
- **System** — host CPU/RAM/disk/uptime, PostgreSQL, Redis (migrated).
- **Queues** — queue status (migrated).
- **ML Models** — live training jobs (CatBoost/TFT progress), training-vs-live accuracy, drift, per-attraction best/worst predictions, anomaly stats + active alerts.
- **Analytics** — realtime counts, geographic activity, live ticker.
- **Parks** — paginated table (155 parks) + global search across parks/rides/shows/restaurants. Scaffolded for future CRUD (per-row Edit, disabled until backend write endpoints exist).
- **Maintenance** — the existing POST admin actions.

Adds read-only proxy routes for the public `/v1/ml/*`, `/v1/analytics/*` and `/v1/parks` endpoints so the client dashboard fetches without CORS.

## Note on CRUD
The Parks table is the groundwork for editing entries, but real CRUD needs **backend write endpoints** (the API currently exposes GET only). The Edit action is present but disabled until that lands.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all new/changed files
- [x] All proxy routes return 200 with data via dev server
- [x] All `/admin/*` routes compile and serve (HTTP 200)
- [ ] Visual/interaction check of the authenticated dashboard — requires the admin password, not available in this environment

https://claude.ai/code/session_01SCkzw7JtCQRQnXLXNmHyFc