### PR TITLE
fix(i18n): add missing geo.countries.malaysia in all locales

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -704,6 +704,7 @@
       "japan": "Japan",
       "china": "China",
       "canada": "Kanada",
+      "malaysia": "Malaysia",
       "mexico": "Mexiko",
       "hong-kong": "Hongkong",
       "south-korea": "Südkorea",

--- a/messages/en.json
+++ b/messages/en.json
@@ -704,6 +704,7 @@
       "japan": "Japan",
       "china": "China",
       "canada": "Canada",
+      "malaysia": "Malaysia",
       "mexico": "Mexico",
       "hong-kong": "Hong Kong",
       "south-korea": "South Korea",

--- a/messages/es.json
+++ b/messages/es.json
@@ -704,6 +704,7 @@
       "japan": "Japón",
       "china": "China",
       "canada": "Canadá",
+      "malaysia": "Malasia",
       "mexico": "México",
       "hong-kong": "Hong Kong",
       "south-korea": "Corea del Sur",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -704,6 +704,7 @@
       "japan": "Japon",
       "china": "Chine",
       "canada": "Canada",
+      "malaysia": "Malaisie",
       "mexico": "Mexique",
       "hong-kong": "Hong Kong",
       "south-korea": "Corée du Sud",

--- a/messages/it.json
+++ b/messages/it.json
@@ -704,6 +704,7 @@
       "japan": "Giappone",
       "china": "Cina",
       "canada": "Canada",
+      "malaysia": "Malesia",
       "mexico": "Messico",
       "hong-kong": "Hong Kong",
       "south-korea": "Corea del Sud",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -704,6 +704,7 @@
       "japan": "Japan",
       "china": "China",
       "canada": "Canada",
+      "malaysia": "Maleisië",
       "mexico": "Mexico",
       "hong-kong": "Hongkong",
       "south-korea": "Zuid-Korea",


### PR DESCRIPTION
## Problem

Static generation of the geo pages crashed with `MISSING_MESSAGE: geo.countries.malaysia` (first surfaced on `fr`/`it` during `generateMetadata`). The key was missing in **every** locale, while the API geo structure exposes a Malaysia country — so the build broke once a Malaysia park was reached.

## Fix

Added `geo.countries.malaysia` to all six locales:

| Locale | Value |
| --- | --- |
| de | Malaysia |
| en | Malaysia |
| es | Malasia |
| fr | Malaisie |
| it | Malesia |
| nl | Maleisië |

## Verification

- Diffed the **live** `api.park.fan` geo structure against the translation keys: all **23** API country slugs now have a translation key (was 1 missing).
- `pnpm validate:translations` → **"Keys missing in locales: NO / All translations are synchronized with master!"**
- `prettier --check messages/*.json` clean.

https://claude.ai/code/session_01L6zzAKjHf9TQ7tKJ4rJodd

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6zzAKjHf9TQ7tKJ4rJodd)_