### PR TITLE
feat(nav): top progress bar during client-side navigation

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -13,6 +13,7 @@ import Script from 'next/script';
 import { AnalyticsIdentify } from '@/components/common/analytics-identify';
 import { WebVitalsReporter } from '@/components/analytics/web-vitals-reporter';
 import { ScrollToTop } from '@/components/common/scroll-to-top';
+import { NavigationProgress } from '@/components/layout/navigation-progress';
 import {
   OrganizationStructuredData,
   WebSiteStructuredData,
@@ -176,6 +177,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
                   which are dynamic under Cache Components — stream them as Suspense holes so the
                   page shell stays statically prerenderable. */}
               <Suspense fallback={null}>
+                <NavigationProgress />
                 <ScrollToTop />
                 <AnalyticsIdentify locale={locale} />
                 <WebVitalsReporter />

--- a/components/layout/navigation-progress.tsx
+++ b/components/layout/navigation-progress.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+
+/**
+ * Thin top-of-viewport progress bar shown during client-side navigations — so a click feels
+ * acknowledged instantly (the way GitHub/YouTube do it), even while the next route is still
+ * being fetched/streamed.
+ *
+ * No dependency: it's driven by CSS width/opacity transitions. It starts on a same-origin link
+ * click or a `history.pushState` (router navigation), trickles toward ~90 %, and snaps to 100 %
+ * (then fades) when the new route's `pathname`/`searchParams` land. A safety timeout finishes it
+ * if a navigation never resolves to a route change.
+ */
+export function NavigationProgress() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [progress, setProgress] = useState(0);
+  const [fading, setFading] = useState(false);
+
+  const trickle = useRef<ReturnType<typeof setInterval> | null>(null);
+  const safety = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fadeOut = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const active = useRef(false);
+  // Lets `start` schedule `finish` without a useCallback dependency cycle.
+  const finishRef = useRef<() => void>(() => {});
+
+  const clearLoadTimers = () => {
+    if (trickle.current) clearInterval(trickle.current);
+    if (safety.current) clearTimeout(safety.current);
+    trickle.current = null;
+    safety.current = null;
+  };
+
+  const finish = useCallback(() => {
+    if (!active.current) return;
+    active.current = false;
+    clearLoadTimers();
+    setProgress(100);
+    setFading(true);
+    fadeOut.current = setTimeout(() => {
+      setProgress(0);
+      setFading(false);
+    }, 240);
+  }, []);
+  finishRef.current = finish;
+
+  const start = useCallback(() => {
+    if (active.current) return;
+    active.current = true;
+    if (fadeOut.current) clearTimeout(fadeOut.current);
+    setFading(false);
+    setProgress(8);
+    // Ease toward 90 % so the bar keeps creeping while the route loads.
+    trickle.current = setInterval(() => {
+      setProgress((p) => (p >= 90 ? 90 : p + Math.max(0.4, (90 - p) * 0.1)));
+    }, 300);
+    // Never leave it stuck if a navigation doesn't end in a route change.
+    safety.current = setTimeout(() => finishRef.current(), 10_000);
+  }, []);
+
+  // START — same-origin link clicks + programmatic navigations (router.push patches pushState).
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        return;
+      }
+      const anchor = (e.target as HTMLElement | null)?.closest('a');
+      if (!anchor) return;
+      const target = anchor.getAttribute('target');
+      if ((target && target !== '_self') || anchor.hasAttribute('download')) return;
+      const href = anchor.getAttribute('href');
+      if (!href || href.startsWith('#')) return;
+      let url: URL;
+      try {
+        url = new URL(anchor.href, window.location.href);
+      } catch {
+        return;
+      }
+      if (url.origin !== window.location.origin) return;
+      // Same page (or pure hash change) — no navigation, no bar.
+      if (url.pathname === window.location.pathname && url.search === window.location.search) return;
+      start();
+    };
+
+    const originalPushState = window.history.pushState;
+    window.history.pushState = function patchedPushState(
+      this: History,
+      ...args: Parameters<History['pushState']>
+    ) {
+      const dest = args[2];
+      if (dest != null) {
+        try {
+          const url = new URL(dest.toString(), window.location.href);
+          if (
+            url.pathname !== window.location.pathname ||
+            url.search !== window.location.search
+          ) {
+            start();
+          }
+        } catch {
+          /* ignore malformed URLs */
+        }
+      }
+      return originalPushState.apply(this, args);
+    };
+
+    document.addEventListener('click', onClick, true);
+    return () => {
+      window.history.pushState = originalPushState;
+      document.removeEventListener('click', onClick, true);
+    };
+  }, [start]);
+
+  // END — the rendered route changed, so the navigation is done.
+  const isFirstRender = useRef(true);
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    finish();
+  }, [pathname, searchParams, finish]);
+
+  useEffect(
+    () => () => {
+      clearLoadTimers();
+      if (fadeOut.current) clearTimeout(fadeOut.current);
+    },
+    []
+  );
+
+  if (progress === 0 && !fading) return null;
+
+  return (
+    <div aria-hidden className="pointer-events-none fixed inset-x-0 top-0 z-[9999] h-0.5">
+      <div
+        className="bg-park-primary h-full transition-[width,opacity] ease-out"
+        style={{
+          width: `${progress}%`,
+          opacity: fading ? 0 : 1,
+          transitionDuration: fading ? '220ms' : '300ms',
+          boxShadow: '0 0 10px 1px var(--park-primary)',
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## What

A thin top-of-viewport progress bar (park-primary, ~2px) that appears during **client-side navigation**, so a click feels acknowledged instantly — even while the next route is still being fetched/streamed (GitHub/YouTube style).

- **No dependency** — pure CSS width/opacity transitions.
- Starts on a same-origin link click (capture-phase listener, beats Next's Link handler) or a `history.pushState` (programmatic `router.push`); trickles toward ~90%; snaps to 100% + fades when the new route's `pathname`/`searchParams` land.
- 10s safety timeout so it never sticks; ignores modifier-clicks, external links, downloads, `target=_blank`, same-page/hash.
- Rendered in the layout's existing client Suspense hole → the static shell is unaffected.

## Verified
- Build + tsc + eslint clean.
- Headless Chromium: bar appears on a real park-link click ✅.

https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr)_