### PR TITLE
perf(glossary): deterministic daily hero (consistent across nav + ~288× fewer writes)

### DIFF
--- a/components/glossary/glossary-background.tsx
+++ b/components/glossary/glossary-background.tsx
@@ -3,17 +3,24 @@ import { RandomHeroImage } from '@/components/layout/hero-background';
 import { HERO_IMAGES } from '@/lib/hero-images';
 
 /**
- * Pick the glossary background server-side (rotates every ~5 min via the data cache), exactly like
- * the homepage hero. This is what makes the image an LCP-friendly resource: passing `imageSrc` to
- * <RandomHeroImage> renders it in the SSR HTML with `priority` + `fetchPriority="high"` (next/image
- * then preloads the optimized rendition). The old client-random pick (no `imageSrc`) only chose the
- * image in a post-hydration effect with no priority, so the largest element didn't even start
- * loading until the JS had run — the cause of the multi-second glossary LCP.
+ * Pick the glossary background server-side. Server-rendering is what makes the image an LCP-friendly
+ * resource: passing `imageSrc` to <RandomHeroImage> renders it in the SSR HTML with `priority` +
+ * `fetchPriority="high"` (next/image then preloads the optimized rendition). The old client-random
+ * pick (no `imageSrc`) only chose the image in a post-hydration effect with no priority — the cause
+ * of the multi-second glossary LCP.
+ *
+ * The pick is DETERMINISTIC per UTC day (not random): every glossary page in a day resolves to the
+ * same image, so navigating between terms no longer swaps the hero. It also no longer re-randomises
+ * every 5 min — the old 5-min `'use cache'` pinned each glossary route to a 5-min ISR revalidate
+ * (pure write churn across all terms × locales). `'days'` rotates it once per day with ~288× fewer
+ * glossary writes.
  */
 async function pickGlossaryHero(): Promise<string> {
   'use cache';
-  cacheLife({ stale: 300, revalidate: 300, expire: 900 });
-  return HERO_IMAGES[Math.floor(Math.random() * HERO_IMAGES.length)];
+  cacheLife('days');
+  // Date.now() is captured at cache-fill time (allowed inside a 'use cache' boundary).
+  const dayIndex = Math.floor(Date.now() / 86_400_000);
+  return HERO_IMAGES[dayIndex % HERO_IMAGES.length];
 }
 
 /**


### PR DESCRIPTION
## Why

The glossary background was picked **randomly** with a 5-min `'use cache'` window. Two problems:

1. **ISR write churn:** the 5-min pick pinned every glossary route to a 5-min ISR revalidate — purely to re-randomise the hero — across all terms × 6 locales.
2. **New image on every navigation:** each glossary route froze its own random pick, so switching between term pages swapped the hero (the "neue beim Seitenwechsel" you noticed).

## What

`pickGlossaryHero` is now **deterministic per UTC day** (`cacheLife('days')`, `dayIndex % HERO_IMAGES.length`):

- All glossary pages resolve to the **same image** → no swap when navigating between terms.
- Rotates **once a day** (you confirmed daily is fine).
- Glossary pages revalidate **daily instead of every 5 min** → **~288× fewer glossary ISR writes**.
- Still server-rendered → the LCP fix from #132 is unchanged.

https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr)_