### PR TITLE
feat(weather): Vorabwarnung vs. dringliche Warnung bei Unwetter

### DIFF
--- a/components/parks/weather-nowcast-banner.tsx
+++ b/components/parks/weather-nowcast-banner.tsx
@@ -55,6 +55,11 @@ const minutesUntil = (iso: string | null | undefined, now: number): number | nul
  *  (storm/hail/thunderstorm) have no gate and show as soon as they're forecast. */
 const RAIN_LEAD_MINUTES = 60;
 
+/** When a severe event (storm/hail/thunderstorm) is at most this many minutes
+ *  away we escalate from a calm pre-warning to the urgent "seek shelter" wording.
+ *  Beyond this lead time we keep it informational and drop the shelter advice. */
+const WARNING_LEAD_MINUTES = 30;
+
 /**
  * Pick the highest-priority warning to surface. Order (per spec):
  *  1. storm (gusts >= 75 km/h)
@@ -206,7 +211,8 @@ export function WeatherNowcastBanner({
         data.peakWindGustsKmh != null ? formatWindSpeed(data.peakWindGustsKmh, unit) : '?';
       if (banner.state === 'starting') {
         const mins = minutesUntil(banner.startsAt, now) ?? 0;
-        body = t('storm.bodyInMin', { duration: formatShortDuration(mins, locale), gusts });
+        const key = mins <= WARNING_LEAD_MINUTES ? 'storm.bodyInMinSoon' : 'storm.bodyInMin';
+        body = t(key, { duration: formatShortDuration(mins, locale), gusts });
       } else {
         const endsIn = minutesUntil(banner.endsAt, now);
         body =
@@ -220,7 +226,8 @@ export function WeatherNowcastBanner({
       heading = t('hail.heading');
       if (banner.state === 'starting') {
         const mins = minutesUntil(banner.startsAt, now) ?? 0;
-        body = t('hail.bodyInMin', { duration: formatShortDuration(mins, locale) });
+        const key = mins <= WARNING_LEAD_MINUTES ? 'hail.bodyInMinSoon' : 'hail.bodyInMin';
+        body = t(key, { duration: formatShortDuration(mins, locale) });
       } else {
         const endsIn = minutesUntil(banner.endsAt, now);
         body =
@@ -234,7 +241,9 @@ export function WeatherNowcastBanner({
       heading = t('thunderstorm.heading');
       if (banner.state === 'starting') {
         const mins = minutesUntil(banner.startsAt, now) ?? 0;
-        body = t('thunderstorm.bodyInMin', { duration: formatShortDuration(mins, locale) });
+        const key =
+          mins <= WARNING_LEAD_MINUTES ? 'thunderstorm.bodyInMinSoon' : 'thunderstorm.bodyInMin';
+        body = t(key, { duration: formatShortDuration(mins, locale) });
       } else {
         const endsIn = minutesUntil(banner.endsAt, now);
         body =

--- a/messages/de.json
+++ b/messages/de.json
@@ -311,19 +311,22 @@
       "thunderstorm": {
         "heading": "Gewitterwarnung",
         "bodyNow": "Gewitter im Park — bitte geschützten Bereich aufsuchen.",
-        "bodyInMin": "Gewitter in ca. {duration} — bitte Schutz aufsuchen.",
+        "bodyInMin": "Gewitter in ca. {duration} erwartet.",
+        "bodyInMinSoon": "Gewitter in ca. {duration} — bitte Schutz aufsuchen.",
         "bodyEndsInMin": "Gewitter aktiv — noch ca. {duration}"
       },
       "hail": {
         "heading": "Hagelwarnung",
         "bodyNow": "Hagel im Park — bitte geschützten Bereich aufsuchen.",
-        "bodyInMin": "Hagel in ca. {duration} — bitte Schutz aufsuchen.",
+        "bodyInMin": "Hagel in ca. {duration} erwartet.",
+        "bodyInMinSoon": "Hagel in ca. {duration} — bitte Schutz aufsuchen.",
         "bodyEndsInMin": "Hagel aktiv — noch ca. {duration}"
       },
       "storm": {
         "heading": "Sturmwarnung",
         "bodyNow": "Sturmböen bis {gusts} aktuell.",
         "bodyInMin": "Sturmböen bis {gusts} in ca. {duration} erwartet.",
+        "bodyInMinSoon": "Sturmböen bis {gusts} in ca. {duration} — bitte Schutz aufsuchen.",
         "bodyEndsInMin": "Sturmböen bis {gusts} — noch ca. {duration}"
       },
       "precipTimeline": "Niederschlagsverlauf bis {until}, Spitze {max} mm pro 15 Min.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -460,18 +460,21 @@
         "heading": "Thunderstorm warning",
         "bodyNow": "Thunderstorm at the park right now — head to a sheltered area.",
         "bodyInMin": "Thunderstorm expected in about {duration}.",
+        "bodyInMinSoon": "Thunderstorm in about {duration} — head to a sheltered area.",
         "bodyEndsInMin": "Thunderstorm in progress — ends in about {duration}."
       },
       "hail": {
         "heading": "Hail warning",
         "bodyNow": "Hail at the park right now — find a sheltered area.",
-        "bodyInMin": "Hail expected in about {duration} — find a sheltered area.",
+        "bodyInMin": "Hail expected in about {duration}.",
+        "bodyInMinSoon": "Hail in about {duration} — find a sheltered area.",
         "bodyEndsInMin": "Hail in progress — ends in about {duration}."
       },
       "storm": {
         "heading": "Storm warning",
         "bodyNow": "Strong wind gusts up to {gusts} right now.",
         "bodyInMin": "Strong wind gusts up to {gusts} expected in about {duration}.",
+        "bodyInMinSoon": "Strong wind gusts up to {gusts} in about {duration} — find a sheltered area.",
         "bodyEndsInMin": "Strong wind gusts up to {gusts} — ends in about {duration}."
       },
       "precipTimeline": "Precipitation forecast until {until}, peak {max} mm per 15 min.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -459,19 +459,22 @@
       "thunderstorm": {
         "heading": "Aviso de tormenta",
         "bodyNow": "Tormenta en curso — busca un lugar resguardado.",
-        "bodyInMin": "Tormenta en unos {duration} — busca un lugar resguardado.",
+        "bodyInMin": "Tormenta prevista en unos {duration}.",
+        "bodyInMinSoon": "Tormenta en unos {duration} — busca un lugar resguardado.",
         "bodyEndsInMin": "Tormenta en curso — termina en unos {duration}."
       },
       "hail": {
         "heading": "Aviso de granizo",
         "bodyNow": "Granizo en curso — busca un lugar resguardado.",
-        "bodyInMin": "Granizo en unos {duration} — busca un lugar resguardado.",
+        "bodyInMin": "Granizo previsto en unos {duration}.",
+        "bodyInMinSoon": "Granizo en unos {duration} — busca un lugar resguardado.",
         "bodyEndsInMin": "Granizo en curso — termina en unos {duration}."
       },
       "storm": {
         "heading": "Aviso de tormenta de viento",
         "bodyNow": "Rachas de viento de hasta {gusts} en este momento.",
         "bodyInMin": "Rachas de viento de hasta {gusts} previstas en unos {duration}.",
+        "bodyInMinSoon": "Rachas de viento de hasta {gusts} en unos {duration} — busca un lugar resguardado.",
         "bodyEndsInMin": "Rachas de viento de hasta {gusts} — terminan en unos {duration}."
       },
       "precipTimeline": "Pronóstico de precipitación hasta {until}, máximo {max} mm por 15 min.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -460,18 +460,21 @@
         "heading": "Alerte orage",
         "bodyNow": "Orage en cours — rejoignez un endroit abrité.",
         "bodyInMin": "Orage prévu dans environ {duration}.",
+        "bodyInMinSoon": "Orage dans environ {duration} — rejoignez un endroit abrité.",
         "bodyEndsInMin": "Orage en cours — se termine dans environ {duration}."
       },
       "hail": {
         "heading": "Alerte grêle",
         "bodyNow": "Grêle en cours — rejoignez un endroit abrité.",
-        "bodyInMin": "Grêle prévue dans environ {duration} — rejoignez un endroit abrité.",
+        "bodyInMin": "Grêle prévue dans environ {duration}.",
+        "bodyInMinSoon": "Grêle dans environ {duration} — rejoignez un endroit abrité.",
         "bodyEndsInMin": "Grêle en cours — se termine dans environ {duration}."
       },
       "storm": {
         "heading": "Alerte tempête",
         "bodyNow": "Rafales jusqu'à {gusts} en cours.",
         "bodyInMin": "Rafales jusqu'à {gusts} prévues dans environ {duration}.",
+        "bodyInMinSoon": "Rafales jusqu'à {gusts} dans environ {duration} — rejoignez un endroit abrité.",
         "bodyEndsInMin": "Rafales jusqu'à {gusts} — se terminent dans environ {duration}."
       },
       "precipTimeline": "Prévisions de précipitations jusquà {until}, pic de {max} mm par 15 min.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -459,19 +459,22 @@
       "thunderstorm": {
         "heading": "Allerta temporale",
         "bodyNow": "Temporale in corso — cerca un'area riparata.",
-        "bodyInMin": "Temporale tra circa {duration}.",
+        "bodyInMin": "Temporale previsto tra circa {duration}.",
+        "bodyInMinSoon": "Temporale tra circa {duration} — cerca un'area riparata.",
         "bodyEndsInMin": "Temporale in corso — finisce tra circa {duration}."
       },
       "hail": {
         "heading": "Allerta grandine",
         "bodyNow": "Grandine in corso — cerca un'area riparata.",
-        "bodyInMin": "Grandine tra circa {duration} — cerca un'area riparata.",
+        "bodyInMin": "Grandine prevista tra circa {duration}.",
+        "bodyInMinSoon": "Grandine tra circa {duration} — cerca un'area riparata.",
         "bodyEndsInMin": "Grandine in corso — finisce tra circa {duration}."
       },
       "storm": {
         "heading": "Allerta tempesta",
         "bodyNow": "Raffiche fino a {gusts} in corso.",
         "bodyInMin": "Raffiche fino a {gusts} previste tra circa {duration}.",
+        "bodyInMinSoon": "Raffiche fino a {gusts} tra circa {duration} — cerca un'area riparata.",
         "bodyEndsInMin": "Raffiche fino a {gusts} — finiscono tra circa {duration}."
       },
       "precipTimeline": "Previsione di precipitazioni fino alle {until}, picco {max} mm ogni 15 min.",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -459,19 +459,22 @@
       "thunderstorm": {
         "heading": "Onweerswaarschuwing",
         "bodyNow": "Onweer in het park — zoek een beschutte plek.",
-        "bodyInMin": "Onweer over ongeveer {duration} — zoek een beschutte plek.",
+        "bodyInMin": "Onweer verwacht over ongeveer {duration}.",
+        "bodyInMinSoon": "Onweer over ongeveer {duration} — zoek een beschutte plek.",
         "bodyEndsInMin": "Onweer actief — stopt over ongeveer {duration}."
       },
       "hail": {
         "heading": "Hagelwaarschuwing",
         "bodyNow": "Hagel in het park — zoek een beschutte plek.",
-        "bodyInMin": "Hagel over ongeveer {duration} — zoek een beschutte plek.",
+        "bodyInMin": "Hagel verwacht over ongeveer {duration}.",
+        "bodyInMinSoon": "Hagel over ongeveer {duration} — zoek een beschutte plek.",
         "bodyEndsInMin": "Hagel actief — stopt over ongeveer {duration}."
       },
       "storm": {
         "heading": "Stormwaarschuwing",
         "bodyNow": "Windstoten tot {gusts} op dit moment.",
         "bodyInMin": "Windstoten tot {gusts} verwacht over ongeveer {duration}.",
+        "bodyInMinSoon": "Windstoten tot {gusts} over ongeveer {duration} — zoek een beschutte plek.",
         "bodyEndsInMin": "Windstoten tot {gusts} — stopt over ongeveer {duration}."
       },
       "precipTimeline": "Neerslagverwachting tot {until}, piek {max} mm per 15 min.",


### PR DESCRIPTION
## Was

Wetterwarnungen für **Sturm, Hagel und Gewitter** verwenden jetzt unterschiedliche Texte je nach Vorlaufzeit:

- **> 30 Min. (Vorabwarnung):** ruhiger, informativer Prognose-Ton **ohne** „bitte Schutz aufsuchen". Z. B. _„Gewitter in ca. 2:10 Std. erwartet."_
- **≤ 30 Min. (dringliche Warnung):** eskalierter Text **mit** Schutz-Hinweis. Z. B. _„Gewitter in ca. 18 Min. — bitte Schutz aufsuchen."_

Damit erscheint die „Schutz aufsuchen"-Aufforderung erst, wenn das Ereignis wirklich nah ist – vorher nur eine sachliche Vorwarnung.

## Wie

- Neuer Schwellwert `WARNING_LEAD_MINUTES = 30` in `weather-nowcast-banner.tsx`.
- Im `starting`-Zustand wählt die Komponente für storm/hail/thunderstorm zwischen `bodyInMin` (Vorabwarnung) und neuem `bodyInMinSoon` (dringlich).
- Neuer Key `bodyInMinSoon` in allen 6 Sprachen (de/en/fr/it/es/nl); `bodyInMin` wurde auf den neutralen Vorab-Wortlaut umgestellt.

Regen bleibt unverändert (keine Schutz-Aufforderung, ohnehin nur 60-Min-Vorwarnfenster).

## Checks

- ✅ `pnpm validate:translations` — alle Locales synchron
- ✅ ESLint auf geänderter Komponente sauber

https://claude.ai/code/session_01G3GmiDzJUoMuHmudqfYJ8c

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3GmiDzJUoMuHmudqfYJ8c)_