### PR TITLE
fix(parks): restore mobile ride list on closed park pages

### DIFF
--- a/components/parks/park-status.tsx
+++ b/components/parks/park-status.tsx
@@ -225,9 +225,6 @@ export function ParkStatus({ park, variant, className, midSlot }: ParkStatusProp
               </Card>
             )}
 
-            {/* Tabs with ride list — only on mobile (hidden sm+, shown in original position there) */}
-            {midSlot && stats && <div className="col-span-full sm:hidden">{midSlot}</div>}
-
             {/* Attractions Status Card */}
             {stats && (
               <Card>
@@ -267,6 +264,11 @@ export function ParkStatus({ park, variant, className, midSlot }: ParkStatusProp
             )}
           </div>
         )}
+
+        {/* Ride list (tabs) on mobile — rendered for EVERY status, incl. closed parks (where the
+            open-parks stats grid above isn't rendered at all). Desktop shows the tabs via a
+            separate `hidden sm:block` block in LiveParkData, so this is mobile-only. */}
+        {midSlot && <div className="sm:hidden">{midSlot}</div>}
       </div>
     );
   }


### PR DESCRIPTION
## Problem

On **mobile**, closed parks showed **no ride list at all** — the whole section was gone.

## Cause

In `ParkStatus` (`variant="detailed"`) the mobile ride-list tabs (`midSlot`) were rendered **inside** the open-parks stats grid, which is gated on `(status === 'OPERATING' || status === 'UNKNOWN') && (stats || occupancy)`. For a closed park that grid isn't rendered at all, so the `midSlot` disappeared on mobile.

Desktop was unaffected: it renders the tabs via a separate `hidden sm:block` block in `LiveParkData`, independent of `ParkStatus`.

## Fix

Render `midSlot` **once, outside** the stats grid, mobile-only (`sm:hidden`), for **every** status.

- **Open parks (mobile):** functionally unchanged — the in-grid copy was already `sm:hidden` (only visible <640px); it just moves from between the stat cards to right after them.
- **Closed parks (mobile):** the ride list is back.
- **Desktop:** untouched.

tsc + ESLint green.

https://claude.ai/code/session_018s32RJka9XZKP7dbBiutWg

---
_Generated by [Claude Code](https://claude.ai/code/session_018s32RJka9XZKP7dbBiutWg)_