### PR TITLE
Move timezone from header into the opening hours card

### DIFF
--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -5,8 +5,7 @@ import { generateAlternateLanguages } from '@/i18n/config';
 import { buildOpenGraphMetadata } from '@/lib/utils/metadata';
 import { translateCountry, translateContinent } from '@/lib/i18n/helpers';
 import { notFound, permanentRedirect } from 'next/navigation';
-import { Clock, MapPin } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
+import { MapPin } from 'lucide-react';
 import { Separator } from '@/components/ui/separator';
 import { getParkByGeoPath } from '@/lib/api/parks';
 import { catchNonFatal } from '@/lib/api/client';
@@ -296,12 +295,6 @@ export default async function ParkPage({ params }: ParkPageProps) {
                       <span>{cityName}</span>,{' '}
                       <span>{translateGeoSlug(tGeo, 'countries', country, countryName)}</span>
                     </address>
-                    {park.timezone && (
-                      <Badge variant="outline" className="gap-1 font-mono text-xs">
-                        <Clock className="h-3 w-3" />
-                        {park.timezone}
-                      </Badge>
-                    )}
                   </div>
                 </div>
                 {park.id && <ParkFavoriteButton parkId={park.id} />}

--- a/components/parks/park-time-info.tsx
+++ b/components/parks/park-time-info.tsx
@@ -244,6 +244,14 @@ export function ParkTimeInfo({
           </div>
         </div>
 
+        {/* Timezone */}
+        {timezone && (
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground text-sm font-medium">{t('timezone')}</span>
+            <span className="font-mono text-sm font-medium">{timezone}</span>
+          </div>
+        )}
+
         {/* Holiday/Bridge Day/School Vacation Badges */}
         {(todaySchedule?.isHoliday ||
           todaySchedule?.isBridgeDay ||

--- a/messages/de.json
+++ b/messages/de.json
@@ -349,6 +349,7 @@
     "weatherLabel": "Wetter",
     "todaySchedule": "Heutige Öffnungszeiten",
     "currentTime": "Aktuelle Uhrzeit",
+    "timezone": "Zeitzone",
     "openingHours": "Öffnungszeiten",
     "opensOn": "Öffnet am",
     "offseason": "OffSeason",

--- a/messages/en.json
+++ b/messages/en.json
@@ -306,6 +306,7 @@
     },
     "todaySchedule": "Today's Schedule",
     "currentTime": "Current Time",
+    "timezone": "Timezone",
     "openingHours": "Opening Hours",
     "opensOn": "Opens on",
     "offseason": "OffSeason",

--- a/messages/es.json
+++ b/messages/es.json
@@ -306,6 +306,7 @@
     },
     "todaySchedule": "Horario de Hoy",
     "currentTime": "Hora Actual",
+    "timezone": "Zona horaria",
     "openingHours": "Horario de apertura",
     "opensOn": "Abre el",
     "offseason": "Fuera de Temporada",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -306,6 +306,7 @@
     },
     "todaySchedule": "Programme du Jour",
     "currentTime": "Heure Actuelle",
+    "timezone": "Fuseau horaire",
     "openingHours": "Heures d'Ouverture",
     "opensOn": "Ouvre le",
     "offseason": "Hors Saison",

--- a/messages/it.json
+++ b/messages/it.json
@@ -306,6 +306,7 @@
     },
     "todaySchedule": "Programma di oggi",
     "currentTime": "Ora attuale",
+    "timezone": "Fuso orario",
     "openingHours": "Orari di apertura",
     "opensOn": "Apre il",
     "offseason": "Fuori stagione",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -306,6 +306,7 @@
     },
     "todaySchedule": "Programma Vandaag",
     "currentTime": "Huidige Tijd",
+    "timezone": "Tijdzone",
     "openingHours": "Openingstijden",
     "opensOn": "Opent op",
     "offseason": "Buiten Seizoen",


### PR DESCRIPTION
## Was

Die Zeitzone wurde bisher als Badge im Seitenkopf (neben Ort/Land) angezeigt. Auf Wunsch wandert sie nun als eigener, beschrifteter Eintrag in die „Heutige Öffnungszeiten“-Karte – direkt unter der aktuellen Uhrzeit.

## Änderungen

- **`components/parks/park-time-info.tsx`**: Neue Zeile „Zeitzone: Europe/Berlin" unterhalb der „Aktuelle Uhrzeit"-Zeile (gleiches Label/Wert-Layout wie die übrigen Zeilen, Wert in Mono-Font).
- **`app/[locale]/parks/.../page.tsx`**: Zeitzonen-Badge aus dem Header entfernt; nicht mehr genutzte `Clock`- und `Badge`-Imports entfernt.
- **`messages/*.json`**: Neuer Übersetzungsschlüssel `parks.timezone` für alle Sprachen (DE „Zeitzone", EN „Timezone", ES „Zona horaria", FR „Fuseau horaire", IT „Fuso orario", NL „Tijdzone").

`pnpm validate:translations` läuft sauber durch (alle Sprachen synchron).

https://claude.ai/code/session_01HKAabNRfUQ7LBq1nFeYUQV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKAabNRfUQ7LBq1nFeYUQV)_