### PR TITLE
fix(i18n): Vary header on locale redirects + SEO title/keyword sharpening

### DIFF
--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/[attraction]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/[attraction]/page.tsx
@@ -1,5 +1,5 @@
 import { getTranslations, setRequestLocale } from 'next-intl/server';
-import { generateAlternateLanguages } from '@/i18n/config';
+import { generateAlternateLanguages, locales } from '@/i18n/config';
 import { buildOpenGraphMetadata } from '@/lib/utils/metadata';
 import { translateCountry, translateContinent } from '@/lib/i18n/helpers';
 import { notFound } from 'next/navigation';
@@ -8,7 +8,7 @@ import { MapPin } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { SeasonalBadge } from '@/components/parks/seasonal-badge';
 import { Separator } from '@/components/ui/separator';
-import { getParkByGeoPath, getAttractionByGeoPath } from '@/lib/api/parks';
+import { getParkByGeoPath, getAttractionByGeoPath, getPopularParks } from '@/lib/api/parks';
 import { catchNonFatal } from '@/lib/api/client';
 import { BreadcrumbNav } from '@/components/common/breadcrumb-nav';
 import type { Metadata } from 'next';
@@ -139,11 +139,32 @@ export async function generateMetadata({ params }: AttractionPageProps): Promise
 
 export const revalidate = 300;
 
