### PR TITLE
feat: trigger maintenance page on 502 Bad Gateway

### DIFF
--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -17,7 +17,7 @@ export default function Error({ error, reset }: ErrorProps) {
   const t = useTranslations('common');
   const router = useRouter();
 
-  // Cloudflare 1033 (Argo Tunnel down) → the whole backend is unreachable.
+  // Backend unreachable (Cloudflare 1033 tunnel down or 502 Bad Gateway).
   // `digest` is the reliable signal in production (Next.js redacts the message
   // for server-thrown errors); the message check covers development.
   const isMaintenance = error.digest === API_MAINTENANCE_DIGEST || /1033/.test(error.message);

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -74,11 +74,10 @@ export async function apiFetch<T>(endpoint: string, options: FetchOptions = {}):
 
   if (!response.ok) {
     const body = await response.text().catch(() => '');
-    throw new ApiError(
-      response.status,
-      `API Error: ${response.statusText}`,
-      isCloudflareTunnelDown(body)
-    );
+    // 502 Bad Gateway means the API origin is unreachable, same as a 1033 tunnel
+    // outage, so both render the maintenance page.
+    const isMaintenance = response.status === 502 || isCloudflareTunnelDown(body);
+    throw new ApiError(response.status, `API Error: ${response.statusText}`, isMaintenance);
   }
 
   return response.json() as Promise<T>;


### PR DESCRIPTION
## Summary
- Extend the maintenance-page trigger (today's Cloudflare 1033 handling) to also fire on HTTP **502 Bad Gateway**, since a 502 from the API origin means the backend is just as unreachable.
- `apiFetch` now flags `isMaintenance` for `status === 502` in addition to the 1033 tunnel-down body check (`lib/api/client.ts`).
- Updated the related comment in `app/[locale]/error.tsx`; the existing `digest`-based detection already routes these to the maintenance page.

## Test plan
- [ ] Simulate a 502 API response and confirm the maintenance page renders / redirects to `/maintenance`.
- [ ] Confirm 1033 tunnel-down behavior still works.
- [ ] Confirm normal (non-error) responses are unaffected.

https://claude.ai/code/session_01E1vB2PMVTNbVWSvMcSFXsw

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1vB2PMVTNbVWSvMcSFXsw)_