### PR TITLE
perf(park): seedless attraction grid (strip live data from ISR seed)

### DIFF
--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -42,7 +42,7 @@ import { ParkBestDaysSectionSkeleton } from '@/components/parks/park-best-days-s
 import { ParkStatsSection } from '@/components/parks/park-stats-section';
 import { ParkStatsSectionSkeleton } from '@/components/parks/park-stats-section-skeleton';
 import { NearbyParksSection } from '@/components/parks/nearby-parks-section';
-import { groupAttractionsByLand } from '@/lib/utils/park-utils';
+import { groupAttractionsByLand, leanParkSeed } from '@/lib/utils/park-utils';
 import { generateParkBreadcrumbs } from '@/lib/utils/breadcrumb-utils';
 import { translateGeoSlug } from '@/lib/utils/geo-translate';
 
@@ -243,9 +243,18 @@ export default async function ParkPage({ params }: ParkPageProps) {
   // shell would surface as "uncached data outside <Suspense>". So, like the calendar, the fetch
   // is invoked INSIDE the dynamic Suspense holes (after connection()), keyed off the geo slugs.
 
+  // Seed the attraction grid status-free: only the structure (name/link/land/headliner/seasonal)
+  // is prerendered; wait times, status, crowd, statistics/sparkline and best-visit times are
+  // refetched on the client by LiveParkData (useLiveParkData), so they aren't baked into the
+  // per-locale ISR output. This is the bulk of the park-page size-weighted write units.
+  const seedPark = leanParkSeed(park);
+
   // Group attractions by land
   const otherAttractionsLabel = t('otherAttractions');
-  const attractionsByLand = groupAttractionsByLand(park.attractions || [], otherAttractionsLabel);
+  const attractionsByLand = groupAttractionsByLand(
+    seedPark.attractions || [],
+    otherAttractionsLabel
+  );
   const landNames = Object.keys(attractionsByLand).sort((a, b) => {
     // Put "Other Attractions" at the end
     if (a === otherAttractionsLabel) return 1;
@@ -386,7 +395,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
 
           {/* Live Park Data (Status + Tabs with auto-refresh) */}
           <LiveParkData
-            initialData={park}
+            initialData={seedPark}
             continent={continent}
             country={country}
             city={city}

--- a/lib/utils/park-utils.ts
+++ b/lib/utils/park-utils.ts
@@ -1,4 +1,41 @@
-import type { ParkAttraction } from '@/lib/api/types';
+import type { ParkAttraction, ParkWithAttractions } from '@/lib/api/types';
+
+/**
+ * Strip the heavy, live per-attraction fields before a park is used as the LiveParkData SSR seed.
+ *
+ * The park page renders the attraction-grid STRUCTURE (name, link, land, headliner/seasonal badges)
+ * server-side for SEO, but the volatile data — wait times (`queues`), `status`, crowd level, the
+ * `statistics`/sparkline and `bestVisitTimes` — is refetched on the client by `useLiveParkData`
+ * (initialDataUpdatedAt: 0) and must not be baked into the per-locale ISR output. Those arrays are
+ * the bulk of the ~130 KB park payload (statistics ≈ 28 KB, bestVisitTimes ≈ 15 KB, queues ≈ 11 KB
+ * across a big park), and they're rendered into per-card sparklines/badges on top — so dropping them
+ * from the seed sharply shrinks the park page's size-weighted ISR write units. The live /api/parks
+ * proxy still returns the FULL park, so the client overlay is unaffected.
+ */
+export function leanParkSeed(park: ParkWithAttractions): ParkWithAttractions {
+  return {
+    ...park,
+    attractions: park.attractions.map((a) => {
+      const lean = { ...a } as ParkAttraction & Record<string, unknown>;
+      // Heavy / live — re-supplied by the client refetch.
+      delete lean.statistics;
+      delete lean.queues;
+      delete lean.bestVisitTimes;
+      delete lean.status;
+      delete lean.crowdLevel;
+      delete lean.currentLoad;
+      delete lean.trend;
+      delete lean.history;
+      delete lean.hourlyForecast;
+      delete lean.predictionAccuracy;
+      // Non-typed extras some backends include — never read by the frontend.
+      delete lean.effectiveStatus;
+      delete lean.baseline;
+      delete lean.comparison;
+      return lean;
+    }),
+  };
+}
 
 /**
  * Groups attractions by their land name.


### PR DESCRIPTION
## Why

After the hub/homepage/nearby conversions (#131), the **park page is the largest remaining ISR write-unit driver** — the probe measured ~540 KB HTML (e.g. Phantasialand) and flagged it as oversized. It seeds `LiveParkData` with the **full park** (`initialData={park}`), baking every attraction's `statistics`/sparkline, `queues` (wait times), `bestVisitTimes`, `status` and crowd level into the per-locale ISR output — even though `LiveParkData` immediately refetches the full park on the client (`initialDataUpdatedAt: 0`).

## What

`leanParkSeed()` strips the heavy live per-attraction fields before the park is used as the seed:

- **Seed (prerendered):** structure only — name, link, land, headliner/seasonal badges (SEO-relevant).
- **Client (`useLiveParkData`):** wait times, status, crowd, per-card sparkline — appear on mount from the existing refetch.

Same SSR-static + client-live split as the hub pages. The `/api/parks` proxy still returns the full park, so the overlay is unaffected. Top-level park `status`/`weather`/`schedule` stay in the seed (the prominent header isn't stripped). `ParkStructuredData` already only bakes attraction name/url/image (lightweight) — untouched.

## Expected result

The ~130 KB per-attraction live payload (statistics ≈ 28 KB, bestVisitTimes ≈ 15 KB, queues ≈ 11 KB on a big park) + its rendered sparklines drop out of the per-locale ISR → the park page should shrink well below the 512 KB oversize flag, cutting its size-weighted write units across all 6 locales.

## Verification

`tsc` + `eslint` clean. On the Vercel preview: the park page should be much smaller (re-run `pnpm probe:isr`), attraction cards render structure-first then live wait/status on mount, and the park header status stays server-rendered.

https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr)_