### PR TITLE
perf(home): restore mobile hero quality 75 + 5min stale-while-revalidate homepage

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -73,7 +73,10 @@ import { GlossaryInject } from '@/components/glossary/glossary-inject';
 
 import type { Metadata } from 'next';
 
-export const revalidate = 60;
+// Stale-while-revalidate: serve the cached page instantly and regenerate in the
+// background. 5 min matches the underlying analytics/geo fetch caches; the live
+// sections (ticker, featured parks, nearby) additionally poll client-side.
+export const revalidate = 300;
 
 export async function generateStaticParams() {
   return locales.map((locale) => ({ locale }));

--- a/lib/utils/image-loader.ts
+++ b/lib/utils/image-loader.ts
@@ -9,6 +9,6 @@ import type { ImageLoaderProps } from 'next/image';
  * Quality values must be listed in next.config `images.qualities`.
  */
 export function backgroundImageLoader({ src, width }: ImageLoaderProps): string {
-  const quality = width <= 828 ? 65 : width <= 1200 ? 85 : 90;
+  const quality = width <= 828 ? 75 : width <= 1200 ? 85 : 90;
   return `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${quality}`;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -38,7 +38,7 @@ const nextConfig: NextConfig = {
     formats: ['image/avif', 'image/webp'],
     deviceSizes: [640, 828, 1080, 1200, 1920, 2560, 3840],
     imageSizes: [32, 48, 64, 96, 128, 256, 384],
-    qualities: [65, 75, 85, 90],
+    qualities: [75, 85, 90],
     minimumCacheTTL: 31536000, // 1 year
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary

- **Mobile hero quality zurück auf 75:** Commit `f464e9d` hatte die mobile (`width <= 828`) Hero-Background-Qualität von 75 → 65 gesenkt. Das brachte keinen messbaren LCP-Vorteil, daher zurückgesetzt auf 75. Die nun ungenutzte `65` wurde aus `next.config.ts` `images.qualities` entfernt.
- **Homepage als Stale-While-Revalidate (5 min):** `revalidate` von 60 → 300 erhöht. Die Seite bleibt vollständig server-gerendert (ISR), liefert sofort den gecachten Stand und regeneriert im Hintergrund. 300s passt zu den darunterliegenden analytics/geo Fetch-Caches. Live-Sektionen (Ticker, Featured Parks, Nearby) pollen zusätzlich client-seitig.

## Kontext / SSR-Analyse

Die Query-Infrastruktur (`@tanstack/react-query`, `QueryClientProvider`) steht bereits, und `LiveWaitTicker`, `FeaturedParksSectionClient` sowie `NearbyParksCard` laden ihre Daten schon client-seitig mit Polling nach. Statt eines größeren Client-Query-Umbaus wurde bewusst der einfache, robuste Weg gewählt: server-seitiges Rendering beibehalten und die TTL auf 5 min setzen. Für die Startseite ist leicht veralteter Content unkritisch.

## Test plan

- [ ] `pnpm build` lokal grün (Environment hier ohne `node_modules`)
- [ ] Mobile Hero-Image sichtbar in besserer Qualität (75)
- [ ] Homepage liefert gecachten Stand sofort, regeneriert nach 5 min im Hintergrund

https://claude.ai/code/session_01LUhysnr4WrNw1ELfYDnDSF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUhysnr4WrNw1ELfYDnDSF)_