-// Static-on-demand (ISR): we don't prebuild the long tail of attractions, but returning []
-// opts the route into static generation + edge caching (revalidate above) instead of
-// per-request dynamic rendering. Live wait times are refreshed client-side.
-export function generateStaticParams() {
-  return [];
+// Prebuild the headliner attractions of the most-requested parks (× all locales) so the
+// long tail's cold first render is eliminated; every other attraction stays on-demand ISR
+// (dynamicParams defaults to true). Bounded by the constants below to keep build time/API
+// load in check. Resilient: a failed park fetch just skips that park's prebuild.
+const PREBUILD_PARK_LIMIT = 15;
+const HEADLINERS_PER_PARK = 4;
+
+export async function generateStaticParams() {
+  const popular = await getPopularParks(PREBUILD_PARK_LIMIT).catch(() => []);
+
+  const geoPaths = popular
+    .map((p) => p.url?.replace(/^\/v1\/parks\//, '').split('/'))
+    .filter((seg): seg is [string, string, string, string] => !!seg && seg.length === 4);
+
+  const perPark = await Promise.all(
+    geoPaths.map(async ([continent, country, city, park]) => {
+      const data = await getParkByGeoPath(continent, country, city, park).catch(() => null);
+      return (data?.attractions ?? [])
+        .filter((a) => a.isHeadliner)
+        .slice(0, HEADLINERS_PER_PARK)
+        .map((a) => ({ continent, country, city, park, attraction: a.slug }));
+    })
+  );
+
+  const base = perPark.flat();
+  return locales.flatMap((locale) => base.map((p) => ({ locale, ...p })));
 }
 
 export default async function AttractionPage({ params }: AttractionPageProps) {

--- a/components/seo/structured-data.tsx
+++ b/components/seo/structured-data.tsx
@@ -303,14 +303,25 @@ export function ShowsStructuredData({
 
   if (showsWithTimes.length === 0) return null;
 
-  // Generate Event schema for each show time
+  // One Event per show (not per showtime): a popular park can have 100+ daily
+  // showtimes, which previously emitted 100+ near-identical Event blocks (~100KB
+  // of JSON-LD). A single representative Event per show keeps the rich-result
+  // value; the remaining showtimes are preserved via eventSchedule.
   const parkBgImage = getParkBackgroundImage(park.slug);
-  const events = showsWithTimes.flatMap((show) =>
-    (show.showtimes || []).map((showtime) => ({
+  const events = showsWithTimes.map((show) => {
+    const startTimes = (show.showtimes || []).map((s) => s.startTime).filter(Boolean);
+    return {
       '@context': 'https://schema.org' as const,
       '@type': 'Event' as const,
       name: stripNewPrefix(show.name),
-      startDate: `${date}T${showtime.startTime}`,
+      startDate: `${date}T${startTimes[0]}`,
+      ...(startTimes.length > 1 && {
+        eventSchedule: {
+          '@type': 'Schedule' as const,
+          startDate: date,
+          byDayTime: startTimes,
+        },
+      }),
       image: parkBgImage ? `https://park.fan${parkBgImage}` : `${SITE_URL}/logo-big.png`,
       location: {
         '@type': 'Place' as const,
@@ -324,8 +335,8 @@ export function ShowsStructuredData({
       },
       eventStatus: 'https://schema.org/EventScheduled' as const,
       eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode' as const,
-    }))
-  );
+    };
+  });
 
   return (
     <>

--- a/lib/faq/attraction-faq.ts
+++ b/lib/faq/attraction-faq.ts
@@ -32,11 +32,26 @@ export function buildAttractionFaqItems(
     });
   }
 
-  items.push({
-    iconName: 'Clock',
-    question: t('waitTimeQ', { attraction: attractionName }),
-    answer: t('waitTimeA', { attraction: attractionName }),
-  });
+  // Use today's live aggregate stats when available, else an evergreen answer.
+  const s = attraction.statistics;
+  if (s && s.avgWaitToday != null && s.minWaitToday != null && s.maxWaitToday != null) {
+    items.push({
+      iconName: 'Clock',
+      question: t('waitTimeQ', { attraction: attractionName }),
+      answer: t('waitTimeStatsA', {
+        attraction: attractionName,
+        avg: Math.round(s.avgWaitToday),
+        min: Math.round(s.minWaitToday),
+        max: Math.round(s.maxWaitToday),
+      }),
+    });
+  } else {
+    items.push({
+      iconName: 'Clock',
+      question: t('waitTimeQ', { attraction: attractionName }),
+      answer: t('waitTimeA', { attraction: attractionName }),
+    });
+  }
 
   const singleRiderQueue = attraction.queues?.find((q) => q.queueType === 'SINGLE_RIDER');
   if (singleRiderQueue) {

--- a/lib/faq/park-faq.ts
+++ b/lib/faq/park-faq.ts
@@ -9,7 +9,8 @@ export type ParkFaqIconName =
   | 'Ticket'
   | 'Map'
   | 'Theater'
-  | 'UtensilsCrossed';
+  | 'UtensilsCrossed'
+  | 'Clock2';
 
 export interface ParkFaqItem {
   iconName: ParkFaqIconName;
@@ -60,6 +61,28 @@ export function buildParkFaqItems(
   }).format(now);
 
   const items: ParkFaqItem[] = [];
+
+  // Q0: Park-wide wait times today — targets the head query "{park} wait times (today)".
+  // Uses live aggregate stats when the park is operating, else a generic evergreen answer.
+  const stats = park.analytics?.statistics;
+  if (stats && stats.operatingAttractions > 0 && stats.avgWaitToday > 0) {
+    items.push({
+      iconName: 'Clock2',
+      question: t('waitTimesQ', { park: parkName }),
+      answer: t('waitTimesA', {
+        park: parkName,
+        avg: Math.round(stats.avgWaitToday),
+        peak: Math.round(stats.peakWaitToday),
+        operating: stats.operatingAttractions,
+      }),
+    });
+  } else {
+    items.push({
+      iconName: 'Clock2',
+      question: t('waitTimesQ', { park: parkName }),
+      answer: t('waitTimesNoDataA', { park: parkName }),
+    });
+  }
 
   // Q1: Opening Hours
   let openingHoursAnswer: string;

--- a/messages/de.json
+++ b/messages/de.json
@@ -173,7 +173,7 @@
   },
   "footer": {
     "description": "Live-Wartezeiten und KI-gestützte Besucherprognosen für über 142 Freizeitparks weltweit. Plane deinen perfekten Parkbesuch mit Echtzeit-Daten und In-Park Navigation.",
-    "keywords": "Freizeitpark Wartezeiten, Warteschlangen, Besucherprognosen, Attraktionen Verfügbarkeit, Öffnungszeiten, Achterbahn, Disney Wartezeiten, Universal Studios, Europa-Park, Phantasialand, Freizeitpark Kalender, bester Besuchszeitpunkt",
+    "keywords": "Freizeitpark Wartezeiten, Wartezeiten LIVE, Wartezeiten heute, Crowd-Kalender, KI-Prognose, Warteschlangen, Besucherprognosen, Öffnungszeiten, Achterbahn, Disney Wartezeiten, Universal Studios, Europa-Park, Phantasialand, beste Besuchszeit",
     "sections": {
       "explore": "Parks weltweit",
       "popularParks": "Beliebte Parks",
@@ -815,7 +815,7 @@
     "global": {
       "title": "park.fan - Freizeitpark Wartezeiten & Prognosen",
       "description": "Live-Wartezeiten und KI-Prognosen für 142+ Freizeitparks weltweit. Plane deinen Parkbesuch mit Echtzeit-Daten und In-Park-Navigation.",
-      "keywords": "Freizeitpark Wartezeiten, Warteschlangen, Besucherprognosen, Attraktionen Verfügbarkeit, Öffnungszeiten, Achterbahn, Disney Wartezeiten, Universal Studios, Europa-Park, Phantasialand, Freizeitpark Kalender, bester Besuchszeitpunkt"
+      "keywords": "Freizeitpark Wartezeiten, Wartezeiten LIVE, Wartezeiten heute, Crowd-Kalender, KI-Prognose, Warteschlangen, Besucherprognosen, Öffnungszeiten, Achterbahn, Disney Wartezeiten, Universal Studios, Europa-Park, Phantasialand, beste Besuchszeit"
     },
     "home": {
       "title": "Live Freizeitpark Wartezeiten & Crowd-Prognosen",
@@ -824,10 +824,10 @@
     "parks": {
       "title": "Freizeitparks Weltweit",
       "description": "Vergleiche aktuelle Wartezeiten, Betriebsstatus und Besucherandrang für Top-Freizeitparks wie Europa-Park, Phantasialand, Disney und Universal.",
-      "metaDescriptionTemplate": "Live-Wartezeiten & Crowd-Kalender für {park} in {city}. Beste Besuchstage, Prognosen und Öffnungszeiten auf einen Blick.",
-      "titleTemplate": "{park} Wartezeiten – {city}",
-      "titleTemplateNoCity": "{park} – Wartezeiten & beste Besuchstage",
-      "metaDescriptionTemplateNoCity": "Live-Wartezeiten & Crowd-Kalender für {park}. Beste Besuchstage, Prognosen und Öffnungszeiten auf einen Blick.",
+      "metaDescriptionTemplate": "Live-Wartezeiten & Crowd-Kalender für {park} in {city}. Prognose für heute, beste Besuchstage & Öffnungszeiten auf einen Blick.",
+      "titleTemplate": "{park} Wartezeiten LIVE – {city}",
+      "titleTemplateNoCity": "{park} – Wartezeiten LIVE & beste Tage",
+      "metaDescriptionTemplateNoCity": "Live-Wartezeiten & Crowd-Kalender für {park}. Prognose für heute, beste Besuchstage & Öffnungszeiten auf einen Blick.",
       "keywordWaitTimes": "Wartezeiten",
       "keywordCrowdCalendar": "Crowd-Kalender",
       "keywordBestTime": "beste Besuchszeit"

--- a/messages/de.json
+++ b/messages/de.json
@@ -833,7 +833,7 @@
       "keywordBestTime": "beste Besuchszeit"
     },
     "attraction": {
-      "titleTemplate": "{attraction} im {park} – Wartezeiten & Status",
+      "titleTemplate": "{attraction} im {park} – Wartezeiten LIVE & Status",
       "metaDescriptionTemplate": "Aktuelle Wartezeiten für {attraction} im {park}. Prüfe Live-Daten und Besucherandrang."
     },
     "continent": {
@@ -863,6 +863,9 @@
     },
     "faq": {
       "title": "Häufig gestellte Fragen",
+      "waitTimesQ": "Wie sind die Wartezeiten im {park} heute?",
+      "waitTimesA": "Aktuell liegt die durchschnittliche Wartezeit im {park} bei rund {avg} Minuten (Spitze {peak} Minuten) bei {operating} geöffneten Attraktionen. Die Live-Wartezeiten aller Fahrgeschäfte findest du oben auf dieser Seite.",
+      "waitTimesNoDataA": "Die Wartezeiten im {park} hängen von Tag, Saison und Andrang ab. Sieh dir die Live-Wartezeiten aller Fahrgeschäfte oben an – plus den Crowd-Kalender für die beste Besuchszeit.",
       "openingHoursQ": "Welche Öffnungszeiten hat {park} heute?",
       "openingHoursA": "Heute, {date}, hat {park} von {open} bis {close} Uhr geöffnet.",
       "openingHoursClosed": "Heute, {date}, ist {park} geschlossen.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -891,6 +891,7 @@
         "inLand": " im Themenbereich {land}",
         "waitTimeQ": "Wie lange ist die Wartezeit für {attraction}?",
         "waitTimeA": "Die Wartezeiten für {attraction} variieren je nach Tag und Saison. Aktuelle Wartezeiten findest du auf park.fan.",
+        "waitTimeStatsA": "Heute liegt die Wartezeit für {attraction} im Schnitt bei {avg} Minuten und schwankt zwischen {min} und {max} Minuten. Die aktuelle Live-Wartezeit siehst du oben auf dieser Seite.",
         "singleRiderQ": "Hat {attraction} eine Single Rider Warteschlange?",
         "singleRiderA": "Ja, {attraction} bietet eine Single Rider Warteschlange für einzelne Gäste, um leere Plätze zu füllen.",
         "paidQueueQ": "Gibt es eine Fast Pass Option für {attraction}?",

--- a/messages/en.json
+++ b/messages/en.json
@@ -173,7 +173,7 @@
   },
   "footer": {
     "description": "Live wait times and AI-powered crowd predictions for 142+ theme parks worldwide. Plan your perfect park visit with real-time data and in-park navigation.",
-    "keywords": "theme park wait times, queue times, crowd predictions, ride availability, opening hours, amusement park, roller coaster, Disney wait times, Universal Studios, Europa-Park, Phantasialand, theme park calendar, best time to visit",
+    "keywords": "theme park wait times, live wait times, wait times today, crowd calendar, AI crowd forecast, queue times, crowd predictions, opening hours, amusement park, roller coaster, Disney wait times, Universal Studios, Europa-Park, Phantasialand, best time to visit",
     "sections": {
       "explore": "Parks Worldwide",
       "popularParks": "Popular Parks",
@@ -815,7 +815,7 @@
     "global": {
       "title": "park.fan - Theme Park Wait Times & Predictions",
       "description": "Real-time theme park wait times, crowd predictions, and schedules. Plan your perfect visit with ML-powered forecasts for 142+ theme parks worldwide.",
-      "keywords": "theme park wait times, queue times, crowd predictions, ride availability, opening hours, amusement park, roller coaster, Disney wait times, Universal Studios, Europa-Park, Phantasialand, theme park calendar, best time to visit"
+      "keywords": "theme park wait times, live wait times, wait times today, crowd calendar, AI crowd forecast, queue times, crowd predictions, opening hours, amusement park, roller coaster, Disney wait times, Universal Studios, Europa-Park, Phantasialand, best time to visit"
     },
     "home": {
       "title": "Live Theme Park Wait Times & Crowd Predictions",
@@ -825,8 +825,8 @@
       "title": "Theme Parks Worldwide",
       "description": "Compare live wait times, crowd levels, and hours for top parks: Disney, Universal, Europa-Park, and more.",
       "metaDescriptionTemplate": "Live wait times & crowd calendar for {park} in {city}. Check today's forecast, best days to visit, and opening hours.",
-      "titleTemplate": "{park} Wait Times – {city}",
-      "titleTemplateNoCity": "{park} – Wait Times & Best Days to Visit",
+      "titleTemplate": "{park} Wait Times LIVE – {city}",
+      "titleTemplateNoCity": "{park} – Wait Times LIVE & Best Days",
       "metaDescriptionTemplateNoCity": "Live wait times & crowd calendar for {park}. Check today's forecast, best days to visit, and opening hours.",
       "keywordWaitTimes": "wait times",
       "keywordCrowdCalendar": "crowd calendar",

--- a/messages/en.json
+++ b/messages/en.json
@@ -863,6 +863,9 @@
     },
     "faq": {
       "title": "Frequently Asked Questions",
+      "waitTimesQ": "What are the wait times at {park} today?",
+      "waitTimesA": "Right now the average wait at {park} is about {avg} minutes (peak {peak} minutes) across {operating} open attractions. Live wait times for every ride are shown above on this page.",
+      "waitTimesNoDataA": "Wait times at {park} vary by day, season and crowd level. Check the live wait times for every ride above, plus the crowd calendar to find the best time to visit.",
       "openingHoursQ": "What are the opening hours for {park} today?",
       "openingHoursA": "Today, {date}, {park} is open from {open} to {close}.",
       "openingHoursClosed": "Today, {date}, {park} is closed.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -891,6 +891,7 @@
         "inLand": " in the {land} themed area",
         "waitTimeQ": "How long is the wait for {attraction}?",
         "waitTimeA": "Wait times for {attraction} vary by day and season. Check live wait times on park.fan.",
+        "waitTimeStatsA": "Today the wait for {attraction} averages {avg} minutes, ranging from {min} to {max} minutes. The current live wait time is shown above on this page.",
         "singleRiderQ": "Does {attraction} have a Single Rider line?",
         "singleRiderA": "Yes, {attraction} has a Single Rider line for individual guests to fill empty seats.",
         "paidQueueQ": "Is there a fast pass options for {attraction}?",

--- a/messages/es.json
+++ b/messages/es.json
@@ -863,6 +863,9 @@
     },
     "faq": {
       "title": "Preguntas Frecuentes",
+      "waitTimesQ": "¿Cuáles son los tiempos de espera en {park} hoy?",
+      "waitTimesA": "Ahora mismo el tiempo de espera medio en {park} es de unos {avg} minutos (pico {peak} minutos) en {operating} atracciones abiertas. Los tiempos de espera en vivo de cada atracción se muestran arriba en esta página.",
+      "waitTimesNoDataA": "Los tiempos de espera en {park} varían según el día, la temporada y la afluencia. Consulta los tiempos de espera en vivo arriba y el calendario de afluencia para la mejor época para visitar.",
       "openingHoursQ": "¿Cuál es el horario de apertura de {park} hoy?",
       "openingHoursA": "Hoy, {date}, {park} está abierto de {open} a {close}.",
       "openingHoursClosed": "Hoy, {date}, {park} está cerrado.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -173,7 +173,7 @@
   },
   "footer": {
     "description": "Tiempos de espera en vivo y predicciones de afluencia para más de 142 parques temáticos. Planifica tu visita perfecta con datos en tiempo real y navegación.",
-    "keywords": "tiempos de espera parques temáticos, colas, predicciones afluencia, horarios apertura, parque de atracciones, montaña rusa, tiempos espera Disney, Universal Studios, Europa-Park, Phantasialand, calendario parque, mejor momento visita",
+    "keywords": "tiempos de espera parques temáticos, tiempos de espera en vivo, tiempos de espera hoy, calendario de afluencia, predicción IA, colas, predicciones afluencia, horarios apertura, parque de atracciones, montaña rusa, tiempos espera Disney, Universal Studios, Europa-Park, Phantasialand, mejor momento visita",
     "sections": {
       "explore": "Parques Internacionales",
       "popularParks": "Parques Populares",
@@ -815,7 +815,7 @@
     "global": {
       "title": "park.fan - Tiempos de Espera Parques Temáticos & Predicciones",
       "description": "Tiempos de espera en vivo y predicciones de afluencia para 142+ parques temáticos. Planifica tu visita con datos en tiempo real.",
-      "keywords": "tiempos de espera parques temáticos, colas, predicciones afluencia, horarios apertura, parque de atracciones, montaña rusa, tiempos espera Disney, Universal Studios, Europa-Park, Phantasialand, calendario parque, mejor momento visita"
+      "keywords": "tiempos de espera parques temáticos, tiempos de espera en vivo, tiempos de espera hoy, calendario de afluencia, predicción IA, colas, predicciones afluencia, horarios apertura, parque de atracciones, montaña rusa, tiempos espera Disney, Universal Studios, Europa-Park, Phantasialand, mejor momento visita"
     },
     "home": {
       "title": "Tiempos de Espera en Vivo & Predicciones de Afluencia",
@@ -825,8 +825,8 @@
       "title": "Parques Temáticos Mundiales",
       "description": "Compara tiempos de espera, estado y afluencia de los mejores parques como Disney World, Disneyland, Universal Studios y Europa-Park.",
       "metaDescriptionTemplate": "Tiempos de espera en vivo y calendario para {park} en {city}. Pronóstico de hoy, mejores días y horarios de apertura.",
-      "titleTemplate": "{park} Tiempos de Espera – {city}",
-      "titleTemplateNoCity": "{park} – Tiempos de Espera & Mejores Días",
+      "titleTemplate": "{park} Tiempos de Espera LIVE – {city}",
+      "titleTemplateNoCity": "{park} – Tiempos de Espera LIVE & Afluencia",
       "metaDescriptionTemplateNoCity": "Tiempos de espera en vivo y calendario para {park}. Pronóstico de hoy, mejores días y horarios de apertura.",
       "keywordWaitTimes": "tiempos de espera",
       "keywordCrowdCalendar": "calendario de afluencia",

--- a/messages/es.json
+++ b/messages/es.json
@@ -891,6 +891,7 @@
         "inLand": " en el área temática {land}",
         "waitTimeQ": "¿Cuánto tiempo de espera hay para {attraction}?",
         "waitTimeA": "Los tiempos de espera para {attraction} varían según el día y la temporada. Consulta los tiempos de espera en vivo en park.fan.",
+        "waitTimeStatsA": "Hoy el tiempo de espera para {attraction} es de media {avg} minutos, variando entre {min} y {max} minutos. El tiempo de espera en vivo se muestra arriba en esta página.",
         "singleRiderQ": "¿Tiene {attraction} una fila Single Rider?",
         "singleRiderA": "Sí, {attraction} tiene una fila Single Rider para huéspedes individuales que llenan asientos vacíos.",
         "paidQueueQ": "¿Hay opciones de pase rápido para {attraction}?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -173,7 +173,7 @@
   },
   "footer": {
     "description": "Temps d'attente en direct et prédictions d'affluence pour 142+ parcs d'attractions. Planifiez votre visite parfaite avec des données en temps réel et la navigation.",
-    "keywords": "temps d'attente parc attraction, file d'attente, prévisions affluence, horaires ouverture, parc d'attractions, montagnes russes, Disney temps d'attente, Universal Studios, Europa-Park, Phantasialand, calendrier parc, meilleur moment visite",
+    "keywords": "temps d'attente parc attraction, temps d'attente en direct, temps d'attente aujourd'hui, calendrier d'affluence, prévision IA, file d'attente, prévisions affluence, horaires ouverture, parc d'attractions, montagnes russes, Disney temps d'attente, Universal Studios, Europa-Park, Phantasialand, meilleur moment visite",
     "sections": {
       "explore": "Parcs Internationaux",
       "popularParks": "Parcs Populaires",
@@ -815,7 +815,7 @@
     "global": {
       "title": "park.fan - Temps d'Attente Parcs d'Attractions & Prédictions",
       "description": "Temps d'attente en direct et prédictions d'affluence pour 142+ parcs. Planifiez votre visite avec des données en temps réel.",
-      "keywords": "temps d'attente parc attraction, file d'attente, prévisions affluence, horaires ouverture, parc d'attractions, montagnes russes, Disney temps d'attente, Universal Studios, Europa-Park, Phantasialand, calendrier parc, meilleur moment visite"
+      "keywords": "temps d'attente parc attraction, temps d'attente en direct, temps d'attente aujourd'hui, calendrier d'affluence, prévision IA, file d'attente, prévisions affluence, horaires ouverture, parc d'attractions, montagnes russes, Disney temps d'attente, Universal Studios, Europa-Park, Phantasialand, meilleur moment visite"
     },
     "home": {
       "title": "Temps d'Attente en Direct & Prédictions d'Affluence",
@@ -825,8 +825,8 @@
       "title": "Parcs d'Attractions Monde",
       "description": "Comparez les temps d'attente, statuts et affluence pour les meilleurs parcs comme Disney World, Disneyland, Universal Studios et Europa-Park.",
       "metaDescriptionTemplate": "Temps d'attente en direct et calendrier pour {park} à {city}. Prévisions du jour, meilleurs jours et horaires d'ouverture.",
-      "titleTemplate": "{park} Temps d'Attente – {city}",
-      "titleTemplateNoCity": "{park} – Temps d'Attente & Meilleurs Jours",
+      "titleTemplate": "{park} Temps d'Attente LIVE – {city}",
+      "titleTemplateNoCity": "{park} – Temps d'Attente LIVE & Affluence",
       "metaDescriptionTemplateNoCity": "Temps d'attente en direct et calendrier pour {park}. Prévisions du jour, meilleurs jours et horaires d'ouverture.",
       "keywordWaitTimes": "temps d'attente",
       "keywordCrowdCalendar": "calendrier d'affluence",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -891,6 +891,7 @@
         "inLand": " dans la zone thématique {land}",
         "waitTimeQ": "Quel est le temps d'attente pour {attraction}?",
         "waitTimeA": "Les temps d'attente pour {attraction} varient selon le jour et la saison. Consultez les temps d'attente en direct sur park.fan.",
+        "waitTimeStatsA": "Aujourd'hui, le temps d'attente pour {attraction} est en moyenne de {avg} minutes, variant entre {min} et {max} minutes. Le temps d'attente en direct est affiché ci-dessus sur cette page.",
         "singleRiderQ": "Est-ce que {attraction} a une file Single Rider?",
         "singleRiderA": "Oui, {attraction} dispose d'une file Single Rider pour les visiteurs individuels afin de remplir les sièges vides.",
         "paidQueueQ": "Y a-t-il des options de coupe-file pour {attraction}?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -863,6 +863,9 @@
     },
     "faq": {
       "title": "Questions Fréquentes",
+      "waitTimesQ": "Quels sont les temps d'attente à {park} aujourd'hui ?",
+      "waitTimesA": "Actuellement, le temps d'attente moyen à {park} est d'environ {avg} minutes (pic {peak} minutes) sur {operating} attractions ouvertes. Les temps d'attente en direct de chaque attraction sont affichés ci-dessus sur cette page.",
+      "waitTimesNoDataA": "Les temps d'attente à {park} varient selon le jour, la saison et l'affluence. Consultez les temps d'attente en direct ci-dessus, ainsi que le calendrier d'affluence pour la meilleure période de visite.",
       "openingHoursQ": "Quels sont les horaires d'ouverture de {park} aujourd'hui?",
       "openingHoursA": "Aujourd'hui, {date}, {park} est ouvert de {open} à {close}.",
       "openingHoursClosed": "Aujourd'hui, {date}, {park} est fermé.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -173,7 +173,7 @@
   },
   "footer": {
     "description": "Tempi di attesa in diretta e previsioni di affluenza basate sull'IA per oltre 142 parchi a tema nel mondo. Pianifica la visita perfetta con dati in tempo reale e navigazione nel parco.",
-    "keywords": "tempi di attesa parchi a tema, tempi di coda, previsioni affluenza, disponibilità giostre, orari di apertura, parco divertimenti, montagna russa, tempi di attesa Disney, Universal Studios, Europa-Park, Phantasialand, calendario parco a tema, miglior momento per visitare",
+    "keywords": "tempi di attesa parchi a tema, tempi di attesa LIVE, tempi di attesa oggi, calendario affluenza, previsione IA, tempi di coda, previsioni affluenza, orari di apertura, parco divertimenti, montagna russa, tempi di attesa Disney, Universal Studios, Europa-Park, Phantasialand, miglior momento per visitare",
     "sections": {
       "explore": "Parchi nel mondo",
       "popularParks": "Parchi popolari",
@@ -815,7 +815,7 @@
     "global": {
       "title": "park.fan - Tempi di attesa e previsioni per parchi a tema",
       "description": "Tempi di attesa in tempo reale e previsioni di affluenza per 142+ parchi a tema. Pianifica la visita con dati live.",
-      "keywords": "tempi di attesa parchi a tema, tempi di coda, previsioni affluenza, disponibilità giostre, orari di apertura, parco divertimenti, montagna russa, tempi di attesa Disney, Universal Studios, Europa-Park, Phantasialand, calendario parco a tema, miglior momento per visitare"
+      "keywords": "tempi di attesa parchi a tema, tempi di attesa LIVE, tempi di attesa oggi, calendario affluenza, previsione IA, tempi di coda, previsioni affluenza, orari di apertura, parco divertimenti, montagna russa, tempi di attesa Disney, Universal Studios, Europa-Park, Phantasialand, miglior momento per visitare"
     },
     "home": {
       "title": "Tempi di attesa e previsioni di affluenza in tempo reale",
@@ -825,8 +825,8 @@
       "title": "Parchi a tema nel mondo",
       "description": "Confronta i tempi di coda in diretta e l'affluenza dei principali parchi: Disney, Universal Studios ed Europa-Park.",
       "metaDescriptionTemplate": "Tempi di attesa in diretta e calendario per {park} a {city}. Controlla le previsioni di oggi, giorni migliori e orari di apertura.",
-      "titleTemplate": "{park} Tempi di attesa – {city}",
-      "titleTemplateNoCity": "{park} – Tempi di attesa e giorni migliori per visitare",
+      "titleTemplate": "{park} Tempi di attesa LIVE – {city}",
+      "titleTemplateNoCity": "{park} – Tempi di attesa LIVE & Giorni Migliori",
       "metaDescriptionTemplateNoCity": "Tempi di attesa in diretta e calendario per {park}. Controlla le previsioni di oggi, giorni migliori e orari di apertura.",
       "keywordWaitTimes": "tempi di attesa",
       "keywordCrowdCalendar": "calendario affluenze",

--- a/messages/it.json
+++ b/messages/it.json
@@ -863,6 +863,9 @@
     },
     "faq": {
       "title": "Domande frequenti",
+      "waitTimesQ": "Quali sono i tempi di attesa a {park} oggi?",
+      "waitTimesA": "In questo momento il tempo di attesa medio a {park} è di circa {avg} minuti (picco {peak} minuti) su {operating} attrazioni aperte. I tempi di attesa in diretta di ogni attrazione sono mostrati qui sopra in questa pagina.",
+      "waitTimesNoDataA": "I tempi di attesa a {park} variano in base a giorno, stagione e affluenza. Controlla i tempi di attesa in diretta qui sopra e il calendario delle affluenze per il momento migliore per visitare.",
       "openingHoursQ": "Quali sono gli orari di apertura di {park} oggi?",
       "openingHoursA": "Oggi, {date}, {park} è aperto dalle {open} alle {close}.",
       "openingHoursClosed": "Oggi, {date}, {park} è chiuso.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -891,6 +891,7 @@
         "inLand": " nell'area tematica {land}",
         "waitTimeQ": "Quanto è lunga l'attesa per {attraction}?",
         "waitTimeA": "I tempi di attesa per {attraction} variano a seconda del giorno e della stagione. Controlla i tempi di attesa in diretta su park.fan.",
+        "waitTimeStatsA": "Oggi il tempo di attesa per {attraction} è in media di {avg} minuti, oscillando tra {min} e {max} minuti. Il tempo di attesa in diretta è mostrato qui sopra in questa pagina.",
         "singleRiderQ": "{attraction} ha una fila Single Rider?",
         "singleRiderA": "Sì, {attraction} ha una fila Single Rider per i visitatori singoli che possono riempire i posti vuoti.",
         "paidQueueQ": "Esiste un'opzione fast pass per {attraction}?",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -891,6 +891,7 @@
         "inLand": " in het themagebied {land}",
         "waitTimeQ": "Hoe lang is de wachttijd voor {attraction}?",
         "waitTimeA": "Wachttijden voor {attraction} variëren per dag en seizoen. Bekijk live wachttijden op park.fan.",
+        "waitTimeStatsA": "Vandaag is de wachttijd voor {attraction} gemiddeld {avg} minuten, variërend van {min} tot {max} minuten. De actuele live wachttijd staat hierboven op deze pagina.",
         "singleRiderQ": "Heeft {attraction} een Single Rider rij?",
         "singleRiderA": "Ja, {attraction} heeft een Single Rider rij voor individuele gasten om lege stoelen te vullen.",
         "paidQueueQ": "Zijn er fast pass opties voor {attraction}?",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -173,7 +173,7 @@
   },
   "footer": {
     "description": "Live wachttijden en AI-gestuurde druktevoorspellingen voor 142+ pretparken wereldwijd. Plan je perfecte parkbezoek met realtime gegevens en navigatie in het park.",
-    "keywords": "pretpark wachttijden, wachtrijtijden, druktevoorspellingen, attractie beschikbaarheid, openingstijden, pretpark, achtbaan, Disney wachttijden, Universal Studios, Europa-Park, Phantasialand, pretpark kalender, beste bezoektijd",
+    "keywords": "pretpark wachttijden, live wachttijden, wachttijden vandaag, druktekalender, AI-voorspelling, wachtrijtijden, druktevoorspellingen, openingstijden, pretpark, achtbaan, Disney wachttijden, Universal Studios, Europa-Park, Phantasialand, beste bezoektijd",
     "sections": {
       "explore": "Parken Wereldwijd",
       "popularParks": "Populaire Parken",
@@ -815,7 +815,7 @@
     "global": {
       "title": "park.fan - Pretpark Wachttijden & Voorspellingen",
       "description": "Live wachttijden en AI-gestuurde druktevoorspellingen voor 142+ pretparken. Plan je bezoek met realtime gegevens en in-park navigatie.",
-      "keywords": "pretpark wachttijden, wachtrijtijden, druktevoorspellingen, attractie beschikbaarheid, openingstijden, pretpark, achtbaan, Disney wachttijden, Universal Studios, Europa-Park, Phantasialand, pretpark kalender, beste bezoektijd"
+      "keywords": "pretpark wachttijden, live wachttijden, wachttijden vandaag, druktekalender, AI-voorspelling, wachtrijtijden, druktevoorspellingen, openingstijden, pretpark, achtbaan, Disney wachttijden, Universal Studios, Europa-Park, Phantasialand, beste bezoektijd"
     },
     "home": {
       "title": "Live Pretpark Wachttijden & Druktevoorspellingen",
@@ -825,8 +825,8 @@
       "title": "Pretparken Wereldwijd",
       "description": "Vergelijk live wachttijden, status en drukte voor topparken zoals Disney World, Disneyland, Universal Studios en Europa-Park.",
       "metaDescriptionTemplate": "Live wachttijden & druktekalender voor {park} in {city}. Bekijk de druktevoorspelling, beste bezoekdagen en openingstijden.",
-      "titleTemplate": "{park} Wachttijden – {city}",
-      "titleTemplateNoCity": "{park} – Wachttijden & Beste Bezoekdagen",
+      "titleTemplate": "{park} Wachttijden LIVE – {city}",
+      "titleTemplateNoCity": "{park} – Wachttijden LIVE & Beste Dagen",
       "metaDescriptionTemplateNoCity": "Live wachttijden & druktekalender voor {park}. Bekijk de druktevoorspelling, beste bezoekdagen en openingstijden.",
       "keywordWaitTimes": "wachttijden",
       "keywordCrowdCalendar": "druktekalender",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -863,6 +863,9 @@
     },
     "faq": {
       "title": "Veelgestelde Vragen",
+      "waitTimesQ": "Wat zijn de wachttijden in {park} vandaag?",
+      "waitTimesA": "Op dit moment is de gemiddelde wachttijd in {park} ongeveer {avg} minuten (piek {peak} minuten) bij {operating} geopende attracties. De live wachttijden van elke attractie staan hierboven op deze pagina.",
+      "waitTimesNoDataA": "De wachttijden in {park} variëren per dag, seizoen en drukte. Bekijk de live wachttijden hierboven, plus de druktekalender voor de beste bezoektijd.",
       "openingHoursQ": "Wat zijn de openingstijden van {park} vandaag?",
       "openingHoursA": "Vandaag, {date}, is {park} open van {open} tot {close}.",
       "openingHoursClosed": "Vandaag, {date}, is {park} gesloten.",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,24 @@
 import createMiddleware from 'next-intl/middleware';
+import type { NextRequest } from 'next/server';
 import { routing } from './i18n/routing';
 
-export default createMiddleware(routing);
+const handleI18nRouting = createMiddleware(routing);
+
+export default function proxy(request: NextRequest) {
+  const response = handleI18nRouting(request);
+
+  // next-intl detects the locale from the Accept-Language header and redirects
+  // unprefixed paths accordingly (e.g. `/` → `/de` vs `/en`). The Location of
+  // those redirects therefore varies by Accept-Language, so we must advertise
+  // that to shared/CDN caches — otherwise one visitor's locale redirect could
+  // be cached and served to everyone. Only tag redirects: the locale-prefixed
+  // pages themselves are keyed by URL path and must stay fully cacheable.
+  if (response.headers.has('location')) {
+    response.headers.set('Vary', 'Accept-Language');
+  }
+
+  return response;
+}
 
 export const config = {
   // Match all paths except:


### PR DESCRIPTION
Two related i18n/SEO improvements, motivated by investigating why google.de showed the English homepage for the `park.fan` query.

## 1. `Vary: Accept-Language` on locale-detection redirects

The root (and other unprefixed paths) redirect based on `Accept-Language` (`/` → `/de` vs `/en`), but the redirect response did **not** set `Vary: Accept-Language`. A shared/CDN cache keyed only on URL could store one visitor's locale redirect and serve it to everyone.

**Fix:** wrap the next-intl middleware in `proxy.ts` and set `Vary: Accept-Language` **only on redirect responses** (those carrying a `Location` header). Locale-prefixed pages stay keyed by URL path and fully cacheable.

**Verified on the preview deployment:**
| Response | `Vary: Accept-Language`? |
| --- | --- |
| `/` → `/de` (Accept-Language: de) | ✅ set |
| `/` → `/en` (Accept-Language: en) | ✅ set |
| `/de` page (200) | ❌ not set (page stays cacheable) |

## 2. SEO: add `LIVE` to park titles + sharpen keywords

Competitive analysis vs. **wartezeiten.app** (which leads every title with "Wartezeiten LIVE") showed our park titles lacked the high-CTR `LIVE` keyword.

- **Park title templates** (with/without city) now include `LIVE` in all 6 locales.
- **Length-validated against all 156 parks**: famous/high-traffic parks stay well under 55 chars even in the longest language (ES/IT, ~37–51 chars). The only >55 cases are already-overlong US park names (e.g. "Six Flags Hurricane Harbor, Oklahoma City"), where the park name + wait-times phrase lead and remain visible — these already truncate today regardless.
- **meta keywords** (`seo.global`): added *live wait times / wait times today / crowd calendar / AI forecast* terms, localized per language.
- **DE meta description**: added "heute" for parity with the other locales' high-intent "today" phrasing.

Descriptions and the park/attraction **FAQ** already cover planning-intent keywords (best days, crowd calendar, opening hours today), so they were left intact.

## Verification
- `tsc --noEmit`, `eslint`, `prettier --check` — clean
- `validate-translations.js` — all locales synchronized

## Note on the original SERP question
The hreflang/canonical setup was already correct (verified live). The English-result-on-google.de behavior is primarily a Google-side hreflang/authority/indexing matter (the bare domain's authority concentrates on `/en`), best diagnosed via Search Console — not a code defect. These two changes remove the one real technical flaw (`Vary`) and strengthen the keyword targeting.

https://claude.ai/code/session_018s32RJka9XZKP7dbBiutWg