### PR TITLE
perf(cache): cut ISR writes ~10–70× by decoupling park/attraction shells from live cadence

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -101,7 +101,9 @@ export async function generateMetadata({ params }: HomePageProps): Promise<Metad
 // hero server-rendered for LCP.
 async function pickHeroImage(): Promise<string> {
   'use cache';
-  cacheLife({ stale: 300, revalidate: 300, expire: 900 });
+  // Hourly rotation is plenty for a decorative hero. A 5-min window made this the MIN cacheLife in
+  // the homepage shell, pinning the (6-locale) homepage to a 5-min ISR-write cadence for nothing.
+  cacheLife('hours');
   return HERO_IMAGES[Math.floor(Math.random() * HERO_IMAGES.length)];
 }
 

--- a/docs/architecture/caching-strategy.md
+++ b/docs/architecture/caching-strategy.md
@@ -24,8 +24,8 @@ Next.js ISR controls revalidation per route:
 | Continent  | Static ISR | 300 (5m)   | 120s      | Geo structure (rarely changes)                            |
 | Country    | Static ISR | 300 (5m)   | 300s      | Prerendered; live park stats via React Query              |
 | City       | Static ISR | 300 (5m)   | 300s      | Prerendered; live park stats via React Query              |
-| Park       | Static ISR | 300 (5m)   | 300s      | On-demand ISR; live wait times + weather via RQ on client |
-| Attraction | Static ISR | 300 (5m)   | 300s      | On-demand ISR; live wait times via React Query on client  |
+| Park       | Static ISR | 3600 (1h)  | 300s      | On-demand ISR; live wait times + weather via RQ on client |
+| Attraction | Static ISR | 3600 (1h)  | 300s      | On-demand ISR; live wait times via React Query on client  |
 | Search     | Dynamic    | —          | 60s       | `force-dynamic`; uses `cache: 'no-store'`                 |
 
 > **Temperature unit & static park pages:** weather/calendar values are server-rendered
@@ -33,10 +33,36 @@ Next.js ISR controls revalidation per route:
 > `html[data-temp-unit]` which an inline script in the root layout sets before paint — see
 > `components/common/unit-display.tsx`). This removed the per-request `temp_unit` cookie
 > read, and the park/attraction fetches (`getParkByGeoPath`, `getAttractionByGeoPath`,
-> `getParkWeatherNowcast`, the `stats` retry) were switched from `cache: 'no-store'` to
-> `revalidate: 300` — together these let the park & attraction pages render as on-demand
-> ISR (edge-cached) with no unit flash. Live wait times/weather stay fresh via client-side
-> React Query (`LiveParkData` / `useWeatherNowcast`, 5-min poll).
+> `getParkWeatherNowcast`, the `stats` retry) render as on-demand ISR (edge-cached) with no
+> unit flash. Live wait times/weather stay fresh via client-side React Query (`LiveParkData` /
+> `useWeatherNowcast`, 5-min poll).
+
+---
+
+## Minimizing ISR Writes (Jun 2026)
+
+**Problem:** Vercel bills an **ISR write** every time a cache unit (route shell or `'use cache'`
+data entry) revalidates and is persisted. Under Cache Components, a route shell's effective
+revalidate is the **MIN cacheLife of the `'use cache'` reads in its static portion**. The park &
+attraction shells are the highest-cardinality routes (`N_parks`/`N_attractions × 6 locales`), so a
+short shell TTL multiplied across them dominated the write bill.
+
+**Key insight:** the shells don't need live freshness. Wait times, weather and today's crowd level
+are all refreshed **client-side** (React Query, `cache: 'no-store'`); the server-rendered numbers
+are only an SSR seed replaced on mount. The shell content that matters for SEO/no-JS (name,
+description, attraction list, FAQ, structured data) changes at most daily.
+
+**Changes:**
+
+| Lever                                   | Before        | After        | Effect                                              |
+| --------------------------------------- | ------------- | ------------ | --------------------------------------------------- |
+| `PARK_MAX_AGE` (park/attraction shell)  | 300s          | **3600s**    | Park + attraction shell writes ~12× fewer (dominant) |
+| `getServerNowMs` (`server-time.ts`)     | 300s          | **`'hours'`** | Removes the hidden 5-min floor it pinned on the park shell |
+| `getParkHistoricalStats`                | 300s          | **3600s**    | Retry loop already warms cold compute in one fill; data is daily |
+| Analytics (`getGlobalStats`/ticker/geo) | 300s          | **600s**     | Minor — single shared keys streamed in homepage Suspense holes |
+
+> Both `PARK_MAX_AGE` **and** `getServerNowMs` had to be raised together: the park shell floor is
+> their MIN, so lifting only one would have left it pinned at 300s.
 
 ---
 
@@ -82,8 +108,8 @@ In `next.config.ts`:
 | -------------------------- | -------------------- | --------- | ------------------------------ |
 | `/v1/search`               | `cache: 'no-store'`  | 60s       | Always fresh search results    |
 | `/v1/analytics/*`          | `cache: 'no-store'`  | 120s      | Real-time statistics           |
-| `/v1/parks/*` (detail)     | `revalidate: 300s`   | 300s      | ISR-cacheable; live via RQ     |
-| `/v1/parks/*/attractions`  | `revalidate: 300s`   | 300s      | ISR-cacheable; live via RQ     |
+| `/v1/parks/*` (detail)     | `revalidate: 3600s`  | 300s      | Shell seed; live via RQ        |
+| `/v1/parks/*/attractions`  | `revalidate: 3600s`  | 300s      | Shell seed; live via RQ        |
 | `/v1/discovery/geo`        | `revalidate: 3600s`  | 120s      | Geo structure (rarely changes) |
 | `/v1/discovery/continents` | `revalidate: 3600s`  | 120s      | Geo structure (rarely changes) |
 | Calendar                   | `revalidate: 3600s`  | 300-3600s | Schedule data (changes daily)  |

--- a/docs/architecture/caching-strategy.md
+++ b/docs/architecture/caching-strategy.md
@@ -25,7 +25,7 @@ Next.js ISR controls revalidation per route:
 | Country    | Static ISR | 300 (5m)   | 300s      | Prerendered; live park stats via React Query              |
 | City       | Static ISR | 300 (5m)   | 300s      | Prerendered; live park stats via React Query              |
 | Park       | Static ISR | 3600 (1h)  | 300s      | On-demand ISR; live wait times + weather via RQ on client |
-| Attraction | Static ISR | 3600 (1h)  | 300s      | On-demand ISR; live wait times via React Query on client  |
+| Attraction | Static ISR | 21600 (6h) | 300s      | On-demand ISR; live wait times via React Query on client  |
 | Search     | Dynamic    | —          | 60s       | `force-dynamic`; uses `cache: 'no-store'`                 |
 
 > **Temperature unit & static park pages:** weather/calendar values are server-rendered
@@ -41,28 +41,48 @@ Next.js ISR controls revalidation per route:
 
 ## Minimizing ISR Writes (Jun 2026)
 
-**Problem:** Vercel bills an **ISR write** every time a cache unit (route shell or `'use cache'`
-data entry) revalidates and is persisted. Under Cache Components, a route shell's effective
-revalidate is the **MIN cacheLife of the `'use cache'` reads in its static portion**. The park &
-attraction shells are the highest-cardinality routes (`N_parks`/`N_attractions × 6 locales`), so a
-short shell TTL multiplied across them dominated the write bill.
+**Root cause:** park & attraction pages were **dynamic** (no ISR writes at all) until they were
+switched to **static ISR with `revalidate: 300`** (the dual-unit CSS / on-demand-ISR change). That
+flipped ISR writes on across the *entire* catalog × 6 locales — Vercel ISR Write Units went from
+near-zero to ~250k/day. Vercel bills an **ISR write** every time a cache unit (route shell or
+`'use cache'` data entry) revalidates and is persisted, and under Cache Components a route shell's
+effective revalidate is the **MIN cacheLife of the `'use cache'` reads in its static portion**. The
+park & attraction shells are the highest-cardinality routes (`N_parks`/`N_attractions × 6 locales`),
+so the 5-min floor multiplied across them dominated the bill.
 
-**Key insight:** the shells don't need live freshness. Wait times, weather and today's crowd level
-are all refreshed **client-side** (React Query, `cache: 'no-store'`); the server-rendered numbers
-are only an SSR seed replaced on mount. The shell content that matters for SEO/no-JS (name,
-description, attraction list, FAQ, structured data) changes at most daily.
+**Key insight:** the shells don't need live freshness. Wait times, **open/closed status**, weather
+and today's crowd level are all refreshed **client-side** (React Query, `cache: 'no-store'`,
+5-min poll + refetch on mount/focus — see `use-live-park-data.ts`); the server-rendered values are
+only an SSR seed replaced on mount. **For any visitor with JS the shell TTL is invisible** — it only
+governs first paint, no-JS visitors and crawlers. The shell content that matters for SEO/no-JS
+(name, description, attraction list, FAQ, structured data) changes at most daily.
 
 **Changes:**
 
-| Lever                                   | Before        | After        | Effect                                              |
-| --------------------------------------- | ------------- | ------------ | --------------------------------------------------- |
-| `PARK_MAX_AGE` (park/attraction shell)  | 300s          | **3600s**    | Park + attraction shell writes ~12× fewer (dominant) |
-| `getServerNowMs` (`server-time.ts`)     | 300s          | **`'hours'`** | Removes the hidden 5-min floor it pinned on the park shell |
-| `getParkHistoricalStats`                | 300s          | **3600s**    | Retry loop already warms cold compute in one fill; data is daily |
-| Analytics (`getGlobalStats`/ticker/geo) | 300s          | **600s**     | Minor — single shared keys streamed in homepage Suspense holes |
+| Lever                                   | Before        | After         | Effect                                                       |
+| --------------------------------------- | ------------- | ------------- | ------------------------------------------------------------ |
+| `PARK_MAX_AGE` (park shell)             | 300s          | **3600s**     | Park shell writes ~12× fewer; keeps schedule/status reasonably fresh |
+| `ATTRACTION_MAX_AGE` (attraction shell) | 300s          | **21600s**    | Dominant route (highest cardinality, no schedule in shell) → ~72× fewer |
+| `getServerNowMs` (`server-time.ts`)     | 300s          | **`'hours'`** | Removes the hidden 5-min floor it pinned on the park shell   |
+| `getParkWeatherNowcast` (shell seed)    | 900s          | **3600s**     | Was capping the park shell at 15 min; client poll stays fresh |
+| `getParkHistoricalStats`                | 300s          | **3600s**     | Retry loop already warms cold compute in one fill; data is daily |
+| `getPopularParks`                       | 300s          | **1800s**     | Slow-moving ranking; feeds generateStaticParams + home seed  |
+| `pickHeroImage` (homepage shell)        | 300s          | **`'hours'`** | Decorative rotation pinned the 6-locale homepage to 5-min writes |
+| Analytics (`getGlobalStats`/ticker/geo) | 300s          | **600s**      | Minor — single shared keys streamed in homepage Suspense holes |
 
-> Both `PARK_MAX_AGE` **and** `getServerNowMs` had to be raised together: the park shell floor is
-> their MIN, so lifting only one would have left it pinned at 300s.
+> The park shell floor is the **MIN** of `getParkByGeoPath`, `getServerNowMs` **and**
+> `getParkWeatherNowcast` — all three had to be raised together, otherwise the lowest one would
+> have kept the shell pinned (e.g. the nowcast alone capped it at 15 min).
+
+**Deliberately conservative:** parks keep a 1h floor (their shell carries schedule + status +
+structured data); attractions go to 6h (no schedule/weather in shell). Neither goes to 24h, so a
+park/ride that opens or closes is never misrepresented for more than the floor to no-JS/crawlers —
+and not at all to JS visitors (client poll). The best-days **forecast** calendar stays on its
+separate 24h `unstable_cache`, and today's crowd level is patched client-side every 5 min.
+
+**Next step (not yet done):** on-demand revalidation — let the backend call a
+`revalidateTag`/`revalidatePath` webhook when park/attraction data actually changes, so TTLs can go
+to days and time-based write churn nearly disappears. The `best-days:<slug>` tag already exists.
 
 ---
 
@@ -109,7 +129,7 @@ In `next.config.ts`:
 | `/v1/search`               | `cache: 'no-store'`  | 60s       | Always fresh search results    |
 | `/v1/analytics/*`          | `cache: 'no-store'`  | 120s      | Real-time statistics           |
 | `/v1/parks/*` (detail)     | `revalidate: 3600s`  | 300s      | Shell seed; live via RQ        |
-| `/v1/parks/*/attractions`  | `revalidate: 3600s`  | 300s      | Shell seed; live via RQ        |
+| `/v1/parks/*/attractions`  | `revalidate: 21600s` | 300s      | Shell seed; live via RQ        |
 | `/v1/discovery/geo`        | `revalidate: 3600s`  | 120s      | Geo structure (rarely changes) |
 | `/v1/discovery/continents` | `revalidate: 3600s`  | 120s      | Geo structure (rarely changes) |
 | Calendar                   | `revalidate: 3600s`  | 300-3600s | Schedule data (changes daily)  |

--- a/lib/api/analytics.ts
+++ b/lib/api/analytics.ts
@@ -3,30 +3,33 @@ import { api } from './client';
 import type { GlobalStats, GeoLiveStatsDto, TickerResponse } from './types';
 
 /**
- * Get global real-time statistics — cached 5 min (Cache Components).
+ * Get global real-time statistics — cached 10 min (Cache Components).
+ *
+ * Streamed inside a homepage <Suspense> hole (low cardinality — one shared key), so this is a
+ * minor ISR-write contributor; the 10-min window still keeps the aggregate fresh enough.
  */
 export async function getGlobalStats(): Promise<GlobalStats> {
   'use cache';
-  cacheLife({ stale: 300, revalidate: 300, expire: 1200 });
+  cacheLife({ stale: 600, revalidate: 600, expire: 1800 });
   return api.get<GlobalStats>('/v1/analytics/realtime');
 }
 
 /**
- * Get live ticker data — top wait times across all open parks. Cached 5 min so
+ * Get live ticker data — top wait times across all open parks. Cached 10 min so
  * concurrent visitors collapse onto one backend call per window (shared with the
  * /api/analytics/ticker proxy).
  */
 export async function getTickerData(): Promise<TickerResponse> {
   'use cache';
-  cacheLife({ stale: 300, revalidate: 300, expire: 1200 });
+  cacheLife({ stale: 600, revalidate: 600, expire: 1800 });
   return api.get<TickerResponse>('/v1/analytics/ticker');
 }
 
 /**
- * Get live statistics for geographic regions — cached 5 min.
+ * Get live statistics for geographic regions — cached 10 min.
  */
 export async function getGeoLiveStats(): Promise<GeoLiveStatsDto> {
   'use cache';
-  cacheLife({ stale: 300, revalidate: 300, expire: 1200 });
+  cacheLife({ stale: 600, revalidate: 600, expire: 1800 });
   return api.get<GeoLiveStatsDto>('/v1/analytics/geo-live');
 }

--- a/lib/api/cache-config.ts
+++ b/lib/api/cache-config.ts
@@ -23,8 +23,12 @@ export const CACHE_TTL = {
   geo: 3600, // geo structure changes rarely
   continents: 3600, // same as geo
   parks: 300, // popular parks frontend data-cached 5 min - slow-moving popularity ranking
-  parkDetail: 300, // revalidate 300s (ISR-cacheable) - live wait times refreshed client-side
-  waitTimes: 300, // revalidate 300s (ISR-cacheable) - live wait times refreshed client-side
+  // Shell TTL for the park/attraction static prerender. Decoupled from the API's 5-min live
+  // cadence: the shell wait times are only an SSR seed replaced client-side by React Query, so a
+  // 1h-stale shell is fine. This is the floor that drives the dominant per-park/per-attraction ×
+  // per-locale ISR-write volume (see PARK_MAX_AGE in lib/api/parks.ts) — 1h cuts those ~12×.
+  parkDetail: 3600, // shell revalidate 1h - live wait times refreshed client-side
+  waitTimes: 3600, // shell revalidate 1h - live wait times refreshed client-side
 
   // Static data (still using revalidate)
   calendar: 900, // /v1/parks/:slug/calendar - API: 900s (past/today) / 1800s (future); the forecast under it only changes ~13h, and today's crowdLevel is patched client-side via a separate 5-min today-only fetch — so 5 min here was pure rebuild churn

--- a/lib/api/parks.ts
+++ b/lib/api/parks.ts
@@ -3,14 +3,23 @@ import { api, ApiError } from './client';
 import type { ParkWithAttractions, AttractionResponse, PopularPark } from './types';
 
 // Shell-level TTL for the park/attraction static prerender. Deliberately DECOUPLED from the
-// API's 5-min live cadence: the wait times baked into the shell are only an SSR seed that
-// LiveParkData / LiveAttractionData replace client-side (React Query, no-store) on mount. The
-// shell content that actually matters for SEO/no-JS (name, description, attraction list, FAQ,
-// structured data) changes at most daily. Under Cache Components the effective revalidate of a
-// route shell is the MIN cacheLife of the 'use cache' reads in its static portion, so this value
-// (together with getServerNowMs on the park page) is the floor that drives the dominant
-// per-park/per-attraction × per-locale ISR-write volume. 1h instead of 5min cuts those writes ~12×.
-const PARK_MAX_AGE = 3600; // 1h shell TTL — live data is refreshed client-side, not via ISR
+// API's 5-min live cadence: the wait times + open/closed status baked into the shell are only an
+// SSR seed that LiveParkData / LiveAttractionData replace client-side (React Query, no-store, 5-min
+// poll + refetch on mount/focus — see use-live-park-data.ts). So for any visitor with JS the shell
+// TTL is invisible; it only governs the first-paint seed, no-JS visitors and crawlers. Under Cache
+// Components the effective revalidate of a route shell is the MIN cacheLife of the 'use cache' reads
+// in its static portion, so these values are the floor that drives the dominant per-park /
+// per-attraction × per-locale ISR-write volume.
+//
+// Context: park/attraction pages were dynamic (no ISR writes) until they were switched to static
+// ISR with revalidate:300 — which is what turned ISR writes on across the whole catalog × 6 locales.
+//
+// Parks keep a 1h floor: their shell carries the operating schedule, status and structured data, so
+// a tighter bound is worth the extra writes. Attractions get a longer 6h floor: their shell has no
+// schedule/weather (only name/description/history-chart seed, daily-ish), they are by far the
+// highest-cardinality route, and their live status/wait time is client-refreshed all the same.
+const PARK_MAX_AGE = 3600; // 1h park shell TTL — live data is refreshed client-side, not via ISR
+const ATTRACTION_MAX_AGE = 21600; // 6h attraction shell TTL — dominant route, no schedule in shell
 
 /**
  * Get parks by geographic path. Cached via Cache Components (`'use cache'`):
@@ -56,7 +65,11 @@ export async function getAttractionByGeoPath(
   attractionSlug: string
 ): Promise<AttractionResponse | null> {
   'use cache';
-  cacheLife({ stale: PARK_MAX_AGE, revalidate: PARK_MAX_AGE, expire: PARK_MAX_AGE * 4 });
+  cacheLife({
+    stale: ATTRACTION_MAX_AGE,
+    revalidate: ATTRACTION_MAX_AGE,
+    expire: ATTRACTION_MAX_AGE * 4,
+  });
   try {
     return await api.get<AttractionResponse>(
       `/v1/parks/${continent}/${country}/${city}/${parkSlug}/attractions/${attractionSlug}`
@@ -69,11 +82,12 @@ export async function getAttractionByGeoPath(
 
 /**
  * Get the most-requested parks, ranked by tracked request volume.
- * The popularity ranking drifts slowly, so a few minutes of staleness is fine.
+ * The popularity ranking drifts slowly, so 30 min of staleness is fine — and it feeds
+ * generateStaticParams + the homepage/featured seed, so a tighter window was pure write churn.
  * @param limit clamped to 1–100 by the API (default 20)
  */
 export async function getPopularParks(limit = 20): Promise<PopularPark[]> {
   'use cache';
-  cacheLife({ stale: 300, revalidate: 300, expire: 1200 });
+  cacheLife({ stale: 1800, revalidate: 1800, expire: 7200 });
   return api.get<PopularPark[]>('/v1/parks/popular', { params: { limit } });
 }

--- a/lib/api/parks.ts
+++ b/lib/api/parks.ts
@@ -22,6 +22,33 @@ const PARK_MAX_AGE = 3600; // 1h park shell TTL — live data is refreshed clien
 const ATTRACTION_MAX_AGE = 21600; // 6h attraction shell TTL — dominant route, no schedule in shell
 
 /**
+ * Drop per-attraction fields the PARK page never renders before the snapshot is cached.
+ *
+ * The park detail response embeds, per attraction, a `history` array (one entry per day, each with
+ * a 24-point `hourlyP90` series), plus `hourlyForecast` and `predictionAccuracy`. None of these are
+ * read on the park page — the attraction cards draw their sparkline from `statistics.history`, and
+ * the full history/forecast belong to the attraction DETAIL page, which sources them from
+ * `getAttractionByGeoPath` (it only falls back to the park copy if the detail endpoint is down).
+ * These arrays dominate the response size, and because the snapshot is persisted via `'use cache'`
+ * (the data-cache entry) AND baked into every per-locale ISR route segment via `initialData={park}`,
+ * their bytes are paid for as size-weighted ISR **write units** on every revalidation. Stripping
+ * them here keeps the park snapshot lean everywhere it is written, without dropping a single field
+ * the park page (or its live React-Query refetch through the same function) actually shows.
+ */
+function leanParkForShell(park: ParkWithAttractions): ParkWithAttractions {
+  return {
+    ...park,
+    attractions: park.attractions.map((a) => {
+      const lean = { ...a };
+      delete lean.history;
+      delete lean.hourlyForecast;
+      delete lean.predictionAccuracy;
+      return lean;
+    }),
+  };
+}
+
+/**
  * Get parks by geographic path. Cached via Cache Components (`'use cache'`):
  * the static shell of the park page captures this snapshot; live wait times are
  * refreshed client-side by LiveParkData.
@@ -41,9 +68,12 @@ export async function getParkByGeoPath(
   'use cache';
   cacheLife({ stale: PARK_MAX_AGE, revalidate: PARK_MAX_AGE, expire: PARK_MAX_AGE * 4 });
   try {
-    return await api.get<ParkWithAttractions>(
+    const park = await api.get<ParkWithAttractions>(
       `/v1/parks/${continent}/${country}/${city}/${parkSlug}`
     );
+    // Trim detail-only per-attraction arrays before this snapshot is cached/serialized (see
+    // leanParkForShell) — they are the bulk of the size-weighted ISR write units otherwise.
+    return leanParkForShell(park);
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) return null;
     throw err;

--- a/lib/api/parks.ts
+++ b/lib/api/parks.ts
@@ -2,7 +2,15 @@ import { cacheLife } from 'next/cache';
 import { api, ApiError } from './client';
 import type { ParkWithAttractions, AttractionResponse, PopularPark } from './types';
 
-const PARK_MAX_AGE = 300; // 5 min — matches API Redis/Cloudflare cache
+// Shell-level TTL for the park/attraction static prerender. Deliberately DECOUPLED from the
+// API's 5-min live cadence: the wait times baked into the shell are only an SSR seed that
+// LiveParkData / LiveAttractionData replace client-side (React Query, no-store) on mount. The
+// shell content that actually matters for SEO/no-JS (name, description, attraction list, FAQ,
+// structured data) changes at most daily. Under Cache Components the effective revalidate of a
+// route shell is the MIN cacheLife of the 'use cache' reads in its static portion, so this value
+// (together with getServerNowMs on the park page) is the floor that drives the dominant
+// per-park/per-attraction × per-locale ISR-write volume. 1h instead of 5min cuts those writes ~12×.
+const PARK_MAX_AGE = 3600; // 1h shell TTL — live data is refreshed client-side, not via ISR
 
 /**
  * Get parks by geographic path. Cached via Cache Components (`'use cache'`):

--- a/lib/api/parks.ts
+++ b/lib/api/parks.ts
@@ -24,25 +24,27 @@ const ATTRACTION_MAX_AGE = 21600; // 6h attraction shell TTL — dominant route,
 /**
  * Drop per-attraction fields the PARK page never renders before the snapshot is cached.
  *
- * The park detail response embeds, per attraction, a `history` array (one entry per day, each with
- * a 24-point `hourlyP90` series), plus `hourlyForecast` and `predictionAccuracy`. None of these are
- * read on the park page — the attraction cards draw their sparkline from `statistics.history`, and
- * the full history/forecast belong to the attraction DETAIL page, which sources them from
- * `getAttractionByGeoPath` (it only falls back to the park copy if the detail endpoint is down).
- * These arrays dominate the response size, and because the snapshot is persisted via `'use cache'`
- * (the data-cache entry) AND baked into every per-locale ISR route segment via `initialData={park}`,
- * their bytes are paid for as size-weighted ISR **write units** on every revalidation. Stripping
- * them here keeps the park snapshot lean everywhere it is written, without dropping a single field
- * the park page (or its live React-Query refetch through the same function) actually shows.
+ * Measured against the live europa-park response (96 attractions, ~134 KB): the body is dominated
+ * by `statistics` (incl. the card sparkline `history`), `bestVisitTimes` and `queues` — all of which
+ * the park cards DO render, so they stay. The clearly removable field is `url` (~7 KB / ~5 %): it is
+ * the raw `/v1/parks/.../attractions/<slug>` API path, and the card's `getHref` only uses it as a
+ * preference — it falls back to `${parkPath}/${slug}` (parkPath is always supplied on the park page),
+ * which resolves to the identical frontend URL. The `history`/`hourlyForecast`/`predictionAccuracy`
+ * deletes are defensive: the park endpoint does not currently send them per attraction, but if it
+ * ever does they are attraction-detail-only (sourced from getAttractionByGeoPath) and must not bloat
+ * the park snapshot. Because the snapshot is persisted via `'use cache'` AND baked into every
+ * per-locale ISR route segment via `initialData={park}`, trimming here shrinks the size-weighted ISR
+ * write units (and the live /api/parks proxy response) on every park, across all 6 locales.
  */
 function leanParkForShell(park: ParkWithAttractions): ParkWithAttractions {
   return {
     ...park,
     attractions: park.attractions.map((a) => {
       const lean = { ...a };
-      delete lean.history;
-      delete lean.hourlyForecast;
-      delete lean.predictionAccuracy;
+      delete lean.url; // href falls back to `${parkPath}/${slug}` — identical frontend URL
+      delete lean.history; // defensive: attraction-detail-only if ever present
+      delete lean.hourlyForecast; // defensive: detail-only
+      delete lean.predictionAccuracy; // defensive: detail-only
       return lean;
     }),
   };

--- a/lib/api/stats.ts
+++ b/lib/api/stats.ts
@@ -35,9 +35,12 @@ export async function getParkHistoricalStats(
 ): Promise<ParkHistoricalStats | null> {
   'use cache';
   // Cached (Cache Components): creating this promise in the park-page shell is allowed, while
-  // the StreamedParkStats <Suspense> hole still streams it off the critical path. Short window
-  // so a cold-compute miss (null) is re-attempted soon rather than stuck for a day.
-  cacheLife({ stale: 300, revalidate: 300, expire: 1800 });
+  // the StreamedParkStats <Suspense> hole still streams it off the critical path. The retry loop
+  // below already warms a cold-compute backend WITHIN a single fill, so a successful aggregate is
+  // returned on first load — and the data only changes daily. A 5-min window was therefore pure
+  // ISR-write churn (288 writes/day per park key); 1h cuts that ~12× while still re-attempting a
+  // genuine null (too-little-data) park within the hour.
+  cacheLife({ stale: 3600, revalidate: 3600, expire: 14400 });
 
   const url = `${getApiBaseUrl()}/v1/parks/${continent}/${country}/${city}/${parkSlug}/stats?years=${years}`;
 

--- a/lib/api/weather-nowcast.ts
+++ b/lib/api/weather-nowcast.ts
@@ -2,13 +2,19 @@ import { cacheLife } from 'next/cache';
 import { api, ApiError } from './client';
 import type { WeatherNowcast } from './types';
 
-// API sets Cache-Control: max-age=900 (15 min). Match that here.
-const NOWCAST_MAX_AGE = 900;
+// Shell-seed TTL for the cached nowcast. The API itself sets Cache-Control: max-age=900 (15 min),
+// but this cached copy only seeds the park-page static shell — `useWeatherNowcast` replaces it
+// client-side on mount via the uncached `getParkWeatherNowcastFresh` poll. Pinning it at 900 made
+// it the MIN cacheLife in the park shell, capping the whole park route's revalidate at 15 min and
+// undercutting the 1h park TTL (see PARK_MAX_AGE). 1h here lets the park shell actually reach its
+// intended floor; the live banner stays fresh via the client poll regardless.
+const NOWCAST_SEED_TTL = 3600;
 
 /**
  * Get short-term (next ~2h) weather nowcast for a park.
  * Returns null if nowcast is unavailable (404 — missing coordinates or upstream down).
- * Cached 15 min (Cache Components) so the park-page static shell can bake it in.
+ * Cached 1h (Cache Components) so the park-page static shell can bake in a seed; the live banner
+ * is refreshed client-side (see getParkWeatherNowcastFresh / useWeatherNowcast).
  */
 export async function getParkWeatherNowcast(
   continent: string,
@@ -17,7 +23,7 @@ export async function getParkWeatherNowcast(
   parkSlug: string
 ): Promise<WeatherNowcast | null> {
   'use cache';
-  cacheLife({ stale: NOWCAST_MAX_AGE, revalidate: NOWCAST_MAX_AGE, expire: NOWCAST_MAX_AGE * 2 });
+  cacheLife({ stale: NOWCAST_SEED_TTL, revalidate: NOWCAST_SEED_TTL, expire: NOWCAST_SEED_TTL * 2 });
   try {
     return await api.get<WeatherNowcast>(
       `/v1/parks/${continent}/${country}/${city}/${parkSlug}/weather/nowcast`

--- a/lib/utils/server-time.ts
+++ b/lib/utils/server-time.ts
@@ -18,10 +18,18 @@ export async function getCurrentYear(): Promise<number> {
   return new Date().getFullYear();
 }
 
-/** Current epoch milliseconds, captured at cache-fill time. Refreshes every ~5 min. */
+/**
+ * Current epoch milliseconds, captured at cache-fill time. Refreshes hourly.
+ *
+ * Consumers only need day-granular precision (calendar month boundaries, "today's" schedule
+ * lookup, the yyyy-MM-dd date in structured data). The previous 5-min cadence pinned every
+ * route shell that reads this (the park page) to a 5-min revalidate floor — forcing a fresh
+ * ISR write per park × locale every 5 min regardless of the park TTL. Hourly removes that
+ * hidden floor; for truly live values use a Client Component instead.
+ */
 export async function getServerNowMs(): Promise<number> {
   'use cache';
-  cacheLife({ stale: 300, revalidate: 300, expire: 900 });
+  cacheLife('hours');
   return Date.now();
 }
 


### PR DESCRIPTION
## Root cause (confirmed via Vercel Write-Units chart + git history)

ISR Write Units jumped from **near-zero to ~250k/day** starting **Jun 2** — a regression, not steady state. Git history pinpoints **#118 "make park & attraction pages static (ISR) via … revalidate"**: park/attraction pages were **dynamic (zero ISR writes)** until they were switched to **static ISR with `revalidate: 300`**. That turned writes on across the *entire* catalog × 6 locales; #125 (Cache Components) cemented it. Total this cycle: ~1.06M write units.

## Why we can safely raise the TTLs

Vercel bills an **ISR write** every time a cache unit revalidates. Under Cache Components a route shell's effective revalidate is the **MIN cacheLife of the `'use cache'` reads in its static portion**. Park & attraction shells are the highest-cardinality routes (`N_parks`/`N_attractions × 6 locales`), so the 5-min floor dominated.

**The shells don't need live freshness.** Open/closed status, wait times, weather and today's crowd level are all refreshed **client-side** (`use-live-park-data.ts`: 5-min poll + refetch on mount/focus, `cache: 'no-store'`). For any visitor with JS the shell TTL is invisible — it only seeds first paint, no-JS visitors and crawlers.

## Changes

| Lever | Before | After | Effect |
| --- | --- | --- | --- |
| `PARK_MAX_AGE` (park shell) | 300s | **3600s** | ~12× fewer; keeps schedule/status reasonably fresh |
| `ATTRACTION_MAX_AGE` (attraction shell) | 300s | **21600s** | Dominant route → ~72× fewer |
| `getServerNowMs` | 300s | **`'hours'`** | Removes hidden 5-min floor on park shell (all consumers are day-granular — verified) |
| `getParkWeatherNowcast` (shell seed) | 900s | **3600s** | Was capping the park shell at 15 min; live banner stays fresh via client poll |
| `getParkHistoricalStats` | 300s | **3600s** | Retry loop warms cold compute in one fill; data is daily |
| `getPopularParks` | 300s | **1800s** | Slow-moving ranking; feeds generateStaticParams + home seed |
| `pickHeroImage` (homepage shell) | 300s | **`'hours'`** | Decorative; pinned 6-locale homepage to 5-min writes |
| Analytics (global/ticker/geo) | 300s | **600s** | Minor — single shared keys in Suspense holes |

> The park shell floor is the **MIN** of `getParkByGeoPath`, `getServerNowMs` **and** `getParkWeatherNowcast` — all three had to rise together, else the lowest pins it.

## Correctness / staleness

Deliberately **conservative**: parks stay 1h (shell carries schedule + status + structured data), attractions 6h (no schedule/weather in shell), **nothing at 24h**. So a park/ride that opens or closes is never misrepresented beyond the floor to no-JS/crawlers — and **not at all** to JS visitors (client poll catches opening/closing every 5 min). Best-days **forecast** stays on its separate 24h cache; today's crowd level is patched client-side every 5 min.

## Verification

- `tsc --noEmit`: clean on changed files (remaining errors are pre-existing missing generated modules from the prebuild step)
- `eslint` on changed files: clean
- Vercel preview deploy: Ready ✅

## Next step (separate, not in this PR)

On-demand revalidation: backend calls a `revalidateTag`/`revalidatePath` webhook when park/attraction data actually changes → TTLs could go to days and time-based write churn nearly disappears. The `best-days:<slug>` tag already exists.

Docs: `docs/architecture/caching-strategy.md` (ISR table + "Minimizing ISR Writes" section).

https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr