### PR TITLE
fix(cls): reserve space for park "updating" indicator (recurring layout shift)

### DIFF
--- a/components/parks/live-park-data.tsx
+++ b/components/parks/live-park-data.tsx
@@ -120,13 +120,17 @@ export function LiveParkData({
         </Card>
       )}
 
-      {/* Subtle loading indicator during background refetch */}
-      {isFetching && !isError && (
-        <div className="text-muted-foreground mb-4 flex items-center gap-2 text-xs">
-          <Loader2 className="h-3 w-3 animate-spin" />
-          <span>{t('updating')}</span>
-        </div>
-      )}
+      {/* Subtle loading indicator during background refetch. Wrapped in a fixed-height slot that is
+          always present, so the indicator appearing/disappearing on every 5-min poll (and on the
+          immediate refetch-on-mount) no longer shifts the status + tabs below it (CLS). */}
+      <div className="mb-4 h-4">
+        {isFetching && !isError && (
+          <div className="text-muted-foreground flex items-center gap-2 text-xs">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            <span>{t('updating')}</span>
+          </div>
+        )}
+      </div>
 
       {/* Park Status Component — on mobile receives the tabs between WaitTime and Attractions */}
       <ParkStatus park={currentPark} variant="detailed" midSlot={tabsWithHash} />


### PR DESCRIPTION
## Why

Measured park-page CLS with a Playwright LayoutShift observer over 10 s (Lighthouse's short window missed it — it reported CLS 0.009 on a stable park). On Phantasialand (active weather warning) **CLS = 0.086**, from two sources:

1. **WeatherNowcastBanner** (~0.065) — `<Suspense fallback={null}>`; appears client-side when the *fresh* nowcast finds a warning the ~1 h-stale seed didn't have → pushes the whole page down. Only on parks with a new active warning (a real fresh-data-vs-layout tradeoff — discussed separately).
2. **"Updating…" indicator** (LiveParkData) — appears/disappears on the refetch-on-mount and every 5-min poll with no reserved space → recurring shift on *every* park view.

## What (this PR)

Fixes #2 — the recurring one: wrap the indicator in an always-present `mb-4 h-4` slot so it fades in/out without shifting the status + tabs below. Safe, zero behaviour change otherwise.

The weather-banner shift (#1) is a separate UX decision (reserve space / overlay toast / accept) — not in this PR.

## Verify

Re-run the Playwright observer on the preview vs prod; the recurring per-poll shift should be gone (typical no-warning park CLS → ~good).

https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr)_