### PR TITLE
perf: status-free cards + client-batch live status (cut ISR writes)

### DIFF
--- a/app/[locale]/parks/[continent]/[country]/[city]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/page.tsx
@@ -3,7 +3,8 @@ import { generateAlternateLanguages, locales } from '@/i18n/config';
 import { buildOpenGraphMetadata } from '@/lib/utils/metadata';
 import { translateCountry, translateContinent } from '@/lib/i18n/helpers';
 import { notFound, permanentRedirect } from 'next/navigation';
-import { ParkCard } from '@/components/parks/park-card';
+import { LiveParkGrid, type StaticPark } from '@/components/parks/live-park-grid';
+import { getParkBackgroundImage } from '@/lib/utils/park-assets';
 import { getCitiesWithParks, getGeoStructure } from '@/lib/api/discovery';
 import { catchNonFatal } from '@/lib/api/client';
 import { PageContainer } from '@/components/common/page-container';
@@ -110,6 +111,19 @@ export default async function CityPage({ params }: CityPageProps) {
   const continentName = translateContinent(t, continent, locale);
   const countryName = translateCountry(t, country, locale);
 
+  // Status-free seed for the cards: only fields that never change during the day. Live status,
+  // crowd level, wait time and schedule are layered on the client by <LiveParkGrid>, so this
+  // (per-locale) prerender carries no volatile data and stays valid for a day.
+  const staticParks: StaticPark[] = parks.map((park) => ({
+    id: park.id,
+    name: stripNewPrefix(park.name),
+    slug: park.slug,
+    city: city.name,
+    countryName,
+    href: `/parks/${continent}/${country}/${citySlug}/${park.slug}`,
+    backgroundImage: getParkBackgroundImage(park.slug),
+  }));
+
   // Generate breadcrumbs with translations
   const tNav = await getTranslations('navigation');
   const { breadcrumbs, currentPage: cityCurrentPage } = generateCityBreadcrumbs({
@@ -142,30 +156,15 @@ export default async function CityPage({ params }: CityPageProps) {
         description={t('parkCount', { count: parks.length })}
       />
 
-      {/* Parks Grid */}
+      {/* Parks Grid — status-free shell (cacheable); live status overlaid client-side. */}
       <section aria-label={tExplore('parks')}>
         <h2 className="sr-only">{tExplore('parks')}</h2>
-        <div className="grid [grid-auto-rows:auto_1fr_auto] gap-4 md:grid-cols-2">
-          {parks.map((park) => (
-            <ParkCard
-              key={park.id}
-              name={stripNewPrefix(park.name)}
-              slug={park.slug}
-              city={city.name}
-              country={countryName}
-              href={`/parks/${continent}/${country}/${citySlug}/${park.slug}`}
-              status={park.status}
-              crowdLevel={park.analytics?.statistics?.crowdLevel ?? park.currentLoad?.crowdLevel}
-              averageWaitTime={park.analytics?.statistics?.avgWaitTime}
-              operatingAttractions={park.analytics?.statistics?.operatingAttractions}
-              totalAttractions={park.analytics?.statistics?.totalAttractions}
-              variant="detailed"
-              timezone={park.timezone}
-              todaySchedule={park.todaySchedule}
-              nextSchedule={park.nextSchedule}
-            />
-          ))}
-        </div>
+        <LiveParkGrid
+          continent={continent}
+          country={country}
+          parks={staticParks}
+          className="grid [grid-auto-rows:auto_1fr_auto] gap-4 md:grid-cols-2"
+        />
       </section>
     </PageContainer>
   );

--- a/app/[locale]/parks/[continent]/[country]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/page.tsx
@@ -4,7 +4,8 @@ import { buildOpenGraphMetadata } from '@/lib/utils/metadata';
 import { translateCountry, translateContinent } from '@/lib/i18n/helpers';
 import { notFound } from 'next/navigation';
 import { MapPin } from 'lucide-react';
-import { ParkCard } from '@/components/parks/park-card';
+import { LiveParkGrid } from '@/components/parks/live-park-grid';
+import { getParkBackgroundImage } from '@/lib/utils/park-assets';
 import { getCitiesWithParks, getGeoStructure, getCountrySummary } from '@/lib/api/discovery';
 import { catchNonFatal } from '@/lib/api/client';
 import { PageContainer } from '@/components/common/page-container';
@@ -149,30 +150,22 @@ export default async function CountryPage({ params }: CountryPageProps) {
               badge={t('parkCount', { count: city.parkCount })}
             />
 
-            <div className="grid [grid-auto-rows:auto_1fr_auto] gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {city.parks.map((park) => (
-                <ParkCard
-                  key={park.id}
-                  name={stripNewPrefix(park.name)}
-                  slug={park.slug}
-                  city={city.name}
-                  country={countryName}
-                  href={`/parks/${continent}/${country}/${city.slug}/${park.slug}`}
-                  status={park.status}
-                  crowdLevel={
-                    park.analytics?.statistics?.crowdLevel ?? park.currentLoad?.crowdLevel
-                  }
-                  averageWaitTime={park.analytics?.statistics?.avgWaitTime}
-                  operatingAttractions={park.analytics?.statistics?.operatingAttractions}
-                  totalAttractions={park.analytics?.statistics?.totalAttractions}
-                  showBackground={true}
-                  variant="detailed"
-                  timezone={park.timezone}
-                  todaySchedule={park.todaySchedule}
-                  nextSchedule={park.nextSchedule}
-                />
-              ))}
-            </div>
+            {/* Status-free shell (cacheable); live status overlaid client-side. All cities on
+                the page share one underlying /api/discovery call (React Query dedupe). */}
+            <LiveParkGrid
+              continent={continent}
+              country={country}
+              parks={city.parks.map((park) => ({
+                id: park.id,
+                name: stripNewPrefix(park.name),
+                slug: park.slug,
+                city: city.name,
+                countryName,
+                href: `/parks/${continent}/${country}/${city.slug}/${park.slug}`,
+                backgroundImage: getParkBackgroundImage(park.slug),
+              }))}
+              className="grid [grid-auto-rows:auto_1fr_auto] gap-4 sm:grid-cols-2 lg:grid-cols-3"
+            />
           </div>
         ))}
       </div>

--- a/app/[locale]/parks/[continent]/page.tsx
+++ b/app/[locale]/parks/[continent]/page.tsx
@@ -4,9 +4,9 @@ import { buildOpenGraphMetadata } from '@/lib/utils/metadata';
 import { translateCountry, translateContinent } from '@/lib/i18n/helpers';
 import { notFound } from 'next/navigation';
 import { getCountriesInContinent, getContinents } from '@/lib/api/discovery';
-import { getGeoLiveStats } from '@/lib/api/analytics';
 import { catchNonFatal } from '@/lib/api/client';
