### PR TITLE
perf(home): daily hero TTL (homepage shell no longer revalidates hourly)

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -101,9 +101,12 @@ export async function generateMetadata({ params }: HomePageProps): Promise<Metad
 // hero server-rendered for LCP.
 async function pickHeroImage(): Promise<string> {
   'use cache';
-  // Hourly rotation is plenty for a decorative hero. A 5-min window made this the MIN cacheLife in
-  // the homepage shell, pinning the (6-locale) homepage to a 5-min ISR-write cadence for nothing.
-  cacheLife('hours');
+  // The homepage shell carries no live data anymore — the global stats and the per-continent "open
+  // now" counts both load client-side (useGlobalStats / useGeoLiveStats), so the structure-only shell
+  // never needs to be fresh. That leaves this hero pick as the shell's only revalidation pin, so a
+  // daily window drops the (6-locale) homepage from an hourly to a daily ISR-write cadence. Daily
+  // rotation is plenty for a decorative hero (same call we made for the glossary hero).
+  cacheLife('days');
   return HERO_IMAGES[Math.floor(Math.random() * HERO_IMAGES.length)];
 }
 


### PR DESCRIPTION
## Why

While debugging ISR write volume, the homepage shell was found to still revalidate **hourly** even though it no longer carries any live data — the global stats and per-continent "open now" counts already load client-side (`useGlobalStats` / `useGeoLiveStats`). The only remaining revalidation pin was `pickHeroImage`'s `'hours'` window.

## What

`pickHeroImage`: `cacheLife('hours')` → `cacheLife('days')`. The structure-only homepage shell now revalidates daily instead of hourly (×6 locales), and the decorative hero rotates once a day — the same call already made for the glossary hero (#136).

Small, self-contained write reduction. Part of a wider ISR-write investigation (the dominant driver — park pages being served `no-store` / not edge-cached — is being tracked separately).

https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr)_