### PR TITLE
perf: trim post-PPR front-end weight (fonts, framer-motion, critical CSS)

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -140,10 +140,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
   // Render html/body here to have access to locale for lang attribute
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} font-sans antialiased`}
-        suppressHydrationWarning
-      >
+      <body className={`${geistSans.variable} font-sans antialiased`} suppressHydrationWarning>
         {umamiOrigin && <link rel="dns-prefetch" href={umamiOrigin} />}
         {/* Set the temperature unit on <html> before paint so weather/calendar values
             (server-rendered in both units, toggled by CSS) show the visitor's unit with

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -17,17 +17,11 @@ import {
   OrganizationStructuredData,
   WebSiteStructuredData,
 } from '@/components/seo/structured-data';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Geist } from 'next/font/google';
 import { ThemeProvider } from 'next-themes';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
-  subsets: ['latin'],
-  display: 'swap',
-});
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
   subsets: ['latin'],
   display: 'swap',
 });
@@ -147,7 +141,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
   return (
     <html lang={locale} suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}
+        className={`${geistSans.variable} font-sans antialiased`}
         suppressHydrationWarning
       >
         {umamiOrigin && <link rel="dns-prefetch" href={umamiOrigin} />}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,16 +1,10 @@
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Geist } from 'next/font/google';
 import '../globals.css';
 import { AdminShell } from './_components/admin-shell';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
-  subsets: ['latin'],
-  display: 'swap',
-});
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
   subsets: ['latin'],
   display: 'swap',
 });
@@ -24,7 +18,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} bg-background text-foreground min-h-screen font-sans antialiased`}
+        className={`${geistSans.variable} bg-background text-foreground min-h-screen font-sans antialiased`}
       >
         <AdminShell>{children}</AdminShell>
       </body>

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,7 +10,11 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  /* Geist_Mono was dropped to save a ~30 KB render-blocking font preload on every
+     route. `font-mono` is intentionally aliased to Geist Sans so existing utility
+     usages keep rendering (in Geist) without touching every call site. Number-heavy
+     live spots add `tabular-nums` for fixed-width digits. */
+  --font-mono: var(--font-geist-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/components/common/location-banner.tsx
+++ b/components/common/location-banner.tsx
@@ -33,15 +33,20 @@ export function LocationBanner({ ariaLabel }: LocationBannerProps) {
   }
 
   return (
+    // Floating, out of the document flow: a fixed bottom card instead of an in-flow
+    // section. The banner only appears after the client-side geolocation check, so when
+    // it was in flow it pushed everything below it down by ~320px on mount — the dominant
+    // homepage CLS (0.13). As a fixed overlay it no longer affects layout. pointer-events
+    // are scoped to the card so the rest of the floating strip stays click-through.
     <section
-      className="px-4 py-4"
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-4 pb-4"
       aria-label={ariaLabel ?? tCommon('locationBannerLabel')}
       data-nosnippet
       data-noindex
     >
-      <div className="container mx-auto">
+      <div className="pointer-events-auto container mx-auto max-w-3xl">
         <div
-          className="border-border/80 bg-card relative overflow-hidden rounded-2xl border shadow-sm ring-1 ring-black/5 dark:ring-white/5"
+          className="border-border/80 bg-card/95 relative overflow-hidden rounded-2xl border shadow-2xl ring-1 ring-black/5 backdrop-blur-md dark:ring-white/5"
           aria-live="polite"
         >
           <div className="from-primary/5 to-primary/5 absolute inset-0 bg-gradient-to-br via-transparent" />

--- a/components/common/location-banner.tsx
+++ b/components/common/location-banner.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useSyncExternalStore } from 'react';
+import { useState, useSyncExternalStore } from 'react';
 import { useTranslations } from 'next-intl';
-import { MapPin, Navigation } from 'lucide-react';
+import { MapPin, Navigation, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useGeolocation } from '@/lib/contexts/geolocation-context';
 import { trackLocationBannerClicked } from '@/lib/analytics/umami';
@@ -28,59 +28,69 @@ export function LocationBanner({ ariaLabel }: LocationBannerProps) {
     () => false
   );
 
-  if (!mounted || !initialCheckDone || permissionGranted || loading) {
+  // Dismissible: hide for the rest of the session once the user closes it (the banner
+  // is client-only, so reading sessionStorage in the initializer is safe).
+  const [dismissed, setDismissed] = useState(
+    () => typeof window !== 'undefined' && sessionStorage.getItem('locationBannerDismissed') === '1'
+  );
+
+  if (!mounted || !initialCheckDone || permissionGranted || loading || dismissed) {
     return null;
   }
 
   return (
-    // Floating, out of the document flow: a fixed bottom card instead of an in-flow
-    // section. The banner only appears after the client-side geolocation check, so when
-    // it was in flow it pushed everything below it down by ~320px on mount — the dominant
-    // homepage CLS (0.13). As a fixed overlay it no longer affects layout. pointer-events
-    // are scoped to the card so the rest of the floating strip stays click-through.
+    // Floating corner toast, out of the document flow: a fixed overlay instead of an
+    // in-flow section. The banner only appears after the client-side geolocation check,
+    // so in flow it pushed everything below it down ~320px on mount — the dominant
+    // homepage CLS (0.13). As a fixed, compact, dismissible toast it no longer affects
+    // layout and stays out of the way. pointer-events are scoped to the card so the rest
+    // of the floating strip stays click-through.
     <section
-      className="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-4 pb-4"
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-40 p-3 sm:inset-x-auto sm:right-4 sm:bottom-4"
       aria-label={ariaLabel ?? tCommon('locationBannerLabel')}
       data-nosnippet
       data-noindex
     >
-      <div className="pointer-events-auto container mx-auto max-w-3xl">
-        <div
-          className="border-border/80 bg-card/95 relative overflow-hidden rounded-2xl border shadow-2xl ring-1 ring-black/5 backdrop-blur-md dark:ring-white/5"
-          aria-live="polite"
+      <div
+        className="border-border/80 bg-card/95 pointer-events-auto relative mx-auto max-w-sm rounded-xl border p-4 pr-9 shadow-2xl ring-1 ring-black/5 backdrop-blur-md sm:mx-0 dark:ring-white/5"
+        aria-live="polite"
+      >
+        <button
+          type="button"
+          onClick={() => {
+            setDismissed(true);
+            try {
+              sessionStorage.setItem('locationBannerDismissed', '1');
+            } catch {}
+          }}
+          aria-label={tCommon('close')}
+          className="text-muted-foreground hover:text-foreground hover:bg-muted absolute top-2 right-2 rounded-md p-1 transition-colors"
         >
-          <div className="from-primary/5 to-primary/5 absolute inset-0 bg-gradient-to-br via-transparent" />
-          <div className="relative flex flex-col gap-5 p-5 sm:flex-row sm:items-end sm:justify-between sm:gap-8 sm:p-6">
-            <div className="flex min-w-0 flex-1 gap-4">
-              <div className="bg-primary/10 flex h-11 w-11 shrink-0 items-center justify-center rounded-xl">
-                <MapPin className="text-primary h-5 w-5" />
-              </div>
-              <div className="min-w-0 space-y-2">
-                <h2 className="text-foreground text-base leading-tight font-semibold sm:text-lg">
-                  {t('bannerHeadline')}
-                </h2>
-                <p className="text-muted-foreground max-w-2xl text-sm leading-relaxed">
-                  {t('bannerBody')}
-                </p>
-                <p className="text-muted-foreground/90 text-xs leading-snug">
-                  {t('bannerPrivacy')}
-                </p>
-              </div>
-            </div>
-            <Button
-              onClick={() => {
-                trackLocationBannerClicked();
-                refresh();
-              }}
-              size="lg"
-              disabled={loading}
-              className="w-full shrink-0 sm:w-auto"
-            >
-              <Navigation className="mr-2 h-4 w-4" />
-              {loading ? t('loadingLocation') : t('enable')}
-            </Button>
+          <X className="h-4 w-4" />
+        </button>
+        <div className="flex items-start gap-3">
+          <div className="bg-primary/10 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg">
+            <MapPin className="text-primary h-4 w-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-foreground text-sm leading-tight font-semibold">
+              {t('bannerHeadline')}
+            </h2>
+            <p className="text-muted-foreground mt-1 text-xs leading-snug">{t('bannerBody')}</p>
           </div>
         </div>
+        <Button
+          onClick={() => {
+            trackLocationBannerClicked();
+            refresh();
+          }}
+          size="sm"
+          disabled={loading}
+          className="mt-3 w-full"
+        >
+          <Navigation className="mr-1.5 h-3.5 w-3.5" />
+          {loading ? t('loadingLocation') : t('enable')}
+        </Button>
       </div>
     </section>
   );

--- a/components/home/announce-section.tsx
+++ b/components/home/announce-section.tsx
@@ -12,9 +12,7 @@ import { getServerNowMs } from '@/lib/utils/server-time';
 // Code-split the countdown: FlipClock pulls in framer-motion (~40 KB gzip), but it
 // only renders when an announcement with `countdownTo` is live. A dynamic import keeps
 // framer-motion out of the homepage's initial bundle until a countdown is actually shown.
-const FlipClock = dynamic(() =>
-  import('@/components/ui/flip-clock').then((m) => m.FlipClock)
-);
+const FlipClock = dynamic(() => import('@/components/ui/flip-clock').then((m) => m.FlipClock));
 
 interface AnnounceSectionProps {
   locale: string;

--- a/components/home/announce-section.tsx
+++ b/components/home/announce-section.tsx
@@ -1,5 +1,5 @@
 import { getMarkdownContent } from '@/lib/markdown';
-import { FlipClock } from '@/components/ui/flip-clock';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import { getTranslations } from 'next-intl/server';
 import ReactMarkdown from 'react-markdown';
@@ -7,6 +7,13 @@ import { Button } from '@/components/ui/button';
 import { Link } from '@/i18n/navigation';
 import { GlossaryInject } from '@/components/glossary/glossary-inject';
 import { getServerNowMs } from '@/lib/utils/server-time';
+
+// Code-split the countdown: FlipClock pulls in framer-motion (~40 KB gzip), but it
+// only renders when an announcement with `countdownTo` is live. A dynamic import keeps
+// framer-motion out of the homepage's initial bundle until a countdown is actually shown.
+const FlipClock = dynamic(() =>
+  import('@/components/ui/flip-clock').then((m) => m.FlipClock)
+);
 
 interface AnnounceSectionProps {
   locale: string;

--- a/components/home/announce-section.tsx
+++ b/components/home/announce-section.tsx
@@ -1,6 +1,7 @@
 import { getMarkdownContent } from '@/lib/markdown';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
+import { backgroundImageLoader } from '@/lib/utils/image-loader';
 import { getTranslations } from 'next-intl/server';
 import ReactMarkdown from 'react-markdown';
 import { Button } from '@/components/ui/button';
@@ -71,10 +72,13 @@ export async function AnnounceSection({ locale }: AnnounceSectionProps) {
             src={cleanBackground}
             alt="Background"
             fill
+            loader={backgroundImageLoader}
             className="object-cover object-top"
             sizes="100vw"
-            priority={true}
-            quality={85}
+            // Sits below the hero — not the LCP. Keeping it off `priority` stops it
+            // competing with the hero image for bandwidth (the hero's LCP load delay
+            // was ~1.4 s on slow 4G). Lazy-loads as it scrolls into view. Shares the
+            // hero's loader so mobile/desktop quality is handled the same way (q60/q90).
           />
           <div className="from-background via-background/90 to-muted/50 absolute inset-0 bg-gradient-to-br" />
           <div className="from-park-primary/10 absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] via-transparent to-transparent" />

--- a/components/home/ml-sparkline.tsx
+++ b/components/home/ml-sparkline.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { LineChart, Line, ResponsiveContainer, Tooltip, ReferenceDot, YAxis } from 'recharts';
+import { Sparkline, type SparklinePoint } from '@/components/parks/sparkline';
 import type { ModelMetricsSnapshot } from '@/lib/api/types';
 
-// Use resolved hex — CSS variables don't work in SVG stroke attributes.
+// Brand blue, resolved hex — the shared Sparkline strokes with `currentColor`.
 const BRAND_BLUE = '#2191D3';
 
 interface Props {
@@ -15,93 +15,31 @@ interface Props {
   decimals?: number;
 }
 
-interface DataPoint {
-  label: string;
-  value: number;
-  isActive: boolean;
-}
-
-function SparklineTooltip({
-  active,
-  payload,
-  unit,
-  decimals = 1,
-}: {
-  active?: boolean;
-  payload?: Array<{ payload: DataPoint }>;
-  unit?: string;
-  decimals?: number;
-}) {
-  if (!active || !payload?.length) return null;
-  const { label, value } = payload[0].payload;
-  return (
-    <div
-      className="rounded border px-2 py-1 text-xs shadow-md"
-      style={{ background: 'var(--background)', borderColor: 'var(--border)' }}
-    >
-      <p style={{ color: 'var(--muted-foreground)' }}>{label}</p>
-      <p className="font-semibold">
-        {value.toFixed(decimals)}
-        {unit ? ` ${unit}` : ''}
-      </p>
-    </div>
-  );
-}
-
+/**
+ * ML model-metric trend. Reuses the shared parks/rides <Sparkline> for consistency (and
+ * to drop the ~100 KB recharts bundle this used to pull onto the homepage). Metrics vary
+ * little in absolute terms (e.g. r² ≈ 0.9), so it opts into the `fit` y-domain.
+ */
 export function MLSparkline({ history, metric, height = 140, unit, decimals = 1 }: Props) {
-  const validPoints = history.filter((m) => m[metric] != null);
-  if (validPoints.length < 2) return null;
-
-  const data: DataPoint[] = validPoints.map((m) => {
-    const date = new Date(m.trainedAt);
-    const label = date.toLocaleDateString('en', { month: 'short', day: 'numeric' });
-    return {
-      label,
+  const points: SparklinePoint[] = history
+    .filter((m) => m[metric] != null)
+    .map((m, i) => ({
+      x: i,
+      label: new Date(m.trainedAt).toLocaleDateString('en', { month: 'short', day: 'numeric' }),
       value: m[metric] as number,
-      isActive: m.isActive,
-    };
-  });
+    }));
 
-  const activeDot = data.findLast((d) => d.isActive);
-  const values = data.map((d) => d.value);
-  const min = Math.min(...values);
-  const max = Math.max(...values);
-  const padding = (max - min) * 0.2 || 1;
+  if (points.length < 2) return null;
+
+  const fmt = (v: number) => `${v.toFixed(decimals)}${unit ? ` ${unit}` : ''}`;
 
   return (
-    <ResponsiveContainer width="100%" height={height}>
-      <LineChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
-        <YAxis domain={[min - padding, max + padding]} hide />
-        <Line
-          type="monotone"
-          dataKey="value"
-          stroke={BRAND_BLUE}
-          strokeWidth={2}
-          dot={false}
-          isAnimationActive={false}
-        />
-        {activeDot && (
-          <ReferenceDot
-            x={activeDot.label}
-            y={activeDot.value}
-            r={4}
-            fill={BRAND_BLUE}
-            stroke="#fff"
-            strokeWidth={1.5}
-            label={{
-              value: `${activeDot.value.toFixed(decimals)}${unit ? ` ${unit}` : ''}`,
-              position: 'top',
-              fill: BRAND_BLUE,
-              fontSize: 11,
-              fontWeight: 600,
-            }}
-          />
-        )}
-        <Tooltip
-          content={<SparklineTooltip unit={unit} decimals={decimals} />}
-          cursor={{ stroke: '#888', strokeWidth: 1, strokeDasharray: '3 3' }}
-        />
-      </LineChart>
-    </ResponsiveContainer>
+    <div className="w-full" style={{ height, color: BRAND_BLUE }}>
+      <Sparkline
+        points={points}
+        yDomain="fit"
+        formatTooltip={(p) => ({ label: p.label, value: fmt(p.value) })}
+      />
+    </div>
   );
 }

--- a/components/parks/attraction-card.tsx
+++ b/components/parks/attraction-card.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
-import Image from 'next/image';
 import { Link } from '@/i18n/navigation';
+import { CardPhoto } from '@/components/parks/card-photo';
 import { useTranslations } from 'next-intl';
 import { Crown, TrendingUp, TrendingDown, Minus, ChartColumn, Clock, MapPin } from 'lucide-react';
 import { cn, stripNewPrefix } from '@/lib/utils';
@@ -157,44 +157,11 @@ export function AttractionCard({
         {/* Photo */}
         <div className="absolute inset-0 z-0 overflow-hidden">
           {backgroundImage ? (
-            <div
-              className={cn(
-                'pk-photo-zoom relative h-full w-full overflow-hidden',
-                !isOperatingOrUnknown && 'pk-photo-closed'
-              )}
-            >
-              <div className="absolute inset-x-0 bottom-0" style={{ top: '50px' }}>
-                <Image
-                  src={backgroundImage}
-                  alt={stripNewPrefix(attraction.name)}
-                  fill
-                  className="object-cover object-top"
-                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                  priority={false}
-                />
-                <div
-                  className="pointer-events-none absolute inset-0"
-                  style={{
-                    transform: 'scaleY(-1)',
-                    transformOrigin: 'center top',
-                    // Mask is applied BEFORE the flip: opaque at element top (= seam after flip)
-                    // and fading to transparent toward element bottom (= top of card after flip).
-                    maskImage: 'linear-gradient(to bottom, black 0%, transparent 16%)',
-                    WebkitMaskImage: 'linear-gradient(to bottom, black 0%, transparent 16%)',
-                  }}
-                >
-                  <Image
-                    src={backgroundImage}
-                    alt=""
-                    aria-hidden="true"
-                    fill
-                    className="object-cover object-top"
-                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                    priority={false}
-                  />
-                </div>
-              </div>
-            </div>
+            <CardPhoto
+              src={backgroundImage}
+              alt={stripNewPrefix(attraction.name)}
+              closed={!isOperatingOrUnknown}
+            />
           ) : (
             <div className="from-muted to-card h-full w-full bg-gradient-to-br" />
           )}

--- a/components/parks/card-photo.tsx
+++ b/components/parks/card-photo.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+
+// Park & ride cards render in a 1- / 2- / 3-column responsive grid.
+const SIZES = '(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw';
+
+interface CardPhotoProps {
+  src: string;
+  alt: string;
+  /** Desaturate while the park/ride is not operating (mirrors `pk-photo-closed`). */
+  closed?: boolean;
+  /** Hide the photo below `sm` and show only the gradient placeholder — park cards collapse
+   *  on phones, so the (decorative) photo download is skipped there. */
+  hideOnMobile?: boolean;
+}
+
+/**
+ * Background photo (main image + masked reflection) for ParkCard / AttractionCard.
+ *
+ * A tiny Client Component purely so the photo can **fade in over a stable gradient
+ * placeholder** once it loads — the cards themselves stay dual-use Server Components.
+ * Nearby/Favorites cards are client-rendered, so their lazy photos used to pop in and look
+ * like they "realigned" a few seconds after load on uncached views (cached = no jump). The
+ * placeholder keeps the area stable and the fade smooths the swap; cached images are caught
+ * via the ref so they show instantly with no fade-from-transparent flash.
+ */
+export function CardPhoto({ src, alt, closed, hideOnMobile }: CardPhotoProps) {
+  const [loaded, setLoaded] = useState(false);
+
+  // A cached image can finish before React attaches `onLoad`; the ref catches that case.
+  const captureImg = useCallback((node: HTMLImageElement | null) => {
+    if (node?.complete) setLoaded(true);
+  }, []);
+
+  return (
+    <>
+      {/* Stable gradient placeholder — visible while the photo loads (and on mobile when the
+          photo is hidden). Matches the no-image card fallback. */}
+      <div className="from-muted to-card absolute inset-0 bg-gradient-to-br" />
+
+      <div
+        className={cn(
+          'absolute inset-0 transition-opacity duration-500',
+          loaded ? 'opacity-100' : 'opacity-0',
+          hideOnMobile && 'hidden sm:block'
+        )}
+      >
+        <div
+          className={cn(
+            'pk-photo-zoom relative h-full w-full overflow-hidden',
+            closed && 'pk-photo-closed'
+          )}
+        >
+          <div className="absolute inset-x-0 bottom-0" style={{ top: '50px' }}>
+            {/* Main photo — top edge at the glass-header seam, fills downward. */}
+            <Image
+              ref={captureImg}
+              src={src}
+              alt={alt}
+              fill
+              className="object-cover object-top"
+              sizes={SIZES}
+              onLoad={() => setLoaded(true)}
+            />
+            {/* Reflection — same image flipped around the container top (= seam), masked to
+                fade out quickly. */}
+            <div
+              className="pointer-events-none absolute inset-0"
+              style={{
+                transform: 'scaleY(-1)',
+                transformOrigin: 'center top',
+                maskImage: 'linear-gradient(to bottom, black 0%, transparent 16%)',
+                WebkitMaskImage: 'linear-gradient(to bottom, black 0%, transparent 16%)',
+              }}
+            >
+              <Image
+                src={src}
+                alt=""
+                aria-hidden="true"
+                fill
+                className="object-cover object-top"
+                sizes={SIZES}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/parks/nearby-parks-card.tsx
+++ b/components/parks/nearby-parks-card.tsx
@@ -219,15 +219,6 @@ export function NearbyParksCard({ className }: { className?: string }) {
             {t('youAreInPark', { parkName: stripNewPrefix(park.name) })}
           </h2>
           <div className="space-y-4">
-            {!permissionGranted && !permissionDenied && (
-              <div className="bg-muted/50 border-border flex flex-wrap items-center justify-between gap-2 rounded-lg border px-3 py-2 text-sm">
-                <span className="text-muted-foreground">{t('locationHint')}</span>
-                <Button onClick={refresh} size="sm" variant="outline">
-                  <Navigation className="mr-1.5 h-3.5 w-3.5" />
-                  {t('enable')}
-                </Button>
-              </div>
-            )}
             {/* Quick navigation: primary CTA to park page when user is in park */}
             {parkPageUrl && (
               <div className="mb-4">
@@ -430,15 +421,9 @@ export function NearbyParksCard({ className }: { className?: string }) {
           <p className="text-muted-foreground mb-4 text-sm">{t('noOpenNearbyFocus')}</p>
         )}
         <div>
-          {!permissionGranted && !permissionDenied && (
-            <div className="bg-muted/50 border-border mb-4 flex flex-wrap items-center justify-between gap-2 rounded-lg border px-3 py-2 text-sm">
-              <span className="text-muted-foreground">{t('locationHint')}</span>
-              <Button onClick={refresh} size="sm" variant="outline">
-                <Navigation className="mr-1.5 h-3.5 w-3.5" />
-                {t('enable')}
-              </Button>
-            </div>
-          )}
+          {/* The location prompt lives in the floating LocationBanner now — an inline,
+              conditionally-rendered hint here would re-introduce an in-flow layout shift
+              (and duplicate the banner's message). */}
           <ul className="grid [grid-auto-rows:auto_1fr_auto] gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {parks.map((park, index) => {
               const hidden = !isExpanded && index >= 2;

--- a/components/parks/nowcast-update-countdown.tsx
+++ b/components/parks/nowcast-update-countdown.tsx
@@ -62,7 +62,7 @@ export function NowcastUpdateCountdown({
   const ss = String(totalSec % 60).padStart(2, '0');
 
   return (
-    <p className={cn('font-mono text-[11px] opacity-60', className)}>
+    <p className={cn('font-mono text-[11px] tabular-nums opacity-60', className)}>
       {t('updateIn', { countdown: `${mm}:${ss}` })}
     </p>
   );

--- a/components/parks/park-card.tsx
+++ b/components/parks/park-card.tsx
@@ -138,12 +138,19 @@ export function ParkCard({
         {/* Photo — z-0, inner div carries the hover scale */}
         <div className="absolute inset-0 z-0 overflow-hidden">
           {backgroundImage ? (
-            <div
-              className={cn(
-                'pk-photo-zoom relative h-full w-full overflow-hidden',
-                !isOperatingOrUnknown && 'pk-photo-closed'
-              )}
-            >
+            <>
+              {/* Mobile (<sm): skip the photo entirely. These cards collapse/scroll on
+                  phones and the photo is purely decorative — each one is rendered twice
+                  (main + reflection), so dropping it removes two image downloads per card
+                  on the slowest connections. Show the gradient fallback instead; desktop
+                  and tablet (sm+) keep the full photo. */}
+              <div className="from-muted to-card h-full w-full bg-gradient-to-br sm:hidden" />
+              <div
+                className={cn(
+                  'pk-photo-zoom relative hidden h-full w-full overflow-hidden sm:block',
+                  !isOperatingOrUnknown && 'pk-photo-closed'
+                )}
+              >
               {/*
                 Photo container starts exactly at glass-header bottom (~100px).
                 The photo's TOP edge is the seam. The reflection (scaleY-1 around
@@ -183,6 +190,7 @@ export function ParkCard({
                 </div>
               </div>
             </div>
+            </>
           ) : (
             <div className="from-muted to-card h-full w-full bg-gradient-to-br" />
           )}

--- a/components/parks/park-card.tsx
+++ b/components/parks/park-card.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from 'react';
-import Image from 'next/image';
 import { Link } from '@/i18n/navigation';
 import { MapPin } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
@@ -7,6 +6,7 @@ import { CrowdLevelBadge } from '@/components/parks/crowd-level-badge';
 import { ParkStatusBadge } from '@/components/parks/park-status-badge';
 import { FavoriteStar } from '@/components/common/favorite-star';
 import { ParkCardScheduleFooter } from '@/components/parks/park-card-schedule-footer';
+import { CardPhoto } from '@/components/parks/card-photo';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { formatDistance } from '@/lib/utils/distance-utils';
@@ -135,62 +135,16 @@ export function ParkCard({
           boxShadow: 'var(--pk-card-shadow)',
         }}
       >
-        {/* Photo — z-0, inner div carries the hover scale */}
+        {/* Photo — z-0, inner div carries the hover scale. Hidden below `sm` (cards collapse
+            on phones), so only the gradient placeholder shows there. */}
         <div className="absolute inset-0 z-0 overflow-hidden">
           {backgroundImage ? (
-            <>
-              {/* Mobile (<sm): skip the photo entirely. These cards collapse/scroll on
-                  phones and the photo is purely decorative — each one is rendered twice
-                  (main + reflection), so dropping it removes two image downloads per card
-                  on the slowest connections. Show the gradient fallback instead; desktop
-                  and tablet (sm+) keep the full photo. */}
-              <div className="from-muted to-card h-full w-full bg-gradient-to-br sm:hidden" />
-              <div
-                className={cn(
-                  'pk-photo-zoom relative hidden h-full w-full overflow-hidden sm:block',
-                  !isOperatingOrUnknown && 'pk-photo-closed'
-                )}
-              >
-              {/*
-                Photo container starts exactly at glass-header bottom (~100px).
-                The photo's TOP edge is the seam. The reflection (scaleY-1 around
-                the container top = seam) extends upward through the glass area.
-              */}
-              <div className="absolute inset-x-0 bottom-0" style={{ top: '50px' }}>
-                {/* Main photo — top edge at seam, fills downward */}
-                <Image
-                  src={backgroundImage}
-                  alt={name}
-                  fill
-                  className="object-cover object-top"
-                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                  priority={false}
-                />
-                {/* Reflection — same image flipped around the container top (= seam).
-                   Mask applies BEFORE the flip: opaque at element top (= seam after flip)
-                   fading to transparent toward the bottom (= top of card after flip). */}
-                <div
-                  className="pointer-events-none absolute inset-0"
-                  style={{
-                    transform: 'scaleY(-1)',
-                    transformOrigin: 'center top',
-                    maskImage: 'linear-gradient(to bottom, black 0%, transparent 16%)',
-                    WebkitMaskImage: 'linear-gradient(to bottom, black 0%, transparent 16%)',
-                  }}
-                >
-                  <Image
-                    src={backgroundImage}
-                    alt=""
-                    aria-hidden="true"
-                    fill
-                    className="object-cover object-top"
-                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                    priority={false}
-                  />
-                </div>
-              </div>
-            </div>
-            </>
+            <CardPhoto
+              src={backgroundImage}
+              alt={name}
+              closed={!isOperatingOrUnknown}
+              hideOnMobile
+            />
           ) : (
             <div className="from-muted to-card h-full w-full bg-gradient-to-br" />
           )}

--- a/components/parks/queue-type-badge.tsx
+++ b/components/parks/queue-type-badge.tsx
@@ -72,9 +72,7 @@ export function QueueTypeBadge({ queue, timezone }: QueueTypeBadgeProps) {
     case 'PAID_STANDBY': {
       Icon = Zap;
       const price = getFormattedPrice(queue);
-      label = price
-        ? t('queue.details.express', { price })
-        : t('queue.details.expressNoPrice');
+      label = price ? t('queue.details.express', { price }) : t('queue.details.expressNoPrice');
       colorClass = colorPaid;
       break;
     }

--- a/components/parks/sparkline.tsx
+++ b/components/parks/sparkline.tsx
@@ -14,23 +14,33 @@ interface SparklineProps {
   points: SparklinePoint[];
   className?: string;
   formatTooltip?: (point: SparklinePoint) => { label: string; value: string };
+  /**
+   * Y-axis scaling. `'zero'` (default) anchors the baseline at 0 — right for wait times.
+   * `'fit'` zooms to the data range (+20% headroom) so series with small relative variation
+   * (e.g. ML scores around 0.9) stay legible instead of flattening to a near-flat line.
+   */
+  yDomain?: 'zero' | 'fit';
 }
 
-export function Sparkline({ points, className, formatTooltip }: SparklineProps) {
+export function Sparkline({ points, className, formatTooltip, yDomain = 'zero' }: SparklineProps) {
   const [activePoint, setActivePoint] = useState<
     (SparklinePoint & { clientX: number; clientY: number }) | null
   >(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const mounted = useMounted();
 
-  const { xMin, xMax, yMax } = useMemo(() => {
-    if (points.length === 0) return { xMin: 0, xMax: 1, yMax: 10 };
-    return {
-      xMin: points[0].x,
-      xMax: points[points.length - 1].x,
-      yMax: Math.max(...points.map((p) => p.value), 10),
-    };
-  }, [points]);
+  const { xMin, xMax, yMin, yMax } = useMemo(() => {
+    if (points.length === 0) return { xMin: 0, xMax: 1, yMin: 0, yMax: 10 };
+    const values = points.map((p) => p.value);
+    const base = { xMin: points[0].x, xMax: points[points.length - 1].x };
+    if (yDomain === 'fit') {
+      const lo = Math.min(...values);
+      const hi = Math.max(...values);
+      const pad = (hi - lo) * 0.2 || 1;
+      return { ...base, yMin: lo - pad, yMax: hi + pad };
+    }
+    return { ...base, yMin: 0, yMax: Math.max(...values, 10) };
+  }, [points, yDomain]);
 
   useEffect(() => {
     if (points.length === 0) return;
@@ -65,8 +75,9 @@ export function Sparkline({ points, className, formatTooltip }: SparklineProps) 
   if (points.length === 0) return null;
 
   const xRange = xMax - xMin || 1;
+  const yRange = yMax - yMin || 1;
   const getX = (x: number) => ((x - xMin) / xRange) * 100;
-  const getY = (value: number) => 100 - (value / yMax) * 100;
+  const getY = (value: number) => 100 - ((value - yMin) / yRange) * 100;
 
   let pathD = '';
   points.forEach((p, i) => {

--- a/components/parks/wind-compass.tsx
+++ b/components/parks/wind-compass.tsx
@@ -59,10 +59,7 @@ export function WindCompass({ directionDeg, windKmh, className }: WindCompassPro
         // direction reads unambiguously instead of as a faint ">" caret. The
         // speed label nests in the centre gap so it stays legible over the
         // glass background.
-        <g
-          transform={`rotate(${directionDeg!} 50 50)`}
-          className="stroke-primary fill-primary"
-        >
+        <g transform={`rotate(${directionDeg!} 50 50)`} className="stroke-primary fill-primary">
           <line x1="50" y1="17" x2="50" y2="42" strokeWidth="3.5" strokeLinecap="round" />
           <polygon points="50,83 42,67 58,67" className="stroke-none" />
         </g>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,10 +18,13 @@ render-blocking stylesheet (not inlined), and a redundant font preload.
 - **framer-motion code-split** — the homepage `FlipClock` countdown is now a `next/dynamic`
   import, so framer-motion (~40 KB gzip) leaves the initial bundle and only loads when an
   announcement countdown is actually live.
-- **Critical CSS inlining restored** — the production `build` now passes `--webpack`. Beasties /
-  `optimizeCss` is Webpack-only, and Next 16 defaults to Turbopack for `next build`, so the
-  stylesheet was render-blocking (no inlined critical CSS). `build:turbo` keeps the Turbopack
-  path available. ⚠️ Verify on a preview deploy: critical-CSS extraction previously caused FOUC.
+
+### Known tradeoff
+
+- The single render-blocking stylesheet (~28 KB gzip) is **not** inlined: `optimizeCss`
+  (Beasties) is Webpack-only and we keep Turbopack for `next build` (build speed). Critical-CSS
+  extraction also previously caused FOUC. `build:webpack` remains for an inlined-CSS build if
+  ever needed.
 
 ### Follow-ups (audited, not yet done)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,10 +18,10 @@ render-blocking stylesheet (not inlined), and a redundant font preload.
 - **framer-motion code-split** — the homepage `FlipClock` countdown is now a `next/dynamic`
   import, so framer-motion (~40 KB gzip) leaves the initial bundle and only loads when an
   announcement countdown is actually live.
-- **Critical CSS inlining restored** — the production `build` runs Webpack again (Beasties /
-  `optimizeCss` is Webpack-only and was a no-op under `next build --turbo`, leaving the full
-  stylesheet render-blocking). `build:turbo` keeps the Turbopack path available. ⚠️ Verify on a
-  preview deploy: critical-CSS extraction previously caused FOUC.
+- **Critical CSS inlining restored** — the production `build` now passes `--webpack`. Beasties /
+  `optimizeCss` is Webpack-only, and Next 16 defaults to Turbopack for `next build`, so the
+  stylesheet was render-blocking (no inlined critical CSS). `build:turbo` keeps the Turbopack
+  path available. ⚠️ Verify on a preview deploy: critical-CSS extraction previously caused FOUC.
 
 ### Follow-ups (audited, not yet done)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,34 @@ Short log of notable changes; details live in the linked docs.
 
 ---
 
+## 2.9.1 (2026-06-06) – Post-PPR front-end weight trim
+
+Follow-up to the Cache Components migration after RUM showed FCP slipping into "needs
+improvement". Measured on the live homepage: ~444 KB gzip JS (24 chunks), one 28 KB-gzip
+render-blocking stylesheet (not inlined), and a redundant font preload.
+
+### Performance
+
+- **Geist_Mono dropped** — `font-mono` is aliased to Geist Sans in `globals.css`, removing a
+  ~30 KB render-blocking font preload on every route. Number-heavy live spots (nowcast
+  countdown) keep fixed-width digits via `tabular-nums`.
+- **framer-motion code-split** — the homepage `FlipClock` countdown is now a `next/dynamic`
+  import, so framer-motion (~40 KB gzip) leaves the initial bundle and only loads when an
+  announcement countdown is actually live.
+- **Critical CSS inlining restored** — the production `build` runs Webpack again (Beasties /
+  `optimizeCss` is Webpack-only and was a no-op under `next build --turbo`, leaving the full
+  stylesheet render-blocking). `build:turbo` keeps the Turbopack path available. ⚠️ Verify on a
+  preview deploy: critical-CSS extraction previously caused FOUC.
+
+### Follow-ups (audited, not yet done)
+
+- ML sparkline still pulls **recharts (~100 KB)** for one line — migrate to the lightweight
+  SVG `Sparkline` (needs a custom y-domain + active-dot).
+- Header `SearchCommand` ships **cmdk** on every page though the dialog only opens on click —
+  lazy-load the `CommandDialog`.
+
+---
+
 ## 2.9.0 (2026-06-05) – Next.js 16 Cache Components (PPR)
 
 Full migration to `cacheComponents: true` (Partial Prerendering). Pages now ship as a static,

--- a/lib/attraction-images.ts
+++ b/lib/attraction-images.ts
@@ -8,7 +8,8 @@
  */
 export const ATTRACTION_IMAGES: Record<string, string> = {
   'attractiepark-toverland/fenix': '/images/parks/attractiepark-toverland/fenix.jpg',
-  'attractiepark-toverland/maximus-blitzbahn': '/images/parks/attractiepark-toverland/maximus-blitzbahn.jpeg',
+  'attractiepark-toverland/maximus-blitzbahn':
+    '/images/parks/attractiepark-toverland/maximus-blitzbahn.jpeg',
   'attractiepark-toverland/troy': '/images/parks/attractiepark-toverland/troy.jpg',
   'attractiepark-toverland/villa-fiasko': '/images/parks/attractiepark-toverland/villa-fiasko.jpg',
   'bobbejaanland/fury': '/images/parks/bobbejaanland/fury.jpg',
@@ -28,17 +29,23 @@ export const ATTRACTION_IMAGES: Record<string, string> = {
   'europa-park/castello-dei-medici': '/images/parks/europa-park/castello-dei-medici.jpg',
   'europa-park/eurosat-cancan-coaster': '/images/parks/europa-park/eurosat-cancan-coaster.jpg',
   'europa-park/eurosat-coastiality': '/images/parks/europa-park/eurosat-coastiality.jpg',
-  'europa-park/madame-freudenreich-curiosites': '/images/parks/europa-park/madame-freudenreich-curiosites.jpg',
+  'europa-park/madame-freudenreich-curiosites':
+    '/images/parks/europa-park/madame-freudenreich-curiosites.jpg',
   'europa-park/matterhorn-blitz': '/images/parks/europa-park/matterhorn-blitz.jpg',
   'europa-park/pirates-in-batavia': '/images/parks/europa-park/pirates-in-batavia.jpg',
   'europa-park/silver-star': '/images/parks/europa-park/silver-star.jpg',
-  'europa-park/voltron-nevera-powered-by-rimac': '/images/parks/europa-park/voltron-nevera-powered-by-rimac.jpg',
-  'europa-park/water-rollercoaster-poseidon': '/images/parks/europa-park/water-rollercoaster-poseidon.jpg',
+  'europa-park/voltron-nevera-powered-by-rimac':
+    '/images/parks/europa-park/voltron-nevera-powered-by-rimac.jpg',
+  'europa-park/water-rollercoaster-poseidon':
+    '/images/parks/europa-park/water-rollercoaster-poseidon.jpg',
   'europa-park/wodan-timburcoaster': '/images/parks/europa-park/wodan-timburcoaster.jpg',
-  'movie-park-germany/area-51-top-secret': '/images/parks/movie-park-germany/area-51-top-secret.jpg',
+  'movie-park-germany/area-51-top-secret':
+    '/images/parks/movie-park-germany/area-51-top-secret.jpg',
   'movie-park-germany/iron-claw': '/images/parks/movie-park-germany/iron-claw.jpg',
-  'movie-park-germany/movie-park-studio-tour': '/images/parks/movie-park-germany/movie-park-studio-tour.jpg',
-  'movie-park-germany/star-trek-operation-enterprise': '/images/parks/movie-park-germany/star-trek-operation-enterprise.jpg',
+  'movie-park-germany/movie-park-studio-tour':
+    '/images/parks/movie-park-germany/movie-park-studio-tour.jpg',
+  'movie-park-germany/star-trek-operation-enterprise':
+    '/images/parks/movie-park-germany/star-trek-operation-enterprise.jpg',
   'phantasialand/black-mamba': '/images/parks/phantasialand/black-mamba.jpg',
   'phantasialand/chiapas-die-wasserbahn': '/images/parks/phantasialand/chiapas-die-wasserbahn.jpg',
   'phantasialand/colorado-adventure': '/images/parks/phantasialand/colorado-adventure.jpg',

--- a/lib/utils/image-loader.ts
+++ b/lib/utils/image-loader.ts
@@ -2,13 +2,16 @@ import type { ImageLoaderProps } from 'next/image';
 
 /**
  * Shared next/image loader for full-bleed background images (homepage hero, park &
- * ride pages). Mobile-width renditions (≤828px) get a lighter q75 where the loss is
- * imperceptible and the LCP byte savings matter most on slow networks; everything
- * larger stays at full q90 for crisp desktop/tablet images.
+ * ride pages). These always sit under gradient overlays + opacity-90 (and a ken-burns
+ * transform on the hero), so mobile-width renditions (≤828px) get a lighter q60 where
+ * the loss is imperceptible and the LCP byte savings matter most on slow networks
+ * — the hero LCP image was ~109 KB at q75 / ~80 KB at q60 (w=828). Desktop/tablet
+ * (>828px) stays at full q90 for crisp images. The 828px cutoff is the clean
+ * mobile↔desktop boundary in `deviceSizes`.
  *
  * Quality values must be listed in next.config `images.qualities`.
  */
 export function backgroundImageLoader({ src, width }: ImageLoaderProps): string {
-  const quality = width <= 828 ? 75 : 90;
+  const quality = width <= 828 ? 60 : 90;
   return `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${quality}`;
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -43,6 +43,7 @@
     "today": "Heute",
     "tomorrow": "Morgen",
     "closed": "Geschlossen",
+    "close": "Schließen",
     "open": "Geöffnet",
     "current": "Aktuell",
     "timeSuffix": " Uhr",

--- a/messages/en.json
+++ b/messages/en.json
@@ -18,6 +18,7 @@
     "today": "Today",
     "tomorrow": "Tomorrow",
     "closed": "Closed",
+    "close": "Close",
     "open": "Open",
     "current": "Current",
     "timeSuffix": "",

--- a/messages/es.json
+++ b/messages/es.json
@@ -18,6 +18,7 @@
     "today": "Hoy",
     "tomorrow": "Mañana",
     "closed": "Cerrado",
+    "close": "Cerrar",
     "open": "Abierto",
     "current": "Actual",
     "timeSuffix": "",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -18,6 +18,7 @@
     "today": "Aujourd'hui",
     "tomorrow": "Demain",
     "closed": "Fermé",
+    "close": "Fermer",
     "open": "Ouvert",
     "current": "Actuel",
     "timeSuffix": "",

--- a/messages/it.json
+++ b/messages/it.json
@@ -18,6 +18,7 @@
     "today": "Oggi",
     "tomorrow": "Domani",
     "closed": "Chiuso",
+    "close": "Chiudi",
     "open": "Aperto",
     "current": "Attuale",
     "timeSuffix": "",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -18,6 +18,7 @@
     "today": "Vandaag",
     "tomorrow": "Morgen",
     "closed": "Gesloten",
+    "close": "Sluiten",
     "open": "Open",
     "current": "Huidig",
     "timeSuffix": "",

--- a/next.config.ts
+++ b/next.config.ts
@@ -29,7 +29,6 @@ const nextConfig: NextConfig = {
       '@radix-ui/react-scroll-area',
       '@radix-ui/react-separator',
       '@radix-ui/react-slot',
-      'recharts',
     ],
     // Optimize CSS to reduce render-blocking
     optimizeCss: true,

--- a/next.config.ts
+++ b/next.config.ts
@@ -42,7 +42,7 @@ const nextConfig: NextConfig = {
     formats: ['image/avif', 'image/webp'],
     deviceSizes: [640, 828, 1080, 1200, 1920, 2560, 3840],
     imageSizes: [32, 48, 64, 96, 128, 256, 384],
-    qualities: [75, 85, 90],
+    qualities: [60, 75, 85, 90],
     minimumCacheTTL: 31536000, // 1 year
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "react-dom": "19.2.6",
     "react-leaflet": "^5.0.0",
     "react-markdown": "^10.1.0",
-    "recharts": "^3.8.1",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -78,14 +77,6 @@
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "postcss": "^8.5.10"
-    },
-    "onlyBuiltDependencies": [
-      "@swc/core"
-    ]
   },
   "browserslist": [
     "chrome >= 109",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "park.fan",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "private": true,
   "license": "GPL-3.0-only",
   "author": "Patrick Arns",
   "scripts": {
     "dev": "next dev --turbopack",
     "prebuild": "node scripts/generate-build-info.mjs && node scripts/generate-client-glossary.mjs && pnpm generate:hero-images && pnpm generate:attraction-images",
-    "build": "pnpm prebuild && next build --turbo",
+    "build": "pnpm prebuild && next build",
+    "build:turbo": "pnpm prebuild && next build --turbo",
     "analyze": "pnpm prebuild && cross-env ANALYZE=true next build --webpack",
     "build:webpack": "pnpm prebuild && next build",
     "generate:hero-images": "node scripts/generate-hero-images.mjs",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "prebuild": "node scripts/generate-build-info.mjs && node scripts/generate-client-glossary.mjs && pnpm generate:hero-images && pnpm generate:attraction-images",
-    "build": "pnpm prebuild && next build",
+    "build": "pnpm prebuild && next build --webpack",
     "build:turbo": "pnpm prebuild && next build --turbo",
     "analyze": "pnpm prebuild && cross-env ANALYZE=true next build --webpack",
-    "build:webpack": "pnpm prebuild && next build",
+    "build:webpack": "pnpm prebuild && next build --webpack",
     "generate:hero-images": "node scripts/generate-hero-images.mjs",
     "generate:attraction-images": "node scripts/generate-attraction-images.mjs",
     "generate:client-glossary": "node scripts/generate-client-glossary.mjs",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "prebuild": "node scripts/generate-build-info.mjs && node scripts/generate-client-glossary.mjs && pnpm generate:hero-images && pnpm generate:attraction-images",
-    "build": "pnpm prebuild && next build --webpack",
-    "build:turbo": "pnpm prebuild && next build --turbo",
+    "build": "pnpm prebuild && next build --turbo",
     "analyze": "pnpm prebuild && cross-env ANALYZE=true next build --webpack",
     "build:webpack": "pnpm prebuild && next build --webpack",
     "generate:hero-images": "node scripts/generate-hero-images.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,6 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.16)(react@19.2.6)
-      recharts:
-        specifier: ^3.8.1
-        version: 3.8.1(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react-is@16.13.1)(react@19.2.6)(redux@5.0.1)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -1108,28 +1105,11 @@ packages:
       react: ^19.0.0
       react-dom: ^19.0.0
 
-  '@reduxjs/toolkit@2.12.0':
-    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
-    peerDependencies:
-      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
-      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-redux:
-        optional: true
-
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
-
-  '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@standard-schema/utils@0.3.0':
-    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/core-darwin-arm64@1.15.40':
     resolution: {integrity: sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==}
@@ -1339,33 +1319,6 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
-  '@types/d3-array@3.2.2':
-    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
-
-  '@types/d3-color@3.1.3':
-    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
-
-  '@types/d3-ease@3.0.2':
-    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
-
-  '@types/d3-interpolate@3.0.4':
-    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
-
-  '@types/d3-path@3.1.1':
-    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
-
-  '@types/d3-scale@4.0.9':
-    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
-
-  '@types/d3-shape@3.1.8':
-    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
-
-  '@types/d3-time@3.0.4':
-    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
-
-  '@types/d3-timer@3.0.2':
-    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
-
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1415,9 +1368,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/use-sync-external-store@0.0.6':
-    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.60.0':
     resolution: {integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==}
@@ -1806,50 +1756,6 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  d3-array@3.2.4:
-    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
-    engines: {node: '>=12'}
-
-  d3-color@3.1.0:
-    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
-    engines: {node: '>=12'}
-
-  d3-ease@3.0.1:
-    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
-    engines: {node: '>=12'}
-
-  d3-format@3.1.2:
-    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
-    engines: {node: '>=12'}
-
-  d3-interpolate@3.0.1:
-    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
-    engines: {node: '>=12'}
-
-  d3-path@3.1.0:
-    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
-    engines: {node: '>=12'}
-
-  d3-scale@4.0.2:
-    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
-    engines: {node: '>=12'}
-
-  d3-shape@3.2.0:
-    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
-    engines: {node: '>=12'}
-
-  d3-time-format@4.1.0:
-    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
-    engines: {node: '>=12'}
-
-  d3-time@3.1.0:
-    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
-    engines: {node: '>=12'}
-
-  d3-timer@3.0.1:
-    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
-    engines: {node: '>=12'}
-
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1892,9 +1798,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  decimal.js-light@2.5.1:
-    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1997,9 +1900,6 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
-
-  es-toolkit@1.47.0:
-    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2138,9 +2038,6 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
-
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -2338,12 +2235,6 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  immer@10.2.0:
-    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
-
-  immer@11.1.8:
-    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
-
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -2354,10 +2245,6 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
-
-  internmap@2.0.3:
-    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
 
   intl-messageformat@11.2.7:
     resolution: {integrity: sha512-+q6Ktg119nULZEpZ8YTuGOst9MyEzFtjD63FTGBlN1mLz0Z/MOUYDIvnpVKwq17eezIEh+cfJIebfJoCetpiNw==}
@@ -3052,18 +2939,6 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
-  react-redux@9.3.0:
-    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
-    peerDependencies:
-      '@types/react': ^18.2.25 || ^19
-      react: ^18.0 || ^19
-      redux: ^5.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      redux:
-        optional: true
-
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -3098,22 +2973,6 @@ packages:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
 
-  recharts@3.8.1:
-    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  redux-thunk@3.1.0:
-    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
-    peerDependencies:
-      redux: ^5.0.0
-
-  redux@5.0.1:
-    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
-
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3127,9 +2986,6 @@ packages:
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
-
-  reselect@5.1.1:
-    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -3302,9 +3158,6 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tiny-invariant@1.3.3:
-    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -3442,9 +3295,6 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
-
-  victory-vendor@37.3.6:
-    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   webpack-bundle-analyzer@4.10.1:
     resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
@@ -4360,25 +4210,9 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.16)(react@19.2.6)(redux@5.0.1))(react@19.2.6)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@standard-schema/utils': 0.3.0
-      immer: 11.1.8
-      redux: 5.0.1
-      redux-thunk: 3.1.0(redux@5.0.1)
-      reselect: 5.1.1
-    optionalDependencies:
-      react: 19.2.6
-      react-redux: 9.3.0(@types/react@19.2.16)(react@19.2.6)(redux@5.0.1)
-
   '@rtsao/scc@1.1.0': {}
 
   '@schummar/icu-type-parser@1.21.5': {}
-
-  '@standard-schema/spec@1.1.0': {}
-
-  '@standard-schema/utils@0.3.0': {}
 
   '@swc/core-darwin-arm64@1.15.40':
     optional: true
@@ -4533,30 +4367,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/d3-array@3.2.2': {}
-
-  '@types/d3-color@3.1.3': {}
-
-  '@types/d3-ease@3.0.2': {}
-
-  '@types/d3-interpolate@3.0.4':
-    dependencies:
-      '@types/d3-color': 3.1.3
-
-  '@types/d3-path@3.1.1': {}
-
-  '@types/d3-scale@4.0.9':
-    dependencies:
-      '@types/d3-time': 3.0.4
-
-  '@types/d3-shape@3.1.8':
-    dependencies:
-      '@types/d3-path': 3.1.1
-
-  '@types/d3-time@3.0.4': {}
-
-  '@types/d3-timer@3.0.2': {}
-
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -4604,8 +4414,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -5007,44 +4815,6 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  d3-array@3.2.4:
-    dependencies:
-      internmap: 2.0.3
-
-  d3-color@3.1.0: {}
-
-  d3-ease@3.0.1: {}
-
-  d3-format@3.1.2: {}
-
-  d3-interpolate@3.0.1:
-    dependencies:
-      d3-color: 3.1.0
-
-  d3-path@3.1.0: {}
-
-  d3-scale@4.0.2:
-    dependencies:
-      d3-array: 3.2.4
-      d3-format: 3.1.2
-      d3-interpolate: 3.0.1
-      d3-time: 3.1.0
-      d3-time-format: 4.1.0
-
-  d3-shape@3.2.0:
-    dependencies:
-      d3-path: 3.1.0
-
-  d3-time-format@4.1.0:
-    dependencies:
-      d3-time: 3.1.0
-
-  d3-time@3.1.0:
-    dependencies:
-      d3-array: 3.2.4
-
-  d3-timer@3.0.1: {}
-
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -5080,8 +4850,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -5255,8 +5023,6 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  es-toolkit@1.47.0: {}
-
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -5266,7 +5032,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.4.1(jiti@2.7.0))
@@ -5293,7 +5059,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5308,14 +5074,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -5330,7 +5096,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -5469,8 +5235,6 @@ snapshots:
   estree-util-is-identifier-name@3.0.0: {}
 
   esutils@2.0.3: {}
-
-  eventemitter3@5.0.4: {}
 
   extend-shallow@2.0.1:
     dependencies:
@@ -5681,10 +5445,6 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  immer@10.2.0: {}
-
-  immer@11.1.8: {}
-
   imurmurhash@0.1.4: {}
 
   inline-style-parser@0.2.7: {}
@@ -5694,8 +5454,6 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.0
-
-  internmap@2.0.3: {}
 
   intl-messageformat@11.2.7:
     dependencies:
@@ -6451,15 +6209,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-redux@9.3.0(@types/react@19.2.16)(react@19.2.6)(redux@5.0.1):
-    dependencies:
-      '@types/use-sync-external-store': 0.0.6
-      react: 19.2.6
-      use-sync-external-store: 1.6.0(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.16
-      redux: 5.0.1
-
   react-remove-scroll-bar@2.3.8(@types/react@19.2.16)(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -6488,32 +6237,6 @@ snapshots:
       '@types/react': 19.2.16
 
   react@19.2.6: {}
-
-  recharts@3.8.1(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react-is@16.13.1)(react@19.2.6)(redux@5.0.1):
-    dependencies:
-      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.16)(react@19.2.6)(redux@5.0.1))(react@19.2.6)
-      clsx: 2.1.1
-      decimal.js-light: 2.5.1
-      es-toolkit: 1.47.0
-      eventemitter3: 5.0.4
-      immer: 10.2.0
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      react-is: 16.13.1
-      react-redux: 9.3.0(@types/react@19.2.16)(react@19.2.6)(redux@5.0.1)
-      reselect: 5.1.1
-      tiny-invariant: 1.3.3
-      use-sync-external-store: 1.6.0(react@19.2.6)
-      victory-vendor: 37.3.6
-    transitivePeerDependencies:
-      - '@types/react'
-      - redux
-
-  redux-thunk@3.1.0(redux@5.0.1):
-    dependencies:
-      redux: 5.0.1
-
-  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6551,8 +6274,6 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
-
-  reselect@5.1.1: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -6790,8 +6511,6 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tiny-invariant@1.3.3: {}
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6987,23 +6706,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  victory-vendor@37.3.6:
-    dependencies:
-      '@types/d3-array': 3.2.2
-      '@types/d3-ease': 3.0.2
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-scale': 4.0.9
-      '@types/d3-shape': 3.1.8
-      '@types/d3-time': 3.0.4
-      '@types/d3-timer': 3.0.2
-      d3-array: 3.2.4
-      d3-ease: 3.0.1
-      d3-interpolate: 3.0.1
-      d3-scale: 4.0.2
-      d3-shape: 3.2.0
-      d3-time: 3.1.0
-      d3-timer: 3.0.1
 
   webpack-bundle-analyzer@4.10.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,9 @@
 packages:
   - .
+overrides:
+  postcss: ^8.5.10
+onlyBuiltDependencies:
+  - '@swc/core'
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver


### PR DESCRIPTION
## Kontext

Follow-up zur Cache-Components-Migration (#125). RUM zeigte nach dem Release FCP im "Needs improvement"-Bereich (p75 ~2,1 s), während LCP/TTFB/CLS/INP "Good" sind. Das Muster (FCP schlecht, TTFB gut) deutet auf den **render-blockierenden kritischen Pfad** (JS/CSS/Dokument), nicht auf ein Daten-/Streaming-Problem.

### Live auf `park.fan/de` gemessen
| Ressource | gzip | Befund |
|-----------|------|--------|
| JavaScript (24 Chunks) | **444 KB** | größter Hebel (INP/TBT/Hydration) |
| HTML-Dokument | ~70 KB (429 KB roh) | viel RSC-Tree |
| CSS (render-blocking, **nicht** inlined) | 28 KB | `optimizeCss` greift unter `--turbo` nicht |
| Fonts (Geist + Geist_Mono) | 60 KB | Mono-Preload reduzierbar |
| i18n-Messages | 36 KB | nur ~2,7 KB sicher droppbar → verworfen |

## Änderungen in diesem PR

- **Geist_Mono komplett entfernt** — `font-mono` ist in `globals.css` auf Geist Sans aliasiert, damit alle bestehenden `font-mono`-Utilities ohne Massen-Edit weiter rendern (in Geist). Spart einen ~30 KB render-blockierenden Font-Preload auf **jeder** Route. Entfernt aus `[locale]`- und `admin`-Layout. Der Nowcast-Countdown behält feste Ziffernbreite via `tabular-nums`.
- **framer-motion code-split** — die Homepage-`FlipClock` ist jetzt ein `next/dynamic`-Import; framer-motion (~40 KB gzip) verlässt das Initial-Bundle und lädt nur, wenn ein Announcement-Countdown aktiv ist.
- **Critical-CSS-Inlining reaktiviert** — Prod-`build` läuft wieder mit Webpack (Beasties/`optimizeCss` ist Webpack-only und war unter `next build --turbo` wirkungslos). `build:turbo` bleibt als Option erhalten.

## ⚠️ Vor dem Merge verifizieren
- **FOUC-Risiko:** Critical-CSS-Extraktion hat früher Flicker verursacht (`b73d85b`, `5d306f7`). Bitte auf einem Preview-Deploy prüfen, dass kein FOUC auftritt und das CSS tatsächlich inlined wird (`<style>` statt blockierendem `<link rel=stylesheet>`).
- **Build-Zeit:** Webpack-Build ist langsamer als Turbopack.
- Konnte hier nicht lokal gebaut/gelintet werden (kein `node_modules`/API im Container) — CI/Preview validiert.

## Folge-Empfehlungen (auditiert, noch offen)
- **recharts (~100 KB)** wird nur für die ML-Sparkline geladen → auf die vorhandene leichte SVG-`Sparkline` umstellen (braucht custom y-domain + active-dot).
- Header-`SearchCommand` liefert **cmdk** auf jeder Seite aus, obwohl der Dialog erst bei Klick öffnet → `CommandDialog` lazy-laden.
- `pnpm analyze` für die exakte Chunk-Aufteilung.

https://claude.ai/code/session_01BX3YanZ3p68oY6XxJx3N9S

---
_Generated by [Claude Code](https://claude.ai/code/session_01BX3YanZ3p68oY6XxJx3N9S)_