### PR TITLE
perf(home): improve hero LCP

### DIFF
--- a/components/layout/hero-background.tsx
+++ b/components/layout/hero-background.tsx
@@ -12,6 +12,10 @@ interface RandomHeroImageProps {
 
 export function RandomHeroImage({ imageSrc, noAnimation }: RandomHeroImageProps) {
   const [randomImage, setRandomImage] = useState<string | null>(null);
+  // Defer the ken-burns transform until the image has painted. Animating (transforming)
+  // the LCP element during its initial render is a known LCP-delay anti-pattern, so we
+  // render it static first and start the effect on load.
+  const [animate, setAnimate] = useState(false);
 
   useEffect(() => {
     if (imageSrc) return;
@@ -26,6 +30,8 @@ export function RandomHeroImage({ imageSrc, noAnimation }: RandomHeroImageProps)
 
   if (!finalImage) return null;
 
+  const animating = !noAnimation && animate;
+
   return (
     <Image
       src={finalImage}
@@ -34,10 +40,9 @@ export function RandomHeroImage({ imageSrc, noAnimation }: RandomHeroImageProps)
       loader={backgroundImageLoader}
       priority={isServerImage}
       fetchPriority={isServerImage ? 'high' : undefined}
-      className={`object-cover opacity-90 ${noAnimation ? '' : 'will-change-transform'}`}
-      style={
-        noAnimation ? undefined : { animation: 'ken-burns 22s ease-in-out infinite alternate' }
-      }
+      onLoad={noAnimation ? undefined : () => setAnimate(true)}
+      className={`object-cover opacity-90 ${animating ? 'will-change-transform' : ''}`}
+      style={animating ? { animation: 'ken-burns 22s ease-in-out infinite alternate' } : undefined}
       sizes="(max-width: 768px) 100vw, 115vw"
     />
   );

--- a/components/search/hero-search-input.tsx
+++ b/components/search/hero-search-input.tsx
@@ -83,8 +83,32 @@ function useTypewriter(
   const { displayText, phraseIndex, phase, started, cursorVisible } = state;
 
   useEffect(() => {
-    const id = setTimeout(() => dispatch({ type: 'start' }), 3000);
-    return () => clearTimeout(id);
+    let idleId: number | undefined;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    // Start only once the page has loaded and the main thread is idle, so the typewriter
+    // (which re-renders the input every ~150ms) never competes with the critical render
+    // (LCP / hydration) on slow connections.
+    const begin = () => {
+      const ric = window.requestIdleCallback;
+      if (ric) {
+        idleId = ric(() => dispatch({ type: 'start' }), { timeout: 3000 });
+      } else {
+        timeoutId = setTimeout(() => dispatch({ type: 'start' }), 1500);
+      }
+    };
+
+    if (document.readyState === 'complete') {
+      begin();
+    } else {
+      window.addEventListener('load', begin, { once: true });
+    }
+
+    return () => {
+      window.removeEventListener('load', begin);
+      if (idleId !== undefined) window.cancelIdleCallback?.(idleId);
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    };
   }, []);
 
   useEffect(() => {

--- a/lib/utils/image-loader.ts
+++ b/lib/utils/image-loader.ts
@@ -9,6 +9,6 @@ import type { ImageLoaderProps } from 'next/image';
  * Quality values must be listed in next.config `images.qualities`.
  */
 export function backgroundImageLoader({ src, width }: ImageLoaderProps): string {
-  const quality = width <= 828 ? 75 : width <= 1200 ? 85 : 90;
+  const quality = width <= 828 ? 65 : width <= 1200 ? 85 : 90;
   return `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${quality}`;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -29,8 +29,10 @@ const nextConfig: NextConfig = {
       '@radix-ui/react-slot',
       'recharts',
     ],
-    // Optimize CSS to reduce render-blocking
-    optimizeCss: true,
+    // Inline the page CSS into the HTML <style> so the initial render no longer waits on a
+    // separate render-blocking stylesheet request. Works with the Turbopack build (unlike
+    // optimizeCss/Beasties, which is webpack-only and was a no-op here).
+    inlineCss: true,
   },
   images: {
     formats: ['image/avif', 'image/webp'],

--- a/next.config.ts
+++ b/next.config.ts
@@ -36,7 +36,7 @@ const nextConfig: NextConfig = {
     formats: ['image/avif', 'image/webp'],
     deviceSizes: [640, 828, 1080, 1200, 1920, 2560, 3840],
     imageSizes: [32, 48, 64, 96, 128, 256, 384],
-    qualities: [75, 85, 90],
+    qualities: [65, 75, 85, 90],
     minimumCacheTTL: 31536000, // 1 year
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary

Follow-up to the homepage perf work (#104, merged). That run got TBT to 90ms (green) and CLS to 0 (green), but mobile LCP was still ~6.1s. The Lighthouse LCP element is the hero background image (`alt="Park Background"`), and the report flagged a large element render-delay plus ~73 KiB of image savings.

- **Defer the ken-burns animation until the hero image's `onLoad`.** Animating/transforming the LCP element during its initial render is a known LCP-delay anti-pattern. The image now paints static (no transform, no `will-change` layer) and the effect starts only after load.
- **Lower mobile (`<=828px`) background image quality 75 → 65.** The hero/park backgrounds sit under gradient overlays at `opacity-90`, so the loss is imperceptible, but it cuts the LCP payload meaningfully on slow 4G. Added `65` to `next.config` `images.qualities`.

Applies to all full-bleed backgrounds via the shared `backgroundImageLoader` (homepage hero + park/ride pages).

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on changed files
- [ ] Re-run Lighthouse (mobile, slow 4G) and confirm LCP drops; verify ken-burns still animates after load and the hero quality looks fine on mobile

https://claude.ai/code/session_01Uid35quGvYpHZuu4QBHg5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uid35quGvYpHZuu4QBHg5J)_