### PR TITLE
perf(isr): park/attraction shells revalidate daily + no stale baked values

### DIFF
--- a/app/[locale]/howto/_mock-components.tsx
+++ b/app/[locale]/howto/_mock-components.tsx
@@ -326,7 +326,7 @@ export async function MockParkHeader({ locale }: { locale: MockLocale }) {
         <div className="grid gap-4 md:grid-cols-2">
           <ParkTimeInfo
             timezone="Europe/Berlin"
-            todaySchedule={todaySchedule}
+            schedule={[todaySchedule]}
             status="OPERATING"
             className="border-primary/10"
           />

--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from 'react';
-import { format, startOfMonth, endOfMonth, addMonths, addDays, min } from 'date-fns';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { generateAlternateLanguages, locales } from '@/i18n/config';
 import { buildOpenGraphMetadata } from '@/lib/utils/metadata';
@@ -9,7 +8,6 @@ import { MapPin } from 'lucide-react';
 import { Separator } from '@/components/ui/separator';
 import { getParkByGeoPath, getPopularParks } from '@/lib/api/parks';
 import { getGeoStructure } from '@/lib/api/discovery';
-import { getServerNowMs } from '@/lib/utils/server-time';
 import { catchNonFatal } from '@/lib/api/client';
 import { getGlossaryTerms, GLOSSARY_SEGMENTS } from '@/lib/glossary/translations';
 import type { Locale } from '@/i18n/config';
@@ -208,19 +206,10 @@ export default async function ParkPage({ params }: ParkPageProps) {
     notFound();
   }
 
-  // Cached "now" (cacheComponents-safe) — drives the calendar range + today lookups below.
-  const nowMs = await getServerNowMs();
-  const now = new Date(nowMs);
-
-  // Calendar date range: current month + next 2 months (API limit: 90 days max — cap to avoid 400).
-  // The calendar feeds only the below-the-fold best-days + FAQ sections, which now load CLIENT-side
-  // (useParkBestDaysCalendar → the `/api/parks/.../calendar` CDN-cached route). We only compute the
-  // from/to window here (cheap, from the cached "now") and hand it to those client components — the
-  // bulky ~2.25 MB fetch never touches the static shell, so it can't poison the prerender.
-  const calendarFrom = startOfMonth(now);
-  const calendarTo = min([endOfMonth(addMonths(now, 2)), addDays(calendarFrom, 89)]);
-  const calendarFromStr = format(calendarFrom, 'yyyy-MM-dd');
-  const calendarToStr = format(calendarTo, 'yyyy-MM-dd');
+  // The calendar window (current month + next 2) that feeds the below-the-fold best-days + FAQ
+  // sections is now derived CLIENT-side (useCalendarWindow) inside those client components, so the
+  // static shell reads no clock at all — keeping it time-independent for the 1-day TTL. The bulky
+  // calendar fetch itself was already client-side (useParkBestDaysCalendar → the CDN-cached route).
 
   // Glossary terms for the (client) FAQ section. This is a small static-content lookup (no fetch,
   // no clock) so it's safe to load in the static shell; the client FAQ tree highlights terms from
@@ -261,18 +250,9 @@ export default async function ParkPage({ params }: ParkPageProps) {
   const countryName = translateCountry(tGeo, country, locale, park.country ?? undefined);
   const cityName = park.city || city.charAt(0).toUpperCase() + city.slice(1).replace(/-/g, ' ');
 
-  // Get today's schedule - filter by date in park's timezone
-  const getTodaySchedule = () => {
-    if (!park.schedule || park.schedule.length === 0) return null;
-
-    // Get today's date in the park's timezone
-    const todayInParkTz = now.toLocaleDateString('en-CA', {
-      timeZone: park.timezone,
-    }); // Format: YYYY-MM-DD
-
-    return park.schedule.find((s) => s.date === todayInParkTz) || park.schedule[0];
-  };
-  const todaySchedule = getTodaySchedule();
+  // Today's schedule is picked CLIENT-side inside <ParkTimeInfo> (from the browser clock in the
+  // park's timezone) — the full day-stable park.schedule is handed down instead of a server-derived
+  // "today" entry, so the shell never reads the server clock.
   const parkName = stripNewPrefix(park.name);
 
   // Construct breadcrumbs using utility
@@ -309,7 +289,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
         />
         <BreadcrumbStructuredData breadcrumbs={breadcrumbs} locale={locale} />
         {park.shows && park.shows.length > 0 && (
-          <ShowsStructuredData shows={park.shows} park={park} date={format(now, 'yyyy-MM-dd')} />
+          <ShowsStructuredData shows={park.shows} park={park} />
         )}
         <FAQStructuredData park={park} locale={locale} />
 
@@ -363,7 +343,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
             <Suspense fallback={null}>
               <ParkTimeInfo
                 timezone={park.timezone}
-                todaySchedule={todaySchedule}
+                schedule={park.schedule}
                 nextSchedule={park.nextSchedule}
                 status={park.status}
                 hasOperatingSchedule={park.hasOperatingSchedule}
@@ -402,8 +382,6 @@ export default async function ParkPage({ params }: ParkPageProps) {
                 country={country}
                 city={city}
                 parkSlug={parkSlug}
-                from={calendarFromStr}
-                to={calendarToStr}
                 timezone={park.timezone}
                 hasOperatingSchedule={park.hasOperatingSchedule}
                 parkName={parkName}
@@ -444,9 +422,6 @@ export default async function ParkPage({ params }: ParkPageProps) {
             country={country}
             city={city}
             parkSlug={parkSlug}
-            from={calendarFromStr}
-            to={calendarToStr}
-            nowMs={nowMs}
             glossaryTerms={faqGlossaryTerms}
             glossarySegment={glossarySegment}
           />

--- a/app/api/discovery/[...path]/route.ts
+++ b/app/api/discovery/[...path]/route.ts
@@ -12,7 +12,11 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.park.fan';
  * ISR shell carries no volatile data (and can be cached for a day). The live open/closed status,
  * crowd level and wait times are layered on the client via `useRegionParks`, which polls this
  * endpoint — exactly the SSR-static + client-live split already used for the park page, favorites
- * and nearby. Always no-store here so the client overlay reflects the backend's latest snapshot.
+ * and nearby. The upstream fetch stays no-store (always the backend's latest), but the RESPONSE
+ * gets a small shared CDN window (s-maxage=60) so concurrent hub polls collapse onto one backend
+ * call instead of hitting it per visitor — the client polls every 5 min anyway, so a ≤60 s CDN
+ * window doesn't meaningfully stale the overlay. (Requires a matching exemption in next.config,
+ * placed AFTER the blanket `/api → no-store` rule, or that rule overrides this header.)
  */
 export async function GET(
   _request: NextRequest,
@@ -38,7 +42,7 @@ export async function GET(
     const data = await response.json();
     return NextResponse.json(data, {
       status: response.status,
-      headers: { 'Cache-Control': 'no-store, must-revalidate' },
+      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120' },
     });
   } catch (error) {
     console.error('[Discovery proxy] Error:', error);

--- a/components/faq/park-faq-section.tsx
+++ b/components/faq/park-faq-section.tsx
@@ -26,21 +26,16 @@ import type { Locale } from '@/i18n/config';
 import { analyzeBestDays } from '@/lib/utils/crowd-analysis';
 import { buildParkFaqItems, getParkArticleForms, type ParkFaqIconName } from '@/lib/faq/park-faq';
 import { useParkBestDaysCalendar } from '@/lib/hooks/use-park-best-days-calendar';
+import { getCalendarWindow } from '@/lib/hooks/use-calendar-window';
+import { useBrowserNow } from '@/lib/hooks/use-mounted';
 
 interface ParkFAQSectionProps {
   park: ParkWithAttractions;
   locale: string;
-  /** Calendar window (current month + next 2) computed in the server shell — used for Q7. */
   continent: string;
   country: string;
   city: string;
   parkSlug: string;
-  from: string;
-  to: string;
-  /** Day-stable "now" (epoch ms) computed in the server shell via getServerNowMs(). Passed in
-   *  (rather than read from Date.now() here) so the base Q0–Q6 stay in the static prerender for
-   *  SEO without reading the clock inside a Client Component during the prerender. */
-  nowMs: number;
   /** Glossary terms + URL segment, loaded in the server shell, so the client tree can highlight
    *  terms without awaiting them. */
   glossaryTerms: GlossaryInjectTerm[];
@@ -81,14 +76,21 @@ export function ParkFAQSection({
   country,
   city,
   parkSlug,
-  from,
-  to,
-  nowMs,
   glossaryTerms,
   glossarySegment,
 }: ParkFAQSectionProps) {
   const t = useTranslations('seo.faq');
   const tGeo = useTranslations('geo');
+
+  // "now" comes from the browser clock (null until mount): during the SSR/static prerender the
+  // time-dependent Q1 (today's hours) renders an evergreen answer and the shell never reads the
+  // clock; the real value fills in after hydration. Day-granular precision is all Q1/Q7 need.
+  const browserNow = useBrowserNow(null);
+  const nowMs = browserNow ? browserNow.getTime() : null;
+
+  // Calendar window derived from the browser clock (client-only) — keeps the park shell
+  // time-independent for the 1-day TTL.
+  const { from, to } = getCalendarWindow(browserNow);
 
   // Calendar feeds only Q7 (least-crowded days); it streams in client-side. Until it lands,
   // the base Q0–Q6 render immediately — same graceful behavior as the old streamed fallback.
@@ -118,8 +120,8 @@ export function ParkFAQSection({
     </CrowdCalendarFaqLink>
   );
 
-  // Q7: Least crowded (requires calendar data, uses rich text)
-  if (calendarData) {
+  // Q7: Least crowded (requires calendar data + a client-derived "now", uses rich text)
+  if (calendarData && nowMs != null) {
     const analysis = analyzeBestDays(calendarData.days, nowMs, calendarData.meta.timezone);
     if (analysis.totalDays >= 7) {
       const conjunctions: Record<string, string> = {

--- a/components/parks/attraction-history-grid.tsx
+++ b/components/parks/attraction-history-grid.tsx
@@ -1,11 +1,13 @@
-import { getLocale, getTranslations } from 'next-intl/server';
+'use client';
+
+import { useLocale, useTranslations } from 'next-intl';
 import { format, eachDayOfInterval } from 'date-fns';
 import { de, enUS, es, fr, it, nl, type Locale } from 'date-fns/locale';
 import { Ban, PartyPopper, Backpack, Calendar } from 'lucide-react';
 import type { AttractionHistoryDay, ScheduleItem } from '@/lib/api/types';
 import { Card } from '@/components/ui/card';
 import { AttractionHistoryDay as HistoryDay, DayDataProps } from './attraction-history-day';
-import { getServerNowMs } from '@/lib/utils/server-time';
+import { useBrowserNow } from '@/lib/hooks/use-mounted';
 
 interface AttractionHistoryGridProps {
   attraction: {
@@ -19,83 +21,15 @@ interface GridDayData extends DayDataProps {
   date: Date;
 }
 
-export async function AttractionHistoryGrid({ attraction }: AttractionHistoryGridProps) {
-  const locale = await getLocale();
-  const t = await getTranslations('attractions');
+export function AttractionHistoryGrid({ attraction }: AttractionHistoryGridProps) {
+  const locale = useLocale();
+  const t = useTranslations('attractions');
+  // "today" is derived from the browser clock (null until mount) so the static shell never reads
+  // the server clock — previously getServerNowMs() here pinned the attraction shell's revalidate.
+  const browserNow = useBrowserNow(null);
 
   const dateLocaleMap: Record<string, Locale> = { de, en: enUS, fr, it, nl, es };
   const dateLocale: Locale = dateLocaleMap[locale] ?? enUS;
-
-  // Calculate date range: today to 30 days ago. Cached "now" (cacheComponents-safe).
-  const today = new Date(await getServerNowMs());
-  today.setHours(0, 0, 0, 0);
-  const thirtyDaysAgo = new Date(today);
-  thirtyDaysAgo.setDate(today.getDate() - 30);
-  const dateRange = { start: thirtyDaysAgo, end: today };
-
-  // Create a map of history data by date for quick lookup
-  const historyMap = new Map<string, AttractionHistoryDay>();
-  if (attraction.history) {
-    attraction.history.forEach((day) => {
-      historyMap.set(day.date, day);
-    });
-  }
-
-  // Create a map of schedule data by date for quick lookup
-  const scheduleMap = new Map<string, ScheduleItem>();
-  if (attraction.schedule) {
-    attraction.schedule.forEach((item) => {
-      scheduleMap.set(item.date, item);
-    });
-  }
-
-  // Generate all days in the range and group into weeks
-  const allDays = eachDayOfInterval(dateRange);
-
-  // Create day data with history and schedule lookup
-  const days: GridDayData[] = allDays.map((date) => {
-    const dateStr = format(date, 'yyyy-MM-dd');
-    const historyData = historyMap.get(dateStr);
-    const scheduleData = scheduleMap.get(dateStr);
-
-    const hasHistory = historyData && historyData.hourlyP90 && historyData.hourlyP90.length > 1;
-    const isToday =
-      date.getFullYear() === today.getFullYear() &&
-      date.getMonth() === today.getMonth() &&
-      date.getDate() === today.getDate();
-
-    let attractionStatus: GridDayData['attractionStatus'] = 'UNKNOWN';
-
-    if (hasHistory) {
-      attractionStatus = 'OPEN';
-    } else {
-      // No history data
-      if (scheduleData) {
-        if (scheduleData.scheduleType !== 'OPERATING') {
-          attractionStatus = 'PARK_CLOSED';
-        } else {
-          // Park is open, but no history
-          if (isToday) {
-            attractionStatus = 'NOT_YET_OPEN';
-          } else if (date < today) {
-            attractionStatus = 'CLOSED_RIDE';
-          }
-        }
-      }
-    }
-
-    return {
-      date,
-      dateStr,
-      dayOfWeek: format(date, 'EEE', { locale: dateLocale }),
-      dayOfMonth: format(date, 'd'),
-      month: format(date, 'MMM', { locale: dateLocale }),
-      historyData,
-      scheduleData,
-      attractionStatus,
-      isToday,
-    };
-  });
 
   if (!attraction.history || attraction.history.length === 0) {
     return (
@@ -107,6 +41,78 @@ export async function AttractionHistoryGrid({ attraction }: AttractionHistoryGri
       </Card>
     );
   }
+
+  // Before mount we have no "today" yet — render the static frame (heading + legend) but defer the
+  // day grid so SSR and the first client render match (no hydration mismatch). The grid fills in
+  // right after hydration.
+  const today = browserNow ? new Date(browserNow) : null;
+  if (today) today.setHours(0, 0, 0, 0);
+
+  // Calculate date range: today to 30 days ago.
+  const days: GridDayData[] = (() => {
+    if (!today) return [];
+    const thirtyDaysAgo = new Date(today);
+    thirtyDaysAgo.setDate(today.getDate() - 30);
+    const dateRange = { start: thirtyDaysAgo, end: today };
+
+    // Create a map of history data by date for quick lookup
+    const historyMap = new Map<string, AttractionHistoryDay>();
+    attraction.history?.forEach((day) => {
+      historyMap.set(day.date, day);
+    });
+
+    // Create a map of schedule data by date for quick lookup
+    const scheduleMap = new Map<string, ScheduleItem>();
+    attraction.schedule?.forEach((item) => {
+      scheduleMap.set(item.date, item);
+    });
+
+    const allDays = eachDayOfInterval(dateRange);
+
+    return allDays.map((date) => {
+      const dateStr = format(date, 'yyyy-MM-dd');
+      const historyData = historyMap.get(dateStr);
+      const scheduleData = scheduleMap.get(dateStr);
+
+      const hasHistory = historyData && historyData.hourlyP90 && historyData.hourlyP90.length > 1;
+      const isToday =
+        date.getFullYear() === today.getFullYear() &&
+        date.getMonth() === today.getMonth() &&
+        date.getDate() === today.getDate();
+
+      let attractionStatus: GridDayData['attractionStatus'] = 'UNKNOWN';
+
+      if (hasHistory) {
+        attractionStatus = 'OPEN';
+      } else {
+        // No history data
+        if (scheduleData) {
+          if (scheduleData.scheduleType !== 'OPERATING') {
+            attractionStatus = 'PARK_CLOSED';
+          } else {
+            // Park is open, but no history
+            if (isToday) {
+              attractionStatus = 'NOT_YET_OPEN';
+            } else if (date < today) {
+              attractionStatus = 'CLOSED_RIDE';
+            }
+          }
+        }
+      }
+
+      return {
+        date,
+        dateStr,
+        dayOfWeek: format(date, 'EEE', { locale: dateLocale }),
+        dayOfMonth: format(date, 'd'),
+        month: format(date, 'MMM', { locale: dateLocale }),
+        historyData,
+        scheduleData,
+        attractionStatus,
+        isToday,
+      };
+    });
+  })();
 
   return (
     <Card className="relative p-4 md:p-6">

--- a/components/parks/daily-wait-time-chart-client.tsx
+++ b/components/parks/daily-wait-time-chart-client.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useMounted } from '@/lib/hooks/use-mounted';
+import type {
+  AttractionHistoryDay,
+  ForecastItem,
+  ScheduleItem,
+  BestVisitSlot,
+} from '@/lib/api/types';
+import { DailyWaitTimeChart, type DailyWaitTimeChartData } from './daily-wait-time-chart';
+
+interface DailyWaitTimeChartClientProps {
+  history?: AttractionHistoryDay[];
+  hourlyForecast?: ForecastItem[];
+  timezone: string;
+  schedule?: ScheduleItem[];
+  bestVisitTimes?: BestVisitSlot[] | null;
+  translations: DailyWaitTimeChartData['translations'];
+}
+
+/** Returns the time string (HH:mm) in the given IANA timezone from an ISO string, rounded to 15m. */
+function getTimeSlotInTimezone(isoStr: string, timezone: string): string {
+  const date = new Date(isoStr);
+  const parts = new Intl.DateTimeFormat('en', {
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: false,
+    hourCycle: 'h23',
+    timeZone: timezone,
+  }).formatToParts(date);
+  const hour = parts.find((p) => p.type === 'hour')?.value || '00';
+  const minute = parts.find((p) => p.type === 'minute')?.value || '00';
+  return `${hour.padStart(2, '0')}:${minute.padStart(2, '0')}`;
+}
+
+/** Today's date as YYYY-MM-DD in the given IANA timezone. */
+function getTodayInTimezone(timezone: string): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: timezone }).format(new Date());
+}
+
+/**
+ * Builds the daily chart's 15-minute slots for the given "today" (park-tz date string).
+ *
+ * Moved verbatim off the former DailyWaitTimeChartServer so the "today" selection no longer reads
+ * the server clock (getServerToday) in the attraction static shell — that read was the #1 ISR-write
+ * driver, pinning the shell to a 1h revalidate. The data itself (history/forecast/schedule) is
+ * still passed down from the server shell (good for SEO/first paint); only the day pick is client.
+ */
+function buildChartData(
+  todayStr: string,
+  {
+    history,
+    hourlyForecast,
+    timezone,
+    schedule,
+    bestVisitTimes,
+    translations,
+  }: DailyWaitTimeChartClientProps
+): DailyWaitTimeChartData | null {
+  // History P90 map: "HH:mm" → value
+  const todayHistory = history?.find((h) => h.date === todayStr);
+  const historyMap = new Map<string, number>();
+  todayHistory?.hourlyP90?.forEach((p) => {
+    historyMap.set(p.hour, p.value);
+  });
+
+  // Forecast map: "HH:mm" (park tz) → waitTime, first entry wins per slot
+  const forecastMap = new Map<string, number>();
+  hourlyForecast?.forEach((f) => {
+    const slot = getTimeSlotInTimezone(f.predictedTime, timezone);
+    if (!forecastMap.has(slot)) forecastMap.set(slot, f.predictedWaitTime);
+  });
+
+  // Time range: schedule-based or derived from data points
+  const todaySchedule = schedule?.find((s) => s.date === todayStr);
+  let startTime = '09:00';
+  let endTime = '19:00';
+
+  if (todaySchedule) {
+    if (todaySchedule.openingTime) {
+      const date = new Date(todaySchedule.openingTime);
+      const h = new Intl.DateTimeFormat('en', {
+        hour: 'numeric',
+        hour12: false,
+        timeZone: timezone,
+      }).format(date);
+      const m = new Intl.DateTimeFormat('en', { minute: 'numeric', timeZone: timezone }).format(
+        date
+      );
+      // Round down to nearest 15m
+      const roundedM = Math.floor(parseInt(m, 10) / 15) * 15;
+      startTime = `${h.padStart(2, '0')}:${roundedM.toString().padStart(2, '0')}`;
+    }
+    if (todaySchedule.closingTime) {
+      const date = new Date(todaySchedule.closingTime);
+      const h = new Intl.DateTimeFormat('en', {
+        hour: 'numeric',
+        hour12: false,
+        timeZone: timezone,
+      }).format(date);
+      const m = new Intl.DateTimeFormat('en', { minute: 'numeric', timeZone: timezone }).format(
+        date
+      );
+      // Round up to nearest 15m
+      const roundedM = Math.ceil(parseInt(m, 10) / 15) * 15;
+      let finalH = parseInt(h, 10);
+      let finalM = roundedM;
+      if (finalM === 60) {
+        finalH = (finalH + 1) % 24;
+        finalM = 0;
+      }
+      endTime = `${finalH.toString().padStart(2, '0')}:${finalM.toString().padStart(2, '0')}`;
+    }
+  } else {
+    const allSlots = [...historyMap.keys(), ...forecastMap.keys()].sort();
+    if (allSlots.length > 0) {
+      startTime = allSlots[0];
+      endTime = allSlots[allSlots.length - 1];
+    }
+  }
+
+  // Filter maps to ensure no data outside operating hours
+  for (const time of historyMap.keys()) {
+    if (time < startTime || time > endTime) historyMap.delete(time);
+  }
+  for (const time of forecastMap.keys()) {
+    if (time < startTime || time > endTime) forecastMap.delete(time);
+  }
+
+  // Start at the first actual history record — forecasts may contain stale past-hour
+  // entries from Redis cache, so only history determines the real data start.
+  const historyKeys = [...historyMap.keys()].sort();
+  if (historyKeys.length > 0 && historyKeys[0] > startTime) {
+    startTime = historyKeys[0];
+  }
+
+  // Track last real data point to trim trailing empty slots later
+  const lastHistoryTime = historyKeys.length > 0 ? historyKeys[historyKeys.length - 1] : null;
+  const forecastKeys = [...forecastMap.keys()].sort();
+  const lastForecastTime = forecastKeys.length > 0 ? forecastKeys[forecastKeys.length - 1] : null;
+  const lastActualTime =
+    [lastHistoryTime, lastForecastTime]
+      .filter((t): t is string => t !== null)
+      .sort()
+      .pop() ?? null;
+
+  // Build 15-minute slots
+  const slots: DailyWaitTimeChartData['slots'] = [];
+  const [startH, startM] = startTime.split(':').map(Number);
+  const [endH, endM] = endTime.split(':').map(Number);
+
+  let curH = startH;
+  let curM = startM;
+
+  while (curH < endH || (curH === endH && curM <= endM)) {
+    const time = `${curH.toString().padStart(2, '0')}:${curM.toString().padStart(2, '0')}`;
+    slots.push({
+      time,
+      historyValue: historyMap.get(time) ?? null,
+      forecastValue: forecastMap.get(time) ?? null,
+    });
+
+    curM += 15;
+    if (curM >= 60) {
+      curM = 0;
+      curH++;
+    }
+  }
+
+  // Trim trailing slots past last actual data point (schedule may extend beyond predictions)
+  if (lastActualTime) {
+    while (slots.length > 0 && slots[slots.length - 1].time > lastActualTime) {
+      slots.pop();
+    }
+  }
+
+  // Fill null history slots using carry-forward from last known value.
+  // This avoids fake sloping lines between two real data points.
+  for (let i = 0; i < slots.length; i++) {
+    if (slots[i].historyValue !== null) continue;
+    const prev = i - 1;
+    if (prev >= 0 && slots[prev].historyValue !== null) {
+      slots[i].historyValue = slots[prev].historyValue;
+    }
+    // Leading nulls (before first data point) remain null — park not open yet
+  }
+
+  // Skip render if there's no data at all
+  if (slots.every((s) => s.historyValue === null && s.forecastValue === null)) return null;
+
+  // Convert bestVisitTimes ISO timestamps → "HH:mm" in park timezone
+  const bestSlots = bestVisitTimes
+    ?.map((s) => ({
+      time: getTimeSlotInTimezone(s.time, timezone),
+      rating: s.rating,
+    }))
+    .filter((s) => s.time >= startTime && s.time <= endTime);
+
+  return {
+    slots,
+    timezone,
+    bestSlots: bestSlots?.length ? bestSlots : undefined,
+    translations,
+  };
+}
+
+export function DailyWaitTimeChartClient(props: DailyWaitTimeChartClientProps) {
+  const mounted = useMounted();
+
+  // Derive "today" (park tz) on the client; before mount render nothing so SSR and the first client
+  // render match (no hydration mismatch) and the static shell never reads the clock.
+  const data = useMemo(() => {
+    if (!mounted) return null;
+    const todayStr = getTodayInTimezone(props.timezone);
+    return buildChartData(todayStr, props);
+    // props is stable per render from the server shell; rebuild only on mount/tz change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mounted, props.timezone]);
+
+  if (!data) return null;
+  return <DailyWaitTimeChart {...data} />;
+}

--- a/components/parks/daily-wait-time-chart-server.tsx
+++ b/components/parks/daily-wait-time-chart-server.tsx
@@ -5,9 +5,7 @@ import type {
   ScheduleItem,
   BestVisitSlot,
 } from '@/lib/api/types';
-import { Suspense } from 'react';
-import { DailyWaitTimeChart, type DailyWaitTimeChartData } from './daily-wait-time-chart';
-import { getServerToday } from '@/lib/utils/server-time';
+import { DailyWaitTimeChartClient } from './daily-wait-time-chart-client';
 
 interface DailyWaitTimeChartServerProps {
   history?: AttractionHistoryDay[];
@@ -17,21 +15,14 @@ interface DailyWaitTimeChartServerProps {
   bestVisitTimes?: BestVisitSlot[] | null;
 }
 
-/** Returns the time string (HH:mm) in the given IANA timezone from an ISO string, rounded to 15m. */
-function getTimeSlotInTimezone(isoStr: string, timezone: string): string {
-  const date = new Date(isoStr);
-  const parts = new Intl.DateTimeFormat('en', {
-    hour: 'numeric',
-    minute: 'numeric',
-    hour12: false,
-    hourCycle: 'h23',
-    timeZone: timezone,
-  }).formatToParts(date);
-  const hour = parts.find((p) => p.type === 'hour')?.value || '00';
-  const minute = parts.find((p) => p.type === 'minute')?.value || '00';
-  return `${hour.padStart(2, '0')}:${minute.padStart(2, '0')}`;
-}
-
+/**
+ * Server shell for the daily wait-time chart: it only loads the (locale-stable) translations and
+ * hands the RAW history/forecast/schedule down to the client. The "today" pick and slot-building
+ * happen client-side (DailyWaitTimeChartClient) — previously this component read getServerToday()
+ * to select today's data, which pinned the attraction static shell to a 1h revalidate (the #1
+ * ISR-write driver). With no clock read here the shell is time-independent (1-day TTL); the data
+ * still originates server-side so it stays available for SEO/first paint.
+ */
 export async function DailyWaitTimeChartServer({
   history,
   hourlyForecast,
@@ -41,169 +32,23 @@ export async function DailyWaitTimeChartServer({
 }: DailyWaitTimeChartServerProps) {
   const t = await getTranslations('attractions.todayChart');
 
-  // Cached today-in-tz (cacheComponents-safe); the chart is a daily aggregate.
-  const todayStr = await getServerToday(timezone);
-
-  // History P90 map: "HH:mm" → value
-  const todayHistory = history?.find((h) => h.date === todayStr);
-  const historyMap = new Map<string, number>();
-  todayHistory?.hourlyP90?.forEach((p) => {
-    historyMap.set(p.hour, p.value);
-  });
-
-  // Forecast map: "HH:mm" (park tz) → waitTime, first entry wins per slot
-  const forecastMap = new Map<string, number>();
-  hourlyForecast?.forEach((f) => {
-    const slot = getTimeSlotInTimezone(f.predictedTime, timezone);
-    if (!forecastMap.has(slot)) forecastMap.set(slot, f.predictedWaitTime);
-  });
-
-  // Time range: schedule-based or derived from data points
-  const todaySchedule = schedule?.find((s) => s.date === todayStr);
-  let startTime = '09:00';
-  let endTime = '19:00';
-
-  if (todaySchedule) {
-    if (todaySchedule.openingTime) {
-      const date = new Date(todaySchedule.openingTime);
-      const h = new Intl.DateTimeFormat('en', {
-        hour: 'numeric',
-        hour12: false,
-        timeZone: timezone,
-      }).format(date);
-      const m = new Intl.DateTimeFormat('en', { minute: 'numeric', timeZone: timezone }).format(
-        date
-      );
-      // Round down to nearest 15m
-      const roundedM = Math.floor(parseInt(m, 10) / 15) * 15;
-      startTime = `${h.padStart(2, '0')}:${roundedM.toString().padStart(2, '0')}`;
-    }
-    if (todaySchedule.closingTime) {
-      const date = new Date(todaySchedule.closingTime);
-      const h = new Intl.DateTimeFormat('en', {
-        hour: 'numeric',
-        hour12: false,
-        timeZone: timezone,
-      }).format(date);
-      const m = new Intl.DateTimeFormat('en', { minute: 'numeric', timeZone: timezone }).format(
-        date
-      );
-      // Round up to nearest 15m
-      const roundedM = Math.ceil(parseInt(m, 10) / 15) * 15;
-      let finalH = parseInt(h, 10);
-      let finalM = roundedM;
-      if (finalM === 60) {
-        finalH = (finalH + 1) % 24;
-        finalM = 0;
-      }
-      endTime = `${finalH.toString().padStart(2, '0')}:${finalM.toString().padStart(2, '0')}`;
-    }
-  } else {
-    const allSlots = [...historyMap.keys(), ...forecastMap.keys()].sort();
-    if (allSlots.length > 0) {
-      startTime = allSlots[0];
-      endTime = allSlots[allSlots.length - 1];
-    }
-  }
-
-  // Filter maps to ensure no data outside operating hours
-  for (const time of historyMap.keys()) {
-    if (time < startTime || time > endTime) historyMap.delete(time);
-  }
-  for (const time of forecastMap.keys()) {
-    if (time < startTime || time > endTime) forecastMap.delete(time);
-  }
-
-  // Start at the first actual history record — forecasts may contain stale past-hour
-  // entries from Redis cache, so only history determines the real data start.
-  const historyKeys = [...historyMap.keys()].sort();
-  if (historyKeys.length > 0 && historyKeys[0] > startTime) {
-    startTime = historyKeys[0];
-  }
-
-  // Track last real data point to trim trailing empty slots later
-  const lastHistoryTime = historyKeys.length > 0 ? historyKeys[historyKeys.length - 1] : null;
-  const forecastKeys = [...forecastMap.keys()].sort();
-  const lastForecastTime = forecastKeys.length > 0 ? forecastKeys[forecastKeys.length - 1] : null;
-  const lastActualTime =
-    [lastHistoryTime, lastForecastTime]
-      .filter((t): t is string => t !== null)
-      .sort()
-      .pop() ?? null;
-
-  // Build 15-minute slots
-  const slots: DailyWaitTimeChartData['slots'] = [];
-  const [startH, startM] = startTime.split(':').map(Number);
-  const [endH, endM] = endTime.split(':').map(Number);
-
-  let curH = startH;
-  let curM = startM;
-
-  while (curH < endH || (curH === endH && curM <= endM)) {
-    const time = `${curH.toString().padStart(2, '0')}:${curM.toString().padStart(2, '0')}`;
-    slots.push({
-      time,
-      historyValue: historyMap.get(time) ?? null,
-      forecastValue: forecastMap.get(time) ?? null,
-    });
-
-    curM += 15;
-    if (curM >= 60) {
-      curM = 0;
-      curH++;
-    }
-  }
-
-  // Trim trailing slots past last actual data point (schedule may extend beyond predictions)
-  if (lastActualTime) {
-    while (slots.length > 0 && slots[slots.length - 1].time > lastActualTime) {
-      slots.pop();
-    }
-  }
-
-  // Fill null history slots using carry-forward from last known value.
-  // This avoids fake sloping lines between two real data points.
-  for (let i = 0; i < slots.length; i++) {
-    if (slots[i].historyValue !== null) continue;
-    const prev = i - 1;
-    if (prev >= 0 && slots[prev].historyValue !== null) {
-      slots[i].historyValue = slots[prev].historyValue;
-    }
-    // Leading nulls (before first data point) remain null — park not open yet
-  }
-
-  // Skip render if there's no data at all
-  if (slots.every((s) => s.historyValue === null && s.forecastValue === null)) return null;
-
-  // Convert bestVisitTimes ISO timestamps → "HH:mm" in park timezone
-  const bestSlots = bestVisitTimes
-    ?.map((s) => ({
-      time: getTimeSlotInTimezone(s.time, timezone),
-      rating: s.rating,
-    }))
-    .filter((s) => s.time >= startTime && s.time <= endTime);
-
-  const data: DailyWaitTimeChartData = {
-    slots,
-    timezone,
-    bestSlots: bestSlots?.length ? bestSlots : undefined,
-    translations: {
-      title: t('title'),
-      now: t('now'),
-      bestSlots: t('bestSlots', { hours: '{hours}' }),
-      bestSlotsGood: t('bestSlotsGood', { hours: '{hours}' }),
-      timeSuffix: t('timeSuffix'),
-      min: t('min'),
-      ratingOptimal: t('ratingOptimal'),
-      ratingGood: t('ratingGood'),
-    },
-  };
-
-  // The chart reads the current time (today marker) on the client; a Suspense boundary lets
-  // it render as a dynamic hole under Cache Components.
   return (
-    <Suspense fallback={null}>
-      <DailyWaitTimeChart {...data} />
-    </Suspense>
+    <DailyWaitTimeChartClient
+      history={history}
+      hourlyForecast={hourlyForecast}
+      timezone={timezone}
+      schedule={schedule}
+      bestVisitTimes={bestVisitTimes}
+      translations={{
+        title: t('title'),
+        now: t('now'),
+        bestSlots: t('bestSlots', { hours: '{hours}' }),
+        bestSlotsGood: t('bestSlotsGood', { hours: '{hours}' }),
+        timeSuffix: t('timeSuffix'),
+        min: t('min'),
+        ratingOptimal: t('ratingOptimal'),
+        ratingGood: t('ratingGood'),
+      }}
+    />
   );
 }

--- a/components/parks/park-best-days-section.tsx
+++ b/components/parks/park-best-days-section.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import { CalendarDays, TrendingDown, AlertTriangle, Sunset } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useMounted } from '@/lib/hooks/use-mounted';
+import { useMounted, useBrowserNow } from '@/lib/hooks/use-mounted';
+import { getCalendarWindow } from '@/lib/hooks/use-calendar-window';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { GlassCard } from '@/components/common/glass-card';
 import type { IntegratedCalendarResponse, CrowdLevel, DayOfWeekStat } from '@/lib/api/types';
@@ -19,9 +20,6 @@ interface ParkBestDaysSectionProps {
   country: string;
   city: string;
   parkSlug: string;
-  /** Calendar window (current month + next 2, capped at 90 days) computed in the server shell. */
-  from: string;
-  to: string;
   /** Park timezone — used for the empty-calendar fallback meta while data loads/fails. */
   timezone: string;
   hasOperatingSchedule: boolean;
@@ -91,8 +89,6 @@ export function ParkBestDaysSection({
   country,
   city,
   parkSlug,
-  from,
-  to,
   timezone,
   hasOperatingSchedule,
   parkName,
@@ -105,6 +101,9 @@ export function ParkBestDaysSection({
   // clock-reading content below — reading Date.now() inside a Client Component during the
   // prerender is forbidden under Cache Components.
   const mounted = useMounted();
+  // Calendar window derived from the browser clock (client-only) so the park shell never reads
+  // the server clock — keeping it time-independent for the 1-day TTL.
+  const { from, to } = getCalendarWindow(useBrowserNow(null));
   const { data: calendarData, isLoading: calendarLoading } = useParkBestDaysCalendar({
     continent,
     country,

--- a/components/parks/park-time-info.tsx
+++ b/components/parks/park-time-info.tsx
@@ -15,7 +15,9 @@ import type { ScheduleItem, NextScheduleItem, InfluencingHoliday } from '@/lib/a
 
 interface ParkTimeInfoProps {
   timezone: string;
-  todaySchedule?: ScheduleItem | null;
+  /** Full park schedule (day-stable, lives in the static shell). Today's entry is picked
+   *  CLIENT-side from the browser clock + park timezone, so the shell stays time-independent. */
+  schedule?: ScheduleItem[] | null;
   nextSchedule?: NextScheduleItem | null;
   status?: ParkStatus | null;
   hasOperatingSchedule?: boolean;
@@ -30,7 +32,7 @@ interface ParkTimeInfoProps {
  */
 export function ParkTimeInfo({
   timezone,
-  todaySchedule,
+  schedule,
   nextSchedule,
   status,
   hasOperatingSchedule = true,
@@ -41,6 +43,16 @@ export function ParkTimeInfo({
   const tNearby = useTranslations('nearby');
   const locale = useLocale();
   const currentTime = useBrowserNow(60_000);
+
+  // Pick today's schedule entry CLIENT-side (from the browser clock in the park's timezone) so the
+  // static shell never reads the server clock. Before mount we fall back to the first entry — same
+  // graceful seed the server used previously — and the real "today" fills in after hydration.
+  const todaySchedule: ScheduleItem | null = (() => {
+    if (!schedule || schedule.length === 0) return null;
+    if (!currentTime) return schedule[0];
+    const todayInParkTz = currentTime.toLocaleDateString('en-CA', { timeZone: timezone });
+    return schedule.find((s) => s.date === todayInParkTz) ?? schedule[0];
+  })();
 
   // Format current time in park timezone
   const formatCurrentTime = () => {

--- a/components/parks/weather-card-demo.tsx
+++ b/components/parks/weather-card-demo.tsx
@@ -495,11 +495,11 @@ export function ParkTimeInfoShowcase() {
     <div className="grid max-w-2xl grid-cols-1 gap-4 sm:grid-cols-2">
       <ParkTimeInfo
         timezone="Europe/Berlin"
-        todaySchedule={buildScheduleForOffset(today, 0, 9, 22, '+01:00')}
+        schedule={[buildScheduleForOffset(today, 0, 9, 22, '+01:00')]}
       />
       <ParkTimeInfo
         timezone="America/New_York"
-        todaySchedule={buildScheduleForOffset(today, 0, 9, 20, '-05:00')}
+        schedule={[buildScheduleForOffset(today, 0, 9, 20, '-05:00')]}
         nextSchedule={buildScheduleForOffset(today, 1, 9, 20, '-05:00')}
       />
     </div>
@@ -528,7 +528,7 @@ export function WeatherCardShowcase({ variant }: WeatherCardShowcaseProps) {
           <ParkTimeInfo
             timezone="Europe/Berlin"
             status="OPERATING"
-            todaySchedule={buildTodaySchedule(today)}
+            schedule={[buildTodaySchedule(today)]}
           />
           <WeatherCard
             weather={buildWeather(today, 'sunny')}

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -12,6 +12,7 @@ import { TemperatureUnitToggle } from '@/components/common/temperature-unit-togg
 import { Temp, Wind, Precip, Distance } from '@/components/common/unit-display';
 import { getWeatherConfig } from '@/lib/utils/weather-utils';
 import { useWeatherNowcast } from '@/lib/hooks/use-weather-nowcast';
+import { useLiveParkData } from '@/lib/hooks/use-live-park-data';
 import type { WeatherData, WeatherDay, WeatherNowcast } from '@/lib/api/types';
 
 interface WeatherCardProps {
@@ -52,10 +53,22 @@ export function WeatherCard({
   // liveNowcast is undefined when the hook is disabled (no params) — fall back to the static prop
   const activeNowcast = hasParams ? liveNowcast : nowcast;
 
-  if (!weather.current) return null;
+  // The base forecast (current + 7-day strip) is baked into the 1-day ISR shell, so it would be up
+  // to a day stale. Subscribe to the same live park query LiveParkData polls (shared key → no extra
+  // fetch) and use its fresh `weather`; fall back to the server-rendered prop until it lands.
+  const { data: livePark } = useLiveParkData({
+    continent: continent ?? '',
+    country: country ?? '',
+    city: city ?? '',
+    parkSlug: parkSlug ?? '',
+    enabled: hasParams,
+  });
+  const activeWeather = hasParams && livePark?.weather?.current ? livePark.weather : weather;
 
-  const current = weather.current;
-  const now = weather.now ?? null;
+  if (!activeWeather.current) return null;
+
+  const current = activeWeather.current;
+  const now = activeWeather.now ?? null;
 
   // Nowcast (~15 min freshness) wins over the daily "now" snapshot, which can be hours old.
   // It now also carries temperature, apparent-temperature, min/max, and isDay — so when a
@@ -199,8 +212,8 @@ export function WeatherCard({
             )}
           </div>
 
-          {(forecast || (weather.forecast && weather.forecast.length > 0)) && (
-            <WeatherForecastStrip forecast={forecast || (weather.forecast ?? [])} />
+          {(forecast || (activeWeather.forecast && activeWeather.forecast.length > 0)) && (
+            <WeatherForecastStrip forecast={forecast || (activeWeather.forecast ?? [])} />
           )}
 
           <p className="text-muted-foreground/50 !-mt-1 -mr-4 -mb-3 flex items-center justify-end gap-1 text-[12px] leading-none font-medium">

--- a/components/seo/faq-structured-data.tsx
+++ b/components/seo/faq-structured-data.tsx
@@ -3,7 +3,6 @@ import { getTranslations } from 'next-intl/server';
 import { WithContext, Thing } from 'schema-dts';
 import { escapeJsonLd } from '@/components/seo/structured-data';
 import { buildParkFaqItems, getParkArticleForms } from '@/lib/faq/park-faq';
-import { getServerNowMs } from '@/lib/utils/server-time';
 
 interface FAQStructuredDataProps {
   park: ParkWithAttractions;
@@ -14,12 +13,15 @@ export async function FAQStructuredData({ park, locale }: FAQStructuredDataProps
   const t = await getTranslations('seo.faq');
   const tGeo = await getTranslations('geo');
 
+  // Pass null for "now": the JSON-LD stays SERVER-rendered (SEO) but TIME-INDEPENDENT, so it can
+  // live in the day-stable static shell without reading the clock (which would pin/stale the
+  // shell). Q1 emits an evergreen opening-hours answer instead of today's concrete hours.
   const items = buildParkFaqItems(
     park,
     locale,
     t as Parameters<typeof buildParkFaqItems>[2],
     tGeo as Parameters<typeof buildParkFaqItems>[3],
-    await getServerNowMs()
+    null
   );
 
   const { parkNom, parkAcc } = getParkArticleForms(park, locale);

--- a/components/seo/structured-data.tsx
+++ b/components/seo/structured-data.tsx
@@ -288,11 +288,9 @@ export function AttractionStructuredData({
 export function ShowsStructuredData({
   shows,
   park,
-  date,
 }: {
   shows: ParkShow[];
   park: ParkResponse | ParkWithAttractions;
-  date: string;
 }) {
   if (!shows || shows.length === 0) return null;
 
@@ -302,6 +300,15 @@ export function ShowsStructuredData({
   );
 
   if (showsWithTimes.length === 0) return null;
+
+  // Representative event date derived from the park's own schedule (the earliest OPERATING day in
+  // the day-stable shell data), NOT the server clock. This keeps the Shows JSON-LD time-INDEPENDENT
+  // so it never pins or stales the static shell, while still emitting a valid Event startDate.
+  const schedule = park.schedule;
+  const date = schedule?.find((s) => s.scheduleType === 'OPERATING')?.date ?? schedule?.[0]?.date;
+
+  // No schedule date to anchor the Event(s) → skip rather than emit a bogus startDate.
+  if (!date) return null;
 
   // One Event per show (not per showtime): a popular park can have 100+ daily
   // showtimes, which previously emitted 100+ near-identical Event blocks (~100KB

--- a/lib/api/cache-config.ts
+++ b/lib/api/cache-config.ts
@@ -29,10 +29,10 @@ export const CACHE_TTL = {
   parks: 300, // popular parks frontend data-cached 5 min - slow-moving popularity ranking
   // Shell TTL for the park/attraction static prerender (see PARK_MAX_AGE / ATTRACTION_MAX_AGE in
   // lib/api/parks.ts). The shell is only an SSR seed; live wait times/status come from the client
-  // poll via getParkByGeoPathFresh (no-store), so the shell can revalidate every 6h instead of
-  // hourly — ~6× fewer park ISR writes, with the live data staying genuinely fresh.
-  parkDetail: 21600, // shell revalidate 6h - live wait times via getParkByGeoPathFresh
-  waitTimes: 21600, // shell revalidate 6h - live wait times via getParkByGeoPathFresh
+  // poll via getParkByGeoPathFresh (no-store), and all "today/now" content is client-derived, so
+  // the shell can revalidate once a day — ~24× fewer park ISR writes vs hourly, live data stays fresh.
+  parkDetail: 86400, // shell revalidate 1d - live wait times via getParkByGeoPathFresh
+  waitTimes: 86400, // shell revalidate 1d - live wait times via getParkByGeoPathFresh
 
   // Static data (still using revalidate)
   calendar: 900, // /v1/parks/:slug/calendar - API: 900s (past/today) / 1800s (future); the forecast under it only changes ~13h, and today's crowdLevel is patched client-side via a separate 5-min today-only fetch — so 5 min here was pure rebuild churn

--- a/lib/api/discovery.ts
+++ b/lib/api/discovery.ts
@@ -96,7 +96,11 @@ export async function getParksNearLocation(
   maxDistanceM: number = 300_000
 ): Promise<NearbyParkItem[]> {
   'use cache';
-  cacheLife({ stale: 3600, revalidate: 3600, expire: 3600 * 4 });
+  // Read in the PARK page's static shell (NearbyParksSection) — its cacheLife is part of the MIN
+  // that pins the park route's revalidate, so an hourly TTL silently capped the park shell at 1h.
+  // The seed here is proximity + structure only (status-free); live status is overlaid client-side
+  // (LiveNearbyParks), and geo proximity is day-stable, so 1d lifts the floor to the intended TTL.
+  cacheLife({ stale: 86400, revalidate: 86400, expire: 86400 * 4 });
   return fetchParksNearLocation(lat, lng, excludeParkId, limit, maxDistanceM, false);
 }
 

--- a/lib/api/parks.ts
+++ b/lib/api/parks.ts
@@ -14,16 +14,17 @@ import type { ParkWithAttractions, AttractionResponse, PopularPark } from './typ
 // Context: park/attraction pages were dynamic (no ISR writes) until they were switched to static
 // ISR with revalidate:300 — which is what turned ISR writes on across the whole catalog × 6 locales.
 //
-// Parks keep a 1h floor: their shell carries the operating schedule, status and structured data, so
-// a tighter bound is worth the extra writes. Attractions get a longer 6h floor: their shell has no
-// schedule/weather (only name/description/history-chart seed, daily-ish), they are by far the
-// highest-cardinality route, and their live status/wait time is client-refreshed all the same.
-// 6h park shell TTL. The shell carries only structure + the schedule/weather seed (both
-// day-stable or client-refreshed); live wait times/status come from the client poll via
-// getParkByGeoPathFresh (see below), so the cached shell no longer needs to be the fresh source —
-// it can revalidate every 6h instead of hourly (~6× fewer park ISR writes), matching attractions.
-const PARK_MAX_AGE = 21600;
-const ATTRACTION_MAX_AGE = 21600; // 6h attraction shell TTL — dominant route, no schedule in shell
+// Both shells now revalidate every 1 DAY. The only thing that previously pinned them below this was
+// a server-time read in their static render — getServerToday('hours') in DailyWaitTimeChartServer
+// (the #1 ISR-write driver) and getServerNowMs in the park page/FAQ/history grid. All of that
+// "today/now"-dependent content (the daily chart's "today" marker, today's opening-hours, the
+// crowd FAQ, the history grid's "today") is now CLIENT-derived (useBrowserNow/useMounted) or made
+// time-INDEPENDENT, so the shells carry only day-stable structure. Live wait times/status come from
+// the client poll via getParkByGeoPathFresh (no-store), so a stale shell never shows stale live
+// data. A 1-day TTL collapses the per-park/per-attraction × per-locale ISR-write volume ~4× vs 6h
+// (and ~24× vs the original hourly park floor).
+const PARK_MAX_AGE = 86400; // 1d park shell TTL — all "today/now" content is client-derived
+const ATTRACTION_MAX_AGE = 86400; // 1d attraction shell TTL — dominant route, "today" client-derived
 
 /**
  * Drop per-attraction fields the PARK page never renders before the snapshot is cached.

--- a/lib/faq/park-faq.ts
+++ b/lib/faq/park-faq.ts
@@ -46,21 +46,29 @@ export function buildParkFaqItems(
   locale: string,
   t: T,
   tGeo: TGeo,
-  /** Epoch ms for "now" — pass a cached value (getServerNowMs) for cacheComponents safety. */
-  nowMs: number
+  /**
+   * Epoch ms for "now", or `null` for a TIME-INDEPENDENT build. The only time-dependent answer is
+   * Q1 (today's opening hours): pass `null` (the SSR / pre-mount / structured-data path) to get an
+   * evergreen "see the calendar" answer, or a client-derived `Date.now()` to get today's concrete
+   * hours after mount. Keeping `null` out of the static shell is what lets the park shell stay
+   * time-independent (1-day TTL) — nothing here may read the server clock.
+   */
+  nowMs: number | null
 ): ParkFaqItem[] {
   const { parkName, parkNom, parkNomCap } = getParkArticleForms(park, locale);
 
   const timeZone = park.timezone || 'UTC';
-  const now = new Date(nowMs);
-  const parkDate = formatInTimeZone(now, timeZone, 'yyyy-MM-dd');
-  const todaySchedule = park.schedule?.find((s) => s.date === parkDate);
-  const localizedDate = new Intl.DateTimeFormat(locale, {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  }).format(now);
+  const now = nowMs != null ? new Date(nowMs) : null;
+  const parkDate = now ? formatInTimeZone(now, timeZone, 'yyyy-MM-dd') : null;
+  const todaySchedule = parkDate ? park.schedule?.find((s) => s.date === parkDate) : undefined;
+  const localizedDate = now
+    ? new Intl.DateTimeFormat(locale, {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      }).format(now)
+    : null;
 
   const items: ParkFaqItem[] = [];
 
@@ -86,9 +94,13 @@ export function buildParkFaqItems(
     });
   }
 
-  // Q1: Opening Hours
+  // Q1: Opening Hours. Time-INDEPENDENT when nowMs is null (SSR/structured-data/pre-mount): an
+  // evergreen answer that never reads the clock, so it can't pin or stale the static shell. With a
+  // client-derived nowMs it upgrades to today's concrete hours after mount.
   let openingHoursAnswer: string;
   if (
+    now &&
+    localizedDate &&
     todaySchedule?.scheduleType === 'OPERATING' &&
     todaySchedule.openingTime &&
     todaySchedule.closingTime
@@ -96,8 +108,10 @@ export function buildParkFaqItems(
     const open = formatInTimeZone(new Date(todaySchedule.openingTime), timeZone, 'HH:mm');
     const close = formatInTimeZone(new Date(todaySchedule.closingTime), timeZone, 'HH:mm');
     openingHoursAnswer = t('openingHoursA', { date: localizedDate, park: parkNom, open, close });
-  } else {
+  } else if (now && localizedDate && todaySchedule) {
     openingHoursAnswer = t('openingHoursClosed', { date: localizedDate, park: parkNom });
+  } else {
+    openingHoursAnswer = t('openingHoursEvergreenA', { park: parkNom });
   }
   items.push({
     iconName: 'Calendar',

--- a/lib/hooks/use-calendar-window.ts
+++ b/lib/hooks/use-calendar-window.ts
@@ -1,0 +1,30 @@
+import { format, startOfMonth, endOfMonth, addMonths, addDays, min } from 'date-fns';
+
+export interface CalendarWindow {
+  /** Start of the window (current month start), `YYYY-MM-DD`. */
+  from: string;
+  /** End of the window (end of month +2, capped at 90 days), `YYYY-MM-DD`. */
+  to: string;
+}
+
+/**
+ * Derive the best-days / FAQ calendar window (current month + next 2 months, capped at the API's
+ * 90-day max) from a "now" Date.
+ *
+ * Previously computed in the park's server shell from getServerNowMs() — which read the clock in
+ * the static prerender and pinned the shell's revalidate to the clock's cacheLife. Pass a
+ * client-derived "now" (e.g. from useBrowserNow, which is null until mount) so the shell stays
+ * time-independent (1-day TTL); `now` is null during SSR/prerender, where we return a stable
+ * placeholder window that the calendar query never uses (it's browser-gated) and which is replaced
+ * once the browser clock is available.
+ */
+export function getCalendarWindow(now: Date | null): CalendarWindow {
+  if (!now) {
+    // Placeholder for the pre-mount render; the calendar fetch is browser-only so this is never
+    // actually requested, and it's replaced as soon as the browser clock lands.
+    return { from: '', to: '' };
+  }
+  const from = startOfMonth(now);
+  const to = min([endOfMonth(addMonths(now, 2)), addDays(from, 89)]);
+  return { from: format(from, 'yyyy-MM-dd'), to: format(to, 'yyyy-MM-dd') };
+}

--- a/lib/hooks/use-live-park-data.ts
+++ b/lib/hooks/use-live-park-data.ts
@@ -7,6 +7,8 @@ interface UseLiveParkDataParams {
   city: string;
   parkSlug: string;
   initialData?: ParkWithAttractions;
+  /** Lets a non-primary consumer (e.g. the WeatherCard) subscribe only when it has geo params. */
+  enabled?: boolean;
 }
 
 /**
@@ -25,6 +27,7 @@ export function useLiveParkData({
   city,
   parkSlug,
   initialData,
+  enabled = true,
 }: UseLiveParkDataParams) {
   return useQuery<ParkWithAttractions>({
     queryKey: ['park-live', continent, country, city, parkSlug],
@@ -46,7 +49,7 @@ export function useLiveParkData({
     // Run the query on the client only. During the static (Cache Components) prerender the
     // component renders from `initialData`; activating React Query server-side would read
     // Date.now() internally, which a static prerender forbids.
-    enabled: typeof window !== 'undefined',
+    enabled: enabled && typeof window !== 'undefined',
     staleTime: 5 * 60_000,
     gcTime: 10 * 60_000,
     refetchOnWindowFocus: true,

--- a/lib/hooks/use-park-best-days-calendar.ts
+++ b/lib/hooks/use-park-best-days-calendar.ts
@@ -46,7 +46,9 @@ export function useParkBestDaysCalendar({
 
       return (await response.json()) as IntegratedCalendarResponse;
     },
-    enabled: typeof window !== 'undefined',
+    // Browser-only, and only once the (client-derived) window is known — `from`/`to` are empty
+    // until the browser clock lands, and we must not fire a `?from=&to=` request.
+    enabled: typeof window !== 'undefined' && from !== '' && to !== '',
     staleTime: 30 * 60_000,
     gcTime: 60 * 60_000,
     refetchOnWindowFocus: false,

--- a/lib/utils/redirect-utils.ts
+++ b/lib/utils/redirect-utils.ts
@@ -14,11 +14,16 @@ import { getGeoStructure } from '@/lib/api/discovery';
 
 /**
  * O(1) park-slug → geo-path index for redirect lookups, cached via Cache Components.
- * Returns a plain Record (serializable across the cache boundary). Refreshes hourly.
+ * Returns a plain Record (serializable across the cache boundary). Refreshes daily.
+ *
+ * This index is read in the PARK page's static shell (findParkPageRedirect), so its cacheLife is
+ * part of the MIN that pins the park route's revalidate. The data is day-stable (geo paths / park
+ * slugs change very rarely, and the underlying getGeoStructure is already fetched with a 1-day
+ * cache), so 'days' lets the park shell reach its intended 1-day TTL instead of an hourly floor.
  */
 async function getParkSlugIndex(): Promise<Record<string, ParkLookupResult>> {
   'use cache';
-  cacheLife('hours');
+  cacheLife('days');
 
   const index: Record<string, ParkLookupResult> = {};
   try {

--- a/messages/de.json
+++ b/messages/de.json
@@ -870,6 +870,7 @@
       "openingHoursQ": "Welche Öffnungszeiten hat {park} heute?",
       "openingHoursA": "Heute, {date}, hat {park} von {open} bis {close} Uhr geöffnet.",
       "openingHoursClosed": "Heute, {date}, ist {park} geschlossen.",
+      "openingHoursEvergreenA": "Die Öffnungszeiten von {park} hängen von Saison und Wochentag ab. Aktuelle Öffnungszeiten findest du im Zeitplan und Crowd-Kalender auf dieser Seite.",
       "locationQ": "Wo befindet sich {park}?",
       "locationA": "{park} befindet sich in {city}, {country}.",
       "attractionCountQ": "Wie viele Attraktionen gibt es im {park}?",

--- a/messages/en.json
+++ b/messages/en.json
@@ -870,6 +870,7 @@
       "openingHoursQ": "What are the opening hours for {park} today?",
       "openingHoursA": "Today, {date}, {park} is open from {open} to {close}.",
       "openingHoursClosed": "Today, {date}, {park} is closed.",
+      "openingHoursEvergreenA": "Opening hours at {park} vary by season and day. Check the schedule and crowd calendar on this page for the current opening times.",
       "locationQ": "Where is {park} located?",
       "locationA": "{park} is located in {city}, {country}.",
       "attractionCountQ": "How many attractions are at {park}?",

--- a/messages/es.json
+++ b/messages/es.json
@@ -870,6 +870,7 @@
       "openingHoursQ": "¿Cuál es el horario de apertura de {park} hoy?",
       "openingHoursA": "Hoy, {date}, {park} está abierto de {open} a {close}.",
       "openingHoursClosed": "Hoy, {date}, {park} está cerrado.",
+      "openingHoursEvergreenA": "El horario de apertura de {park} varía según la temporada y el día. Consulta el calendario y el calendario de afluencia en esta página para conocer los horarios actuales.",
       "locationQ": "¿Dónde se encuentra {park}?",
       "locationA": "{park} se encuentra en {city}, {country}.",
       "attractionCountQ": "¿Cuántas atracciones hay en {park}?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -870,6 +870,7 @@
       "openingHoursQ": "Quels sont les horaires d'ouverture de {park} aujourd'hui?",
       "openingHoursA": "Aujourd'hui, {date}, {park} est ouvert de {open} à {close}.",
       "openingHoursClosed": "Aujourd'hui, {date}, {park} est fermé.",
+      "openingHoursEvergreenA": "Les horaires d'ouverture de {park} varient selon la saison et le jour. Consultez le calendrier et le calendrier d'affluence sur cette page pour les horaires actuels.",
       "locationQ": "Où se trouve {park}?",
       "locationA": "{park} se trouve à {city}, {country}.",
       "attractionCountQ": "Combien d'attractions y a-t-il à {park}?",

--- a/messages/it.json
+++ b/messages/it.json
@@ -870,6 +870,7 @@
       "openingHoursQ": "Quali sono gli orari di apertura di {park} oggi?",
       "openingHoursA": "Oggi, {date}, {park} è aperto dalle {open} alle {close}.",
       "openingHoursClosed": "Oggi, {date}, {park} è chiuso.",
+      "openingHoursEvergreenA": "Gli orari di apertura di {park} variano in base alla stagione e al giorno. Consulta il programma e il calendario delle affluenze in questa pagina per gli orari aggiornati.",
       "locationQ": "Dove si trova {park}?",
       "locationA": "{park} si trova a {city}, {country}.",
       "attractionCountQ": "Quante attrazioni ci sono a {park}?",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -870,6 +870,7 @@
       "openingHoursQ": "Wat zijn de openingstijden van {park} vandaag?",
       "openingHoursA": "Vandaag, {date}, is {park} open van {open} tot {close}.",
       "openingHoursClosed": "Vandaag, {date}, is {park} gesloten.",
+      "openingHoursEvergreenA": "De openingstijden van {park} variëren per seizoen en dag. Bekijk het schema en de druktekalender op deze pagina voor de actuele openingstijden.",
       "locationQ": "Waar bevindt {park} zich?",
       "locationA": "{park} bevindt zich in {city}, {country}.",
       "attractionCountQ": "Hoeveel attracties zijn er in {park}?",

--- a/next.config.ts
+++ b/next.config.ts
@@ -210,6 +210,14 @@ const nextConfig: NextConfig = {
         ],
       },
       {
+        // Hub "X parks open now" live-counts batch, polled by every continent/country/city card grid.
+        // A 60s shared CDN window collapses concurrent polls off the backend (it was no-store).
+        source: '/api/discovery/:path*',
+        headers: [
+          { key: 'Cache-Control', value: 'public, s-maxage=60, stale-while-revalidate=120' },
+        ],
+      },
+      {
         source: '/:locale/search',
         headers: [{ key: 'Cache-Control', value: 'no-store, must-revalidate' }],
       },


### PR DESCRIPTION
## Why

Park/attraction pages were the dominant ISR-write source (writes ≫ reads in production). Their shells revalidated far below the intended TTL because of **server-clock reads in the static render**: `getServerToday('hours')` in the daily wait chart pinned the **attraction** shell to **1h**, and a couple of `'use cache'` reads pinned the **park** shell to **1h** (`getParkSlugIndex` via `findParkPageRedirect`, `getParksNearLocation`). Every revalidation rewrote the shell **+ its ~6 PPR segments × 6 locales** — that's the write spike.

## What

Move all "today/now"-dependent content to the client so the shells are time-independent and revalidate **once a day**:

- **`PARK_MAX_AGE` / `ATTRACTION_MAX_AGE` → 86400 (1d)**; `getParkSlugIndex` + `getParksNearLocation` → 1d.
- **Client-derived** (`useBrowserNow`): today's opening hours, the daily-chart "today" marker, the attraction history-grid "today", the crowd FAQ. FAQ JSON-LD kept server-rendered but made **time-independent** (evergreen) so it neither pins nor stales the shell.
- **No stale baked values:** the weather forecast (current + 7-day strip) was server-baked → a day stale. The `WeatherCard` now reads it from the shared `LiveParkData` poll (fresh, **no extra fetch** — same React Query key). Wait times/status/crowd were already client-refreshed.
- **`/api/discovery` no-store → `s-maxage=60`** (next.config exemption after the blanket `/api` rule) so the hub "X open now" polls collapse onto one backend call instead of per-visitor.

## Verified
- park + attraction serve `Cache-Control: s-maxage=86400` (1d, edge-cacheable — no `no-store` regression from #140).
- No `getServerNowMs`/`getServerToday` in the park/attraction render; SEO structure + `ThemePark`/`TouristAttraction`/`FAQPage` JSON-LD stay in SSR HTML.
- Build route table: `[park]` + `[attraction]` = 1d. tsc / eslint / prettier clean.

The big lever: park/attraction revalidate **daily instead of 1h/6h** → ~24×/6× fewer shell+segment writes → the spikes.

https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGHUXvSbr3A7kQfWshjMvr)_