### PR TITLE
fix(analytics): enable Umami Web Vitals collection

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -144,6 +144,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
             data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
             data-domains="park.fan"
             data-do-not-track="true"
+            data-performance="true"
             strategy="afterInteractive"
           />
         )}


### PR DESCRIPTION
## Problem

The Umami **Web Vitals / Performance** report (LCP, INP, CLS, FCP, TTFB) stays empty — every metric shows `0` and **Sample size: 0** — even though pageviews are tracked (the dashboard shows live "Online" visitors).

## Root cause

Umami's native Web Vitals report is **only** populated when the tracker script is loaded with `data-performance="true"` (feature introduced in Umami v3.1.0). Our `<Script>` tag in `app/[locale]/layout.tsx` was missing that attribute, so the tracker never collected/sent Core Web Vitals → the Performance page can never fill up.

The existing `WebVitalsReporter` (`components/analytics/web-vitals-reporter.tsx`) sends `web-vital-inp` / `web-vital-lcp` / `web-vital-cls` as **custom events**. Those land in the **Events** list — they do **not** feed the native Web Vitals report, so they couldn't fix the empty Performance page.

## Fix

Add `data-performance="true"` to the Umami `<Script>` tag.

## Notes / follow-ups (not changed here)

- **`data-do-not-track="true"`** is still set — events are dropped for any visitor with Do Not Track enabled (Firefox/Brave/privacy setups). Intentional privacy behavior, but it does reduce volume; worth a conscious decision.
- **`data-domains="park.fan"`** means events are only sent when the hostname is exactly `park.fan` — nothing is tracked on `localhost`, Vercel preview URLs, or a `www.` host. Keep this in mind when testing.
- Requires the self-hosted Umami instance to be **v3.1.0+** for the Web Vitals feature (the dashboard UI with the p50/p75/p95 selector indicates it already is).
- The custom `web-vital-*` events are now partly redundant with the native feature, but they carry extra **INP attribution** (target selector, phase breakdown) that the native report doesn't, so they're worth keeping.

https://claude.ai/code/session_01Rc6BAWtNViQEsVN1tN8dVM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rc6BAWtNViQEsVN1tN8dVM)_