### PR TITLE
perf(images): lighter desktop background renditions (q90 → q75) to shorten cold-load flicker

### DIFF
--- a/lib/utils/image-loader.ts
+++ b/lib/utils/image-loader.ts
@@ -1,17 +1,20 @@
 import type { ImageLoaderProps } from 'next/image';
 
 /**
- * Shared next/image loader for full-bleed background images (homepage hero, park &
+ * Shared next/image loader for full-bleed background images (homepage hero, glossary, park &
  * ride pages). These always sit under gradient overlays + opacity-90 (and a ken-burns
  * transform on the hero), so mobile-width renditions (≤828px) get a lighter q60 where
  * the loss is imperceptible and the LCP byte savings matter most on slow networks
  * — the hero LCP image was ~109 KB at q75 / ~80 KB at q60 (w=828). Desktop/tablet
- * (>828px) stays at full q90 for crisp images. The 828px cutoff is the clean
- * mobile↔desktop boundary in `deviceSizes`.
+ * (>828px) uses q75 (next/image's own default): under the overlays + opacity-90 it is
+ * indistinguishable from q90 but ~30-40% lighter, so the heavy desktop rendition loads
+ * faster on a cold/uncached reload — which shortens the blur-placeholder→photo swap that
+ * otherwise reads as a flicker. The 828px cutoff is the clean mobile↔desktop boundary in
+ * `deviceSizes`.
  *
  * Quality values must be listed in next.config `images.qualities`.
  */
 export function backgroundImageLoader({ src, width }: ImageLoaderProps): string {
-  const quality = width <= 828 ? 60 : 90;
+  const quality = width <= 828 ? 60 : 75;
   return `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${quality}`;
 }


### PR DESCRIPTION
## Why

You noticed a flicker on the glossary index that only happens on a **cold reload** (final image not yet cached). Reproduced with headless Chromium: only **one** hero image is requested (no wrong second photo) — what you see is next/image's **blur placeholder → photo** swap. It's drawn out because the desktop rendition is heavy (**q90**), so on a cold load the placeholder phase is long; warm/cached = instant = no flicker.

A smooth fade-in would mask it but **hurts LCP** (the hero is the LCP element; animating it on first paint is a known LCP anti-pattern — already noted in the code). So the LCP-safe lever is to make the image **lighter** → shorter placeholder phase.

## What

`backgroundImageLoader`: desktop renditions (>828px) **q90 → q75** (next/image's own default). Under the gradient overlays + `opacity-90` it's visually indistinguishable but ~30-40% lighter, so the cold-load image arrives faster and the blur→photo swap is much shorter. Mobile (≤828px) stays q60. `75` is already in `images.qualities`.

Applies to all full-bleed backgrounds (homepage hero, glossary, park/ride) — all decorative, all benefit.

## Verify

Cold-reload the glossary/home/park on the preview (hard refresh / disable cache): the placeholder phase should be noticeably shorter. Also a small LCP/bandwidth win everywhere.

https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr)_