### PR TITLE
perf(park): 6h shell TTL + truly-fresh live poll (cut park ISR writes ~6×)

### DIFF
--- a/app/api/parks/[...path]/route.ts
+++ b/app/api/parks/[...path]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getIntegratedCalendar } from '@/lib/api/integrated-calendar';
-import { getParkByGeoPath } from '@/lib/api/parks';
+import { getParkByGeoPathFresh } from '@/lib/api/parks';
 import { getParkWeatherNowcastFresh } from '@/lib/api/weather-nowcast';
 
 export async function GET(
@@ -16,9 +16,10 @@ export async function GET(
     const [continent, country, city, park] = path;
 
     try {
-      const parkData = await getParkByGeoPath(continent, country, city, park);
+      // Fresh (no-store) so the client poll reflects the backend's latest wait times — NOT the
+      // cached shell snapshot (which now lives 6h). getParkByGeoPathFresh resolves to null on 404.
+      const parkData = await getParkByGeoPathFresh(continent, country, city, park);
 
-      // getParkByGeoPath resolves to null for a non-existent park (404) instead of throwing.
       if (!parkData) {
         return NextResponse.json({ error: 'Park not found' }, { status: 404 });
       }

--- a/lib/api/cache-config.ts
+++ b/lib/api/cache-config.ts
@@ -27,12 +27,12 @@ export const CACHE_TTL = {
   geo: 86400, // geo structure changes rarely (was 3600 — hub shells no longer carry live status)
   continents: 86400, // same as geo
   parks: 300, // popular parks frontend data-cached 5 min - slow-moving popularity ranking
-  // Shell TTL for the park/attraction static prerender. Decoupled from the API's 5-min live
-  // cadence: the shell wait times are only an SSR seed replaced client-side by React Query, so a
-  // 1h-stale shell is fine. This is the floor that drives the dominant per-park/per-attraction ×
-  // per-locale ISR-write volume (see PARK_MAX_AGE in lib/api/parks.ts) — 1h cuts those ~12×.
-  parkDetail: 3600, // shell revalidate 1h - live wait times refreshed client-side
-  waitTimes: 3600, // shell revalidate 1h - live wait times refreshed client-side
+  // Shell TTL for the park/attraction static prerender (see PARK_MAX_AGE / ATTRACTION_MAX_AGE in
+  // lib/api/parks.ts). The shell is only an SSR seed; live wait times/status come from the client
+  // poll via getParkByGeoPathFresh (no-store), so the shell can revalidate every 6h instead of
+  // hourly — ~6× fewer park ISR writes, with the live data staying genuinely fresh.
+  parkDetail: 21600, // shell revalidate 6h - live wait times via getParkByGeoPathFresh
+  waitTimes: 21600, // shell revalidate 6h - live wait times via getParkByGeoPathFresh
 
   // Static data (still using revalidate)
   calendar: 900, // /v1/parks/:slug/calendar - API: 900s (past/today) / 1800s (future); the forecast under it only changes ~13h, and today's crowdLevel is patched client-side via a separate 5-min today-only fetch — so 5 min here was pure rebuild churn

--- a/lib/api/parks.ts
+++ b/lib/api/parks.ts
@@ -18,7 +18,11 @@ import type { ParkWithAttractions, AttractionResponse, PopularPark } from './typ
 // a tighter bound is worth the extra writes. Attractions get a longer 6h floor: their shell has no
 // schedule/weather (only name/description/history-chart seed, daily-ish), they are by far the
 // highest-cardinality route, and their live status/wait time is client-refreshed all the same.
-const PARK_MAX_AGE = 3600; // 1h park shell TTL — live data is refreshed client-side, not via ISR
+// 6h park shell TTL. The shell carries only structure + the schedule/weather seed (both
+// day-stable or client-refreshed); live wait times/status come from the client poll via
+// getParkByGeoPathFresh (see below), so the cached shell no longer needs to be the fresh source —
+// it can revalidate every 6h instead of hourly (~6× fewer park ISR writes), matching attractions.
+const PARK_MAX_AGE = 21600;
 const ATTRACTION_MAX_AGE = 21600; // 6h attraction shell TTL — dominant route, no schedule in shell
 
 /**
@@ -69,9 +73,38 @@ export async function getParkByGeoPath(
 ): Promise<ParkWithAttractions | null> {
   'use cache';
   cacheLife({ stale: PARK_MAX_AGE, revalidate: PARK_MAX_AGE, expire: PARK_MAX_AGE * 4 });
+  return fetchParkByGeoPath(continent, country, city, parkSlug, false);
+}
+
+/**
+ * Live (no-store) variant of {@link getParkByGeoPath} for the client poll path.
+ *
+ * The `/api/parks/...` proxy (polled by LiveParkData / LiveAttractionData every 5 min) used to call
+ * the cached `getParkByGeoPath`, so the "live" wait times were actually up to PARK_MAX_AGE stale.
+ * This variant skips our cache so the poll reflects the backend's latest snapshot (the upstream
+ * Redis/Cloudflare 5-min cache still collapses concurrent calls). Decoupling the poll from the shell
+ * cache is what lets the shell TTL go to 6h without freezing the live data.
+ */
+export async function getParkByGeoPathFresh(
+  continent: string,
+  country: string,
+  city: string,
+  parkSlug: string
+): Promise<ParkWithAttractions | null> {
+  return fetchParkByGeoPath(continent, country, city, parkSlug, true);
+}
+
+async function fetchParkByGeoPath(
+  continent: string,
+  country: string,
+  city: string,
+  parkSlug: string,
+  fresh: boolean
+): Promise<ParkWithAttractions | null> {
   try {
     const park = await api.get<ParkWithAttractions>(
-      `/v1/parks/${continent}/${country}/${city}/${parkSlug}`
+      `/v1/parks/${continent}/${country}/${city}/${parkSlug}`,
+      fresh ? { cache: 'no-store' } : undefined
     );
     // Trim detail-only per-attraction arrays before this snapshot is cached/serialized (see
     // leanParkForShell) — they are the bulk of the size-weighted ISR write units otherwise.


### PR DESCRIPTION
## Why

Closing the seedless experiment (#133) showed the park page's ISR writes are driven by **frequency**, not size: the seedless seed only trimmed ~6% of the write size and regressed LCP/CLS (Lighthouse: CLS 0→0.11, LCP 4.9→7.0s). The real lever is the **revalidate cadence**.

The park shell was at **1h** (`PARK_MAX_AGE=3600`) while attractions were at 6h — kept tighter because the shell carries schedule/status. But status is client-refreshed (LiveParkData) and the schedule is day-stable, so the shell doesn't need hourly freshness.

## What

- **`PARK_MAX_AGE` 3600 → 21600** (6h, matching attractions) → **~6× fewer park ISR writes**.
- **Decoupled the live poll from the shell cache** — and fixed a pre-existing staleness bug:
  - The `/api/parks` proxy (polled by `LiveParkData`/`LiveAttractionData` every 5 min) called the **cached** `getParkByGeoPath`, so the "live" wait times were actually up to `PARK_MAX_AGE` stale (1h today — and would have become 6h with the TTL bump).
  - New **`getParkByGeoPathFresh`** (no-store); the proxy now uses it → the poll reflects the backend's latest snapshot (upstream Redis/Cloudflare 5-min cache still collapses concurrent calls).
  - Both share `fetchParkByGeoPath`; 404→null still handled inside the `'use cache'` boundary.

So the shell gets cheaper (6h) **and** the live data gets *fresher* than before (truly no-store instead of 1h-cached).

## Safety

6h shell carries only structure + the day-stable schedule/weather seed (weather is client-refreshed via nowcast; park/ride status via LiveParkData). No stale open/closed shown to JS visitors.

#3 (on-demand revalidation — write once on real data change) is being discussed with the backend team separately.

https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr)_