-import { GeoLocationCard } from '@/components/common/geo-location-card';
+import { LiveCountryCards, type StaticCountryCard } from '@/components/parks/live-country-cards';
+import { LiveOpenCount } from '@/components/parks/live-open-count';
 import { PageContainer } from '@/components/common/page-container';
 import { PageHeader } from '@/components/common/page-header';
 import { BreadcrumbStructuredData, ItemListStructuredData } from '@/components/seo/structured-data';
@@ -60,11 +60,10 @@ export default async function ContinentPage({ params }: ContinentPageProps) {
   const t = await getTranslations('geo');
   const tExplore = await getTranslations('explore');
 
-  // Fetch countries in this continent
-  const [rawCountries, liveStats] = await Promise.all([
-    catchNonFatal(getCountriesInContinent(continent)),
-    catchNonFatal(getGeoLiveStats()),
-  ]);
+  // Fetch countries in this continent. Live open-park counts are NOT fetched here anymore — they
+  // are layered on the client (<LiveCountryCards> / <LiveOpenCount> → useGeoLiveStats), so this
+  // shell stays status-free and cacheable instead of revalidating every 10 min to refresh counts.
+  const rawCountries = await catchNonFatal(getCountriesInContinent(continent));
 
   if (!rawCountries) {
     notFound();
@@ -87,24 +86,11 @@ export default async function ContinentPage({ params }: ContinentPageProps) {
     }
   });
 
-  const countries = Array.from(uniqueCountries.values()).map((country) => {
-    // Find live stats for this country
-    // Note: we might need to find by slug.
-    // The liveStats structure is: continents -> countries.
-    // We need to find the current continent in liveStats, then find the country.
-    const continentStats = liveStats?.continents.find((c) => c.slug === continent);
-    const countryStats = continentStats?.countries.find((c) => c.slug === country.slug);
+  const countries = Array.from(uniqueCountries.values());
 
-    return {
-      ...country,
-      openParkCount: countryStats?.openParkCount ?? country.openParkCount ?? 0,
-    };
-  });
-
-  // Calculate totals
+  // Calculate totals (static structure only — the live "open" total is overlaid client-side).
   const totalParks = countries.reduce((sum, c) => sum + c.parkCount, 0);
   const totalCities = countries.reduce((sum, c) => sum + c.cityCount, 0);
-  const totalOpenParks = countries.reduce((sum, c) => sum + (c.openParkCount || 0), 0);
 
   const continentName = translateContinent(t, continent, locale);
 
@@ -140,7 +126,7 @@ export default async function ContinentPage({ params }: ContinentPageProps) {
         description={
           <>
             <span className="text-park-primary font-medium">
-              {totalOpenParks} {t('open')}
+              <LiveOpenCount continent={continent} /> {t('open')}
             </span>{' '}
             / {totalParks} {tExplore('stats.park', { count: totalParks })} • {countries.length}{' '}
             {tExplore('stats.country', { count: countries.length })} • {totalCities}{' '}
@@ -151,24 +137,20 @@ export default async function ContinentPage({ params }: ContinentPageProps) {
 
       <section aria-label={tExplore('countries')}>
         <h2 className="sr-only">{tExplore('countries')}</h2>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {countries.map((country) => {
-            const countryName = translateCountry(t, country.slug, locale, country.name);
-
-            return (
-              <GeoLocationCard
-                key={country.slug}
-                name={countryName}
-                slug={country.slug}
-                href={`/parks/${continent}/${country.slug}`}
-                openParkCount={country.openParkCount}
-                totalParkCount={country.parkCount}
-                subtitle={`${country.cityCount} ${tExplore('stats.city', { count: country.cityCount })}`}
-                variant="country"
-              />
-            );
-          })}
-        </div>
+        {/* Status-free shell; live open-park counts overlaid client-side (shared geo-live call). */}
+        <LiveCountryCards
+          continent={continent}
+          countries={countries.map(
+            (country): StaticCountryCard => ({
+              slug: country.slug,
+              name: translateCountry(t, country.slug, locale, country.name),
+              href: `/parks/${continent}/${country.slug}`,
+              totalParkCount: country.parkCount,
+              subtitle: `${country.cityCount} ${tExplore('stats.city', { count: country.cityCount })}`,
+            })
+          )}
+          className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
+        />
       </section>
     </PageContainer>
   );

--- a/app/api/discovery/[...path]/route.ts
+++ b/app/api/discovery/[...path]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerAuthHeaders } from '@/lib/api/client';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.park.fan';
+
+/**
+ * Live (no-store) passthrough for a region's parks — `/api/discovery/<continent>/<country>`
+ * maps to the backend `/v1/discovery/continents/<continent>/<country>` (the same data
+ * `getCitiesWithParks` reads, but uncached).
+ *
+ * The hub pages (continent/country/city) render their ParkCards STATUS-FREE so the per-locale
+ * ISR shell carries no volatile data (and can be cached for a day). The live open/closed status,
+ * crowd level and wait times are layered on the client via `useRegionParks`, which polls this
+ * endpoint — exactly the SSR-static + client-live split already used for the park page, favorites
+ * and nearby. Always no-store here so the client overlay reflects the backend's latest snapshot.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await params;
+
+  if (path.length !== 2) {
+    return NextResponse.json(
+      { error: 'Expected /api/discovery/<continent>/<country>' },
+      { status: 400 }
+    );
+  }
+
+  const [continent, country] = path;
+  const apiUrl = `${API_BASE}/v1/discovery/continents/${continent}/${country}`;
+
+  try {
+    const response = await fetch(apiUrl, {
+      cache: 'no-store',
+      headers: getServerAuthHeaders(),
+    });
+    const data = await response.json();
+    return NextResponse.json(data, {
+      status: response.status,
+      headers: { 'Cache-Control': 'no-store, must-revalidate' },
+    });
+  } catch (error) {
+    console.error('[Discovery proxy] Error:', error);
+    return NextResponse.json({ error: 'Failed to fetch discovery data' }, { status: 502 });
+  }
+}

--- a/app/api/parks/near/route.ts
+++ b/app/api/parks/near/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getParksNearLocationFresh } from '@/lib/api/discovery';
+
+/**
+ * Live (no-store) "parks near these coordinates" — backs the park page's nearby-parks client
+ * overlay (`useParkNeighbors`). The page renders the nearby cards status-free (cacheable shell);
+ * this endpoint supplies the live status/crowd on the client. Takes precedence over the
+ * /api/parks/[...path] catch-all (static segment wins).
+ */
+export async function GET(request: NextRequest) {
+  const sp = new URL(request.url).searchParams;
+  const lat = Number(sp.get('lat'));
+  const lng = Number(sp.get('lng'));
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    return NextResponse.json({ error: 'lat and lng are required' }, { status: 400 });
+  }
+  const exclude = sp.get('exclude') ?? undefined;
+  const limit = sp.get('limit') ? Number(sp.get('limit')) : 3;
+  const maxDistanceM = sp.get('radius') ? Number(sp.get('radius')) : 100_000;
+
+  try {
+    const parks = await getParksNearLocationFresh(lat, lng, exclude, limit, maxDistanceM);
+    return NextResponse.json({ parks }, { headers: { 'Cache-Control': 'no-store, must-revalidate' } });
+  } catch (error) {
+    console.error('[Park neighbors proxy] Error:', error);
+    return NextResponse.json({ error: 'Failed to fetch nearby parks' }, { status: 502 });
+  }
+}

--- a/components/common/geo-location-card.tsx
+++ b/components/common/geo-location-card.tsx
@@ -4,13 +4,15 @@ import { ChevronRight, MapPin } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { OpenStatusProgress } from '@/components/common/open-status-progress';
 import { IconContainer } from '@/components/common/icon-container';
+import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 
 interface GeoLocationCardProps {
   name: string;
   slug: string;
   href: string;
-  openParkCount: number;
+  /** Live open-park count. `undefined` = not yet loaded (client overlay) → renders a skeleton. */
+  openParkCount?: number;
   totalParkCount: number;
   subtitle?: string; // e.g., "5 countries" for continents, "3 cities" for countries
   variant?: 'continent' | 'country' | 'city';
@@ -40,7 +42,12 @@ export function GeoLocationCard({
                 {subtitle && <p className="text-muted-foreground text-sm">{subtitle}</p>}
                 <div className="mt-1 flex items-center gap-2 text-sm">
                   <span className="text-park-primary font-medium">
-                    {openParkCount} {t('open')}
+                    {openParkCount === undefined ? (
+                      <Skeleton className="inline-block h-4 w-5 align-middle" />
+                    ) : (
+                      openParkCount
+                    )}{' '}
+                    {t('open')}
                   </span>
                   <span className="text-muted-foreground">
                     / {totalParkCount} {tExplore('stats.park', { count: totalParkCount })}
@@ -51,12 +58,12 @@ export function GeoLocationCard({
             <ChevronRight className="group-interactive-icon h-5 w-5" />
           </div>
 
-          {/* Progress bar */}
+          {/* Progress bar — muted placeholder until the live count loads */}
           <OpenStatusProgress
-            openCount={openParkCount}
+            openCount={openParkCount ?? 0}
             totalCount={totalParkCount}
             showLabel={false}
-            className="mt-4"
+            className={cn('mt-4', openParkCount === undefined && 'opacity-40')}
           />
         </CardContent>
       </Card>

--- a/components/home/global-stats-section.tsx
+++ b/components/home/global-stats-section.tsx
@@ -1,36 +1,40 @@
-import { getTranslations } from 'next-intl/server';
+'use client';
+
+import { useTranslations } from 'next-intl';
 import { BarChart3, Database } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { StatsCard } from '@/components/common/stats-card';
 import { CompactNumberWithTooltip } from '@/components/common/compact-number-with-tooltip';
 import { ParkCard } from '@/components/parks/park-card';
 import { AttractionCard } from '@/components/parks/attraction-card';
-import { getGlobalStats } from '@/lib/api/analytics';
-import { catchNonFatal } from '@/lib/api/client';
 import { translateGeoSlug } from '@/lib/utils/geo-translate';
 import { convertApiUrlToFrontendUrl } from '@/lib/utils/url-utils';
-import { getParkBackgroundImage, getAttractionBackgroundImage } from '@/lib/utils/park-assets';
-import { getServerNowMs } from '@/lib/utils/server-time';
+import { useGlobalStats } from '@/lib/hooks/use-global-stats';
+import {
+  useParkBackgrounds,
+  resolveParkBg,
+  resolveAttractionBg,
+} from '@/lib/hooks/use-park-backgrounds';
+import { GlobalStatsSkeleton } from '@/components/home/home-skeletons';
 
 /**
  * Global real-time stats + platform statistics.
  *
- * Both blocks share a single `getGlobalStats` fetch, so they live in one
- * <Suspense> boundary. Rendered server-side (below the fold) and streamed in
- * after the hero — never blocking first paint.
+ * Fully live, so it loads client-side via {@link useGlobalStats} (no-store, 5-min poll) instead of
+ * being baked into the homepage ISR shell. Background images for the live park/ride highlights are
+ * resolved on the client via {@link useParkBackgrounds}. Until the data lands, the section renders
+ * its skeleton (same one the homepage <Suspense> uses), so the prerendered shell stays status-free.
  */
-export async function GlobalStatsSection() {
-  const [t, tCommon, tGeo, stats] = await Promise.all([
-    getTranslations('stats'),
-    getTranslations('common'),
-    getTranslations('geo'),
-    catchNonFatal(getGlobalStats()),
-  ]);
+export function GlobalStatsSection() {
+  const t = useTranslations('stats');
+  const tCommon = useTranslations('common');
+  const tGeo = useTranslations('geo');
+  const { data: stats } = useGlobalStats();
+  const bgSet = useParkBackgrounds();
 
-  if (!stats) return null;
+  if (!stats) return <GlobalStatsSkeleton />;
 
-  // Cached "now" for the synthetic stat snapshot timestamps (cacheComponents-safe).
-  const nowIso = new Date(await getServerNowMs()).toISOString();
+  const nowIso = new Date().toISOString();
 
   return (
     <>
@@ -85,7 +89,7 @@ export async function GlobalStatsSection() {
                     stats.mostCrowdedPark.country
                   )}
                   href={convertApiUrlToFrontendUrl(stats.mostCrowdedPark.url) as '/'}
-                  backgroundImage={getParkBackgroundImage(stats.mostCrowdedPark.slug)}
+                  backgroundImage={resolveParkBg(stats.mostCrowdedPark.slug, bgSet)}
                   status="OPERATING"
                   timezone={stats.mostCrowdedPark.timezone}
                   crowdLevel={stats.mostCrowdedPark.crowdLevel ?? undefined}
@@ -110,7 +114,7 @@ export async function GlobalStatsSection() {
                     stats.leastCrowdedPark.country
                   )}
                   href={convertApiUrlToFrontendUrl(stats.leastCrowdedPark.url) as '/'}
-                  backgroundImage={getParkBackgroundImage(stats.leastCrowdedPark.slug)}
+                  backgroundImage={resolveParkBg(stats.leastCrowdedPark.slug, bgSet)}
                   status="OPERATING"
                   timezone={stats.leastCrowdedPark.timezone}
                   crowdLevel={stats.leastCrowdedPark.crowdLevel ?? undefined}
@@ -130,12 +134,11 @@ export async function GlobalStatsSection() {
                 <AttractionCard
                   parkStatus="OPERATING"
                   showParkName
-                  backgroundImage={
-                    getAttractionBackgroundImage(
-                      stats.longestWaitRide.parkSlug,
-                      stats.longestWaitRide.slug
-                    ) ?? getParkBackgroundImage(stats.longestWaitRide.parkSlug)
-                  }
+                  backgroundImage={resolveAttractionBg(
+                    stats.longestWaitRide.parkSlug,
+                    stats.longestWaitRide.slug,
+                    bgSet
+                  )}
                   attraction={{
                     id: stats.longestWaitRide.id,
                     name: stats.longestWaitRide.name,
@@ -184,12 +187,11 @@ export async function GlobalStatsSection() {
                 <AttractionCard
                   parkStatus="OPERATING"
                   showParkName
-                  backgroundImage={
-                    getAttractionBackgroundImage(
-                      stats.shortestWaitRide.parkSlug,
-                      stats.shortestWaitRide.slug
-                    ) ?? getParkBackgroundImage(stats.shortestWaitRide.parkSlug)
-                  }
+                  backgroundImage={resolveAttractionBg(
+                    stats.shortestWaitRide.parkSlug,
+                    stats.shortestWaitRide.slug,
+                    bgSet
+                  )}
                   attraction={{
                     id: stats.shortestWaitRide.id,
                     name: stats.shortestWaitRide.name,

--- a/components/home/live-activity-grid.tsx
+++ b/components/home/live-activity-grid.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { ChevronRight } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { OpenStatusProgress } from '@/components/common/open-status-progress';
+import { Skeleton } from '@/components/ui/skeleton';
+import { translateGeoSlug } from '@/lib/utils/geo-translate';
+import { useGeoLiveStats, findOpenParkCount } from '@/lib/hooks/use-geo-live-stats';
+
+/** Static (cacheable) per-continent fields — everything except the live open-park count. */
+export interface StaticContinentCard {
+  slug: string;
+  name: string;
+  parkCount: number;
+  countryCount: number;
+}
+
+/**
+ * Homepage "parks open now" grid. Card structure (continent name, country count, total parks) is
+ * prerendered; the live open count is layered on the client via the shared {@link useGeoLiveStats}
+ * batch call — so this section no longer bakes a 10-min-stale count into the homepage ISR shell.
+ */
+export function LiveActivityGrid({ continents }: { continents: StaticContinentCard[] }) {
+  const tGeo = useTranslations('geo');
+  const tExplore = useTranslations('explore');
+  const { data } = useGeoLiveStats();
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {continents.map((continent) => {
+        const continentName = translateGeoSlug(tGeo, 'continents', continent.slug, continent.name);
+        const openParkCount = findOpenParkCount(data, continent.slug);
+
+        return (
+          <Link
+            key={continent.slug}
+            href={`/parks/${continent.slug}`}
+            prefetch={false}
+            className="group block"
+          >
+            <Card className="bg-muted/50 hover:bg-muted/70 border-border hover:border-primary/50 h-full transition-all duration-200 hover:scale-[1.02] hover:shadow-lg">
+              <CardHeader className="pb-2">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-lg font-medium">{continentName}</CardTitle>
+                  <ChevronRight className="text-muted-foreground group-hover:text-primary h-4 w-4 transition-colors" />
+                </div>
+                <div className="text-muted-foreground text-xs">
+                  {continent.countryCount}{' '}
+                  {tExplore('stats.country', { count: continent.countryCount })}
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="mb-2 flex items-baseline gap-2">
+                  <span className="bg-gradient-to-r from-green-600 to-emerald-500 bg-clip-text text-3xl font-bold text-transparent">
+                    {openParkCount === undefined ? (
+                      <Skeleton className="inline-block h-7 w-8 align-middle" />
+                    ) : (
+                      openParkCount
+                    )}
+                  </span>
+                  <span className="text-muted-foreground text-sm">/ {continent.parkCount}</span>
+                </div>
+                {/* Progress bar — muted placeholder until the live count loads */}
+                <OpenStatusProgress
+                  openCount={openParkCount ?? 0}
+                  totalCount={continent.parkCount}
+                  showLabel={false}
+                  className={openParkCount === undefined ? 'opacity-40' : undefined}
+                />
+              </CardContent>
+            </Card>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/home/live-activity-section.tsx
+++ b/components/home/live-activity-section.tsx
@@ -1,37 +1,31 @@
 import { getTranslations } from 'next-intl/server';
-import { ChevronRight, Globe } from 'lucide-react';
-import { Link } from '@/i18n/navigation';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { OpenStatusProgress } from '@/components/common/open-status-progress';
+import { Globe } from 'lucide-react';
 import { getGeoStructure } from '@/lib/api/discovery';
-import { getGeoLiveStats } from '@/lib/api/analytics';
 import { catchNonFatal } from '@/lib/api/client';
-import { translateGeoSlug } from '@/lib/utils/geo-translate';
+import { LiveActivityGrid, type StaticContinentCard } from '@/components/home/live-activity-grid';
 
 /**
  * "Parks open now" — per-continent live open-park counts.
  *
- * Fetches the geo structure (deduped with the featured-parks slot) and merges in
- * the live open counts from the geo-live endpoint. Rendered inside <Suspense> so
- * neither fetch blocks the above-the-fold hero.
+ * The section structure (continent names + total park counts) comes from the static geo structure
+ * and is prerendered/edge-cached; the live open counts are layered on the client by
+ * {@link LiveActivityGrid} (shared geo-live batch call), so this section no longer bakes a stale
+ * count into the homepage ISR shell. Rendered inside <Suspense> so the geo fetch never blocks the
+ * hero.
  */
 export async function LiveActivitySection() {
-  const [tHome, tGeo, tExplore, geoData, liveStats] = await Promise.all([
+  const [tHome, geoData] = await Promise.all([
     getTranslations('home'),
-    getTranslations('geo'),
-    getTranslations('explore'),
-    catchNonFatal(getGeoStructure(300)),
-    catchNonFatal(getGeoLiveStats()),
+    catchNonFatal(getGeoStructure()),
   ]);
 
-  const continents =
-    geoData?.continents.map((continent) => {
-      const liveContinent = liveStats?.continents.find((c) => c.slug === continent.slug);
-      return {
-        ...continent,
-        openParkCount: liveContinent?.openParkCount ?? continent.openParkCount,
-      };
-    }) || [];
+  const continents: StaticContinentCard[] =
+    geoData?.continents.map((continent) => ({
+      slug: continent.slug,
+      name: continent.name,
+      parkCount: continent.parkCount,
+      countryCount: continent.countryCount,
+    })) || [];
 
   if (continents.length === 0) return null;
 
@@ -43,52 +37,7 @@ export async function LiveActivitySection() {
           <h2 className="text-xl font-bold">{tHome('sections.liveNow')}</h2>
         </div>
         <p className="text-muted-foreground mb-8 text-sm">{tHome('sections.liveNowIntro')}</p>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {continents.map((continent) => {
-            const continentName = translateGeoSlug(
-              tGeo,
-              'continents',
-              continent.slug,
-              continent.name
-            );
-
-            return (
-              <Link
-                key={continent.slug}
-                href={`/parks/${continent.slug}`}
-                prefetch={false}
-                className="group block"
-              >
-                <Card className="bg-muted/50 hover:bg-muted/70 border-border hover:border-primary/50 h-full transition-all duration-200 hover:scale-[1.02] hover:shadow-lg">
-                  <CardHeader className="pb-2">
-                    <div className="flex items-center justify-between">
-                      <CardTitle className="text-lg font-medium">{continentName}</CardTitle>
-                      <ChevronRight className="text-muted-foreground group-hover:text-primary h-4 w-4 transition-colors" />
-                    </div>
-                    <div className="text-muted-foreground text-xs">
-                      {continent.countryCount}{' '}
-                      {tExplore('stats.country', { count: continent.countryCount })}
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="mb-2 flex items-baseline gap-2">
-                      <span className="bg-gradient-to-r from-green-600 to-emerald-500 bg-clip-text text-3xl font-bold text-transparent">
-                        {continent.openParkCount}
-                      </span>
-                      <span className="text-muted-foreground text-sm">/ {continent.parkCount}</span>
-                    </div>
-                    {/* Progress bar */}
-                    <OpenStatusProgress
-                      openCount={continent.openParkCount}
-                      totalCount={continent.parkCount}
-                      showLabel={false}
-                    />
-                  </CardContent>
-                </Card>
-              </Link>
-            );
-          })}
-        </div>
+        <LiveActivityGrid continents={continents} />
       </div>
     </section>
   );

--- a/components/parks/live-country-cards.tsx
+++ b/components/parks/live-country-cards.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { GeoLocationCard } from '@/components/common/geo-location-card';
+import { useGeoLiveStats, findOpenParkCount } from '@/lib/hooks/use-geo-live-stats';
+
+/** Static (cacheable) country-card fields — everything except the live open-park count. */
+export interface StaticCountryCard {
+  slug: string;
+  name: string;
+  href: string;
+  totalParkCount: number;
+  subtitle: string;
+}
+
+/**
+ * Continent-page country grid. The card structure (name, link, total parks, city count) is
+ * prerendered/edge-cached; the live open-park count is layered on the client via the shared
+ * {@link useGeoLiveStats} batch call — so the continent shell no longer revalidates every 10 min
+ * just to keep the count fresh.
+ */
+export function LiveCountryCards({
+  continent,
+  countries,
+  className,
+}: {
+  continent: string;
+  countries: StaticCountryCard[];
+  className?: string;
+}) {
+  const { data } = useGeoLiveStats();
+  return (
+    <div className={className}>
+      {countries.map((c) => (
+        <GeoLocationCard
+          key={c.slug}
+          name={c.name}
+          slug={c.slug}
+          href={c.href}
+          openParkCount={findOpenParkCount(data, continent, c.slug)}
+          totalParkCount={c.totalParkCount}
+          subtitle={c.subtitle}
+          variant="country"
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/parks/live-nearby-parks.tsx
+++ b/components/parks/live-nearby-parks.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { ParkCard } from '@/components/parks/park-card';
+import { useParkNeighbors } from '@/lib/hooks/use-park-neighbors';
+import type { ParkStatus } from '@/lib/api/types';
+
+/** Static (cacheable) nearby-park fields — name, link, distance, photo. No live status. */
+export interface StaticNearbyPark {
+  id: string;
+  name: string;
+  slug: string;
+  city: string;
+  country: string;
+  distance: number;
+  /** API url (converted to a frontend href by ParkCard). */
+  url: string;
+  backgroundImage: string | null;
+}
+
+/**
+ * Park-page "nearby parks" grid. The proximity list (names, links, distance, photo) is prerendered
+ * and edge-cached; live open/closed status + crowd is layered on the client via
+ * {@link useParkNeighbors}, so the park-page shell no longer bakes (potentially stale) neighbour
+ * statuses into the cached output.
+ */
+export function LiveNearbyParks({
+  parkId,
+  lat,
+  lng,
+  parks,
+}: {
+  parkId: string;
+  lat: number;
+  lng: number;
+  parks: StaticNearbyPark[];
+}) {
+  const { liveByParkId } = useParkNeighbors(lat, lng, parkId);
+
+  return (
+    <ul className="grid [grid-auto-rows:auto_1fr_auto] gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {parks.map((park) => {
+        const live = liveByParkId?.get(park.id);
+        return (
+          <li key={park.id} className="row-span-3 grid [grid-template-rows:subgrid]">
+            <ParkCard
+              id={park.id}
+              slug={park.slug}
+              name={park.name}
+              city={park.city}
+              country={park.country}
+              url={park.url}
+              backgroundImage={park.backgroundImage}
+              distance={park.distance}
+              translateCountry
+              variant="detailed"
+              status={live?.status as ParkStatus | undefined}
+              timezone={live?.timezone}
+              totalAttractions={live?.totalAttractions}
+              operatingAttractions={live?.operatingAttractions}
+              analytics={live?.analytics}
+              todaySchedule={live?.todaySchedule ?? undefined}
+              nextSchedule={live?.nextSchedule ?? undefined}
+              hasOperatingSchedule={live?.hasOperatingSchedule}
+            />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/components/parks/live-open-count.tsx
+++ b/components/parks/live-open-count.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { useGeoLiveStats, findOpenParkCount } from '@/lib/hooks/use-geo-live-stats';
+import { cn } from '@/lib/utils';
+
+/**
+ * Inline live "open parks" number for a continent (or a country within it). Renders a skeleton
+ * until the shared {@link useGeoLiveStats} batch call lands, so the surrounding text can be
+ * prerendered/cached without baking a stale count into the ISR shell.
+ */
+export function LiveOpenCount({
+  continent,
+  country,
+  className,
+}: {
+  continent: string;
+  country?: string;
+  className?: string;
+}) {
+  const { data } = useGeoLiveStats();
+  const count = findOpenParkCount(data, continent, country);
+  if (count === undefined) {
+    return <Skeleton className={cn('inline-block h-[1em] w-6 align-middle', className)} />;
+  }
+  return <>{count}</>;
+}

--- a/components/parks/live-park-grid.tsx
+++ b/components/parks/live-park-grid.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { ParkCard } from '@/components/parks/park-card';
+import { useRegionParks } from '@/lib/hooks/use-region-parks';
+
+/** Static (cacheable) per-park fields resolved on the server — nothing here changes during the day. */
+export interface StaticPark {
+  id: string;
+  name: string;
+  slug: string;
+  /** City display name (for the card subtitle). */
+  city: string;
+  /** Already-translated country name. */
+  countryName: string;
+  /** Frontend href. */
+  href: string;
+  /** Resolved server-side (fs lookup can't run on the client). */
+  backgroundImage: string | null;
+}
+
+interface LiveParkGridProps {
+  continent: string;
+  country: string;
+  parks: StaticPark[];
+  className?: string;
+}
+
+/**
+ * Renders a grid of park cards whose STRUCTURE (name, link, city, photo) is prerendered and
+ * edge-cached, while the live status / crowd / wait time / schedule is layered on the client via
+ * {@link useRegionParks}. This keeps the hub-page ISR shell status-free (so it can be cached for a
+ * day instead of churning every hour to stay fresh) without ever showing a stale open/closed badge:
+ * the badge simply renders once the client batch call lands. Multiple grids on a country page share
+ * one underlying request (React Query dedupe by continent+country).
+ */
+export function LiveParkGrid({ continent, country, parks, className }: LiveParkGridProps) {
+  const { liveByParkId } = useRegionParks(continent, country);
+
+  return (
+    <div className={className}>
+      {parks.map((park) => {
+        const live = liveByParkId?.get(park.id);
+        return (
+          <ParkCard
+            key={park.id}
+            parkId={park.id}
+            name={park.name}
+            slug={park.slug}
+            city={park.city}
+            country={park.countryName}
+            href={park.href}
+            backgroundImage={park.backgroundImage}
+            variant="detailed"
+            // Live overlay — undefined until the client batch call resolves, so the prerendered
+            // shell shows the card without a status badge (the footer renders its own skeleton).
+            status={live?.status}
+            crowdLevel={live?.crowdLevel}
+            averageWaitTime={live?.averageWaitTime}
+            operatingAttractions={live?.operatingAttractions}
+            totalAttractions={live?.totalAttractions}
+            timezone={live?.timezone}
+            hasOperatingSchedule={live?.hasOperatingSchedule}
+            todaySchedule={live?.todaySchedule}
+            nextSchedule={live?.nextSchedule}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/components/parks/nearby-parks-section.tsx
+++ b/components/parks/nearby-parks-section.tsx
@@ -1,8 +1,9 @@
 import { getTranslations } from 'next-intl/server';
 import { MapPin } from 'lucide-react';
-import { ParkCard } from '@/components/parks/park-card';
 import { getParksNearLocation } from '@/lib/api/discovery';
+import { getParkBackgroundImage } from '@/lib/utils/park-assets';
 import { stripNewPrefix } from '@/lib/utils';
+import { LiveNearbyParks, type StaticNearbyPark } from '@/components/parks/live-nearby-parks';
 
 interface NearbyParksSectionProps {
   parkId: string;
@@ -19,6 +20,18 @@ export async function NearbyParksSection({ parkId, lat, lng, className }: Nearby
 
   if (parks.length < 2) return null;
 
+  // Status-free seed (proximity + structure only); live status is overlaid client-side.
+  const staticParks: StaticNearbyPark[] = parks.map((park) => ({
+    id: park.id,
+    name: stripNewPrefix(park.name),
+    slug: park.slug,
+    city: park.city ?? '',
+    country: park.country ?? '',
+    distance: park.distance,
+    url: park.url ?? '',
+    backgroundImage: getParkBackgroundImage(park.slug),
+  }));
+
   return (
     <section className={className}>
       <div className="bg-background/70 mb-4 rounded-xl px-4 py-3 backdrop-blur-md">
@@ -29,30 +42,7 @@ export async function NearbyParksSection({ parkId, lat, lng, className }: Nearby
         <p className="text-muted-foreground mt-1 text-sm">{t('nearbyParksArea')}</p>
       </div>
 
-      <ul className="grid [grid-auto-rows:auto_1fr_auto] gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {parks.map((park) => (
-          <li key={park.id} className="row-span-3 grid [grid-template-rows:subgrid]">
-            <ParkCard
-              id={park.id}
-              slug={park.slug}
-              name={stripNewPrefix(park.name)}
-              city={park.city ?? ''}
-              country={park.country ?? ''}
-              distance={park.distance}
-              status={park.status as import('@/lib/api/types').ParkStatus}
-              timezone={park.timezone}
-              totalAttractions={park.totalAttractions}
-              operatingAttractions={park.operatingAttractions}
-              analytics={park.analytics}
-              todaySchedule={park.todaySchedule ?? undefined}
-              nextSchedule={park.nextSchedule ?? undefined}
-              url={park.url ?? ''}
-              hasOperatingSchedule={park.hasOperatingSchedule}
-              translateCountry
-            />{' '}
-          </li>
-        ))}
-      </ul>
+      <LiveNearbyParks parkId={parkId} lat={lat} lng={lng} parks={staticParks} />
     </section>
   );
 }

--- a/lib/api/cache-config.ts
+++ b/lib/api/cache-config.ts
@@ -19,9 +19,13 @@ export const CACHE_TTL = {
   nearby: 60, // ⚠️ Using cache: 'no-store' - IP/GeoIP-dependent, must not be cached
   realtime: 120, // ⚠️ Using cache: 'no-store' - live ticker/realtime stats
 
-  // Discovery & Park data
-  geo: 3600, // geo structure changes rarely
-  continents: 3600, // same as geo
+  // Discovery & Park data. Raised to 24h once the hub pages (continent/country/city) render their
+  // ParkCards STATUS-FREE: live status/crowd/wait now come from the client (<LiveParkGrid> →
+  // /api/discovery), so the per-locale ISR shells carry only structure (park names/slugs), which
+  // changes ~weekly. A new/removed park appears within 24h (or via on-demand revalidate); this
+  // collapses the hourly hub-page write churn ~24×.
+  geo: 86400, // geo structure changes rarely (was 3600 — hub shells no longer carry live status)
+  continents: 86400, // same as geo
   parks: 300, // popular parks frontend data-cached 5 min - slow-moving popularity ranking
   // Shell TTL for the park/attraction static prerender. Decoupled from the API's 5-min live
   // cadence: the shell wait times are only an SSR seed replaced client-side by React Query, so a

--- a/lib/api/discovery.ts
+++ b/lib/api/discovery.ts
@@ -97,6 +97,34 @@ export async function getParksNearLocation(
 ): Promise<NearbyParkItem[]> {
   'use cache';
   cacheLife({ stale: 3600, revalidate: 3600, expire: 3600 * 4 });
+  return fetchParksNearLocation(lat, lng, excludeParkId, limit, maxDistanceM, false);
+}
+
+/**
+ * Live (no-store) variant of {@link getParksNearLocation} for the client overlay.
+ *
+ * The park page renders its "nearby parks" cards status-free (cacheable shell) and refreshes the
+ * live open/closed status on the client via `useParkNeighbors` → `/api/parks/near`, which calls
+ * this. Same proximity logic, just uncached so the overlay reflects the latest status.
+ */
+export async function getParksNearLocationFresh(
+  lat: number,
+  lng: number,
+  excludeParkId?: string,
+  limit: number = 3,
+  maxDistanceM: number = 300_000
+): Promise<NearbyParkItem[]> {
+  return fetchParksNearLocation(lat, lng, excludeParkId, limit, maxDistanceM, true);
+}
+
+async function fetchParksNearLocation(
+  lat: number,
+  lng: number,
+  excludeParkId: string | undefined,
+  limit: number,
+  maxDistanceM: number,
+  fresh: boolean
+): Promise<NearbyParkItem[]> {
   // The API sometimes returns coordinates as strings despite being typed as number — coerce defensively.
   const latNum = Number(lat);
   const lngNum = Number(lng);
@@ -114,7 +142,10 @@ export async function getParksNearLocation(
   const endpoint = `/v1/discovery/nearby?lat=${offsetLat}&lng=${lngNum}&limit=${fetchLimit}&radius=0`;
 
   try {
-    const response = await api.get<NearbyApiResponse>(endpoint);
+    const response = await api.get<NearbyApiResponse>(
+      endpoint,
+      fresh ? { cache: 'no-store' } : undefined
+    );
 
     if (response.type !== 'nearby_parks' || !response.data.parks) {
       return [];

--- a/lib/hooks/use-geo-live-stats.ts
+++ b/lib/hooks/use-geo-live-stats.ts
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import type { GeoLiveStatsDto } from '@/lib/api/types';
+
+/**
+ * Batch-fetch live "open park" counts per continent/country.
+ *
+ * One shared request (deduped via React Query) feeds every consumer on a page — the homepage
+ * "parks open now" grid and the continent page's country cards. Client-only + 5-min poll, so these
+ * counts no longer have to be baked into (and revalidate) the ISR shell. Hits the existing no-store
+ * `/api/analytics/geo-live` proxy.
+ */
+export function useGeoLiveStats() {
+  return useQuery<GeoLiveStatsDto>({
+    queryKey: ['geo-live'],
+    queryFn: async () => {
+      const res = await fetch('/api/analytics/geo-live', { cache: 'no-store' });
+      if (!res.ok) throw new Error(`Failed to fetch geo-live stats: ${res.statusText}`);
+      return res.json();
+    },
+    enabled: typeof window !== 'undefined',
+    staleTime: 5 * 60_000,
+    gcTime: 10 * 60_000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: 5 * 60_000,
+    retry: 2,
+  });
+}
+
+/** Look up the live open-park count for a continent (or a country within it). `undefined` until loaded. */
+export function findOpenParkCount(
+  stats: GeoLiveStatsDto | undefined,
+  continentSlug: string,
+  countrySlug?: string
+): number | undefined {
+  const continent = stats?.continents.find((c) => c.slug === continentSlug);
+  if (!continent) return undefined;
+  if (!countrySlug) return continent.openParkCount;
+  return continent.countries.find((c) => c.slug === countrySlug)?.openParkCount;
+}

--- a/lib/hooks/use-global-stats.ts
+++ b/lib/hooks/use-global-stats.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import type { GlobalStats } from '@/lib/api/types';
+
+/**
+ * Live global platform stats (open parks, most/least crowded park, longest/shortest wait ride).
+ *
+ * Fetched on the client via the existing no-store `/api/analytics/realtime` proxy so the homepage
+ * "global stats" section is no longer baked into (and revalidating) the ISR shell every 10 min.
+ * Client-only + 5-min poll.
+ */
+export function useGlobalStats() {
+  return useQuery<GlobalStats>({
+    queryKey: ['global-stats'],
+    queryFn: async () => {
+      const res = await fetch('/api/analytics/realtime', { cache: 'no-store' });
+      if (!res.ok) throw new Error(`Failed to fetch global stats: ${res.statusText}`);
+      return res.json();
+    },
+    enabled: typeof window !== 'undefined',
+    staleTime: 5 * 60_000,
+    gcTime: 10 * 60_000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: 5 * 60_000,
+    retry: 2,
+  });
+}

--- a/lib/hooks/use-park-backgrounds.ts
+++ b/lib/hooks/use-park-backgrounds.ts
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+
+const SUPPORTED_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp'] as const;
+
+/**
+ * Client-side park/attraction background-image resolution.
+ *
+ * `getParkBackgroundImage` (server) probes the filesystem, which the client can't do — but
+ * `/api/parks/backgrounds` returns the full list of available image paths. This hook fetches that
+ * list once (images only change on deploy, so it's cached for the session) so client-rendered cards
+ * (e.g. the homepage live global-stats highlights) can resolve the same background image the server
+ * would, via {@link resolveParkBg} / {@link resolveAttractionBg}.
+ */
+export function useParkBackgrounds() {
+  const { data } = useQuery<Set<string>>({
+    queryKey: ['park-backgrounds'],
+    queryFn: async () => {
+      const res = await fetch('/api/parks/backgrounds');
+      if (!res.ok) throw new Error(`Failed to fetch park backgrounds: ${res.statusText}`);
+      const json = (await res.json()) as { backgrounds?: string[] };
+      return new Set(json.backgrounds ?? []);
+    },
+    enabled: typeof window !== 'undefined',
+    staleTime: Infinity, // images change only on deploy
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+  return data;
+}
+
+/** Mirror of the server `getParkBackgroundImage`: `/images/parks/<slug>/background.<ext>`. */
+export function resolveParkBg(slug: string, set: Set<string> | undefined): string | null {
+  if (!set) return null;
+  for (const ext of SUPPORTED_EXTENSIONS) {
+    const p = `/images/parks/${slug}/background${ext}`;
+    if (set.has(p)) return p;
+  }
+  return null;
+}
+
+/** Mirror of the server `getAttractionBackgroundImage` (with park-background fallback). */
+export function resolveAttractionBg(
+  parkSlug: string,
+  attractionSlug: string,
+  set: Set<string> | undefined
+): string | null {
+  if (!set) return null;
+  for (const ext of SUPPORTED_EXTENSIONS) {
+    const p = `/images/parks/${parkSlug}/${attractionSlug}${ext}`;
+    if (set.has(p)) return p;
+  }
+  for (const ext of SUPPORTED_EXTENSIONS) {
+    const p = `/images/parks/${parkSlug}/attractions/${attractionSlug}${ext}`;
+    if (set.has(p)) return p;
+  }
+  return resolveParkBg(parkSlug, set);
+}

--- a/lib/hooks/use-park-neighbors.ts
+++ b/lib/hooks/use-park-neighbors.ts
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query';
+import type { NearbyParkItem } from '@/lib/api/types';
+
+/**
+ * Batch-fetch live status for the parks near a given location, keyed by park id.
+ *
+ * Backs the park page's nearby-parks overlay: the cards' structure is prerendered status-free and
+ * this hook layers live open/closed status + crowd on the client (no-store, 5-min poll). Mirrors
+ * the other live hooks; client-only so the SSR shell stays status-free.
+ */
+export function useParkNeighbors(
+  lat: number,
+  lng: number,
+  excludeParkId: string,
+  limit = 3,
+  maxDistanceM = 100_000
+) {
+  const query = useQuery<Map<string, NearbyParkItem>>({
+    queryKey: ['park-neighbors', lat, lng, excludeParkId],
+    queryFn: async () => {
+      const url = new URL('/api/parks/near', window.location.origin);
+      url.searchParams.set('lat', String(lat));
+      url.searchParams.set('lng', String(lng));
+      url.searchParams.set('exclude', excludeParkId);
+      url.searchParams.set('limit', String(limit));
+      url.searchParams.set('radius', String(maxDistanceM));
+      const res = await fetch(url.toString(), { cache: 'no-store' });
+      if (!res.ok) throw new Error(`Failed to fetch nearby parks: ${res.statusText}`);
+      const data = (await res.json()) as { parks?: NearbyParkItem[] };
+      const map = new Map<string, NearbyParkItem>();
+      for (const park of data.parks ?? []) map.set(park.id, park);
+      return map;
+    },
+    enabled: typeof window !== 'undefined',
+    staleTime: 5 * 60_000,
+    gcTime: 10 * 60_000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: 5 * 60_000,
+    retry: 2,
+  });
+
+  return { liveByParkId: query.data };
+}

--- a/lib/hooks/use-region-parks.ts
+++ b/lib/hooks/use-region-parks.ts
@@ -1,0 +1,61 @@
+import { useQuery } from '@tanstack/react-query';
+import type { DiscoveryCityResponse, ParkStatus, CrowdLevel, ScheduleSummary } from '@/lib/api/types';
+
+/** Live, per-park fields the hub ParkCards overlay client-side (everything that can change during the day). */
+export interface LiveParkFields {
+  status?: ParkStatus;
+  crowdLevel?: CrowdLevel;
+  averageWaitTime?: number;
+  operatingAttractions?: number;
+  totalAttractions?: number;
+  timezone?: string;
+  hasOperatingSchedule?: boolean;
+  todaySchedule?: ScheduleSummary;
+  nextSchedule?: ScheduleSummary;
+}
+
+/**
+ * Batch-fetch live status for every park in a country, keyed by park id.
+ *
+ * One request per (continent, country) — React Query dedupes it across all `<LiveParkGrid>`
+ * instances on a country page (one per city), so a country page makes a SINGLE live call no
+ * matter how many cities it lists. Mirrors the `useLiveParkData` contract: client-only, refetch
+ * on mount (the SSR shell is status-free), 5-min poll, refetch on focus/reconnect.
+ */
+export function useRegionParks(continent: string, country: string) {
+  const query = useQuery<Map<string, LiveParkFields>>({
+    queryKey: ['region-parks', continent, country],
+    queryFn: async () => {
+      const res = await fetch(`/api/discovery/${continent}/${country}`, { cache: 'no-store' });
+      if (!res.ok) throw new Error(`Failed to fetch region parks: ${res.statusText}`);
+      const data = (await res.json()) as DiscoveryCityResponse;
+      const map = new Map<string, LiveParkFields>();
+      for (const city of data.data ?? []) {
+        for (const park of city.parks ?? []) {
+          map.set(park.id, {
+            status: park.status,
+            crowdLevel: park.analytics?.statistics?.crowdLevel ?? park.currentLoad?.crowdLevel,
+            averageWaitTime: park.analytics?.statistics?.avgWaitTime,
+            operatingAttractions: park.analytics?.statistics?.operatingAttractions,
+            totalAttractions: park.analytics?.statistics?.totalAttractions,
+            timezone: park.timezone,
+            hasOperatingSchedule: park.hasOperatingSchedule,
+            todaySchedule: park.todaySchedule,
+            nextSchedule: park.nextSchedule,
+          });
+        }
+      }
+      return map;
+    },
+    // Run only on the client: the SSR/prerendered shell renders status-free cards.
+    enabled: typeof window !== 'undefined',
+    staleTime: 5 * 60_000,
+    gcTime: 10 * 60_000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: 5 * 60_000,
+    retry: 2,
+  });
+
+  return { liveByParkId: query.data, isFetching: query.isFetching };
+}


### PR DESCRIPTION
## Principle

Server renders only **static structure**; all live data (open/closed status, wait times, crowd, open-counts) loads via a **client batch call** (React Query, no-store, 5-min poll, refetch on mount). Every ISR shell becomes status-free → long TTL → minimal writes, with **zero stale status** (the shell never claims a status; badges/numbers appear once the client call lands, skeleton until then). Same SSR-static + client-live split already used by the park page, favorites and nearby — now applied consistently.

## All phases (this branch)

**Phase 1 — Hub city/country** ✅
`/api/discovery/<continent>/<country>` proxy + `useRegionParks` (one batch call/country, deduped) + `<LiveParkGrid>`. City/country render status-free `ParkCard`s. `CACHE_TTL.geo/continents` 3600 → 86400 (~24× fewer hub writes).

**Phase 2a — Continent + homepage open-counts** ✅
`useGeoLiveStats` + `findOpenParkCount` (existing `/api/analytics/geo-live`). `GeoLocationCard.openParkCount` now optional (skeleton). `<LiveCountryCards>` / `<LiveOpenCount>` (continent) + `<LiveActivityGrid>` (homepage). Continent shell drops 600s → 24h.

**Phase 2b — Homepage global stats** ✅
`useGlobalStats` (`/api/analytics/realtime`) + `useParkBackgrounds` (client mirror of the fs background lookup via `/api/parks/backgrounds`, keeps photos). `GlobalStatsSection` is now a client component (skeleton until data).

**Phase 3 — Park page nearby** ✅
`getParksNearLocationFresh` + `/api/parks/near` proxy + `useParkNeighbors` + `<LiveNearbyParks>`. Nearby cards render status-free (links/photos for SEO), status overlaid on the client.

## Verification

`tsc` + `eslint` clean across all phases. Runtime verification on this PR's Vercel preview (`parkfan-git-claude-statusless-cards-arns.vercel.app`): hub/continent/homepage/park cards render status-free in the prerendered HTML (no-JS/crawler safe), live status/counts appear on mount. Per-route ISR behaviour checkable via `scripts/isr-cache-probe.mjs` (PR #130).

> Netlify checks fail (pre-existing: Next 16 + Cache Components unsupported by the Netlify runtime, ~15s infra fail) — Vercel is the production target and builds green.

https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr