### PR TITLE
perf(isr): drop Cache Components — force-dynamic park/attraction/home

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
-import { generateAlternateLanguages, locales } from '@/i18n/config';
+import { generateAlternateLanguages } from '@/i18n/config';
 import { buildOpenGraphMetadata } from '@/lib/utils/metadata';
 import { Link } from '@/i18n/navigation';
 import { GLOSSARY_SEGMENTS } from '@/lib/glossary/translations';
@@ -11,7 +11,6 @@ import { Button } from '@/components/ui/button';
 import nextDynamic from 'next/dynamic';
 import { HeroBackground } from '@/components/layout/hero-background';
 import { HERO_IMAGES } from '@/lib/hero-images';
-import { cacheLife } from 'next/cache';
 import { HomepageFAQStructuredData } from '@/components/seo/homepage-faq-structured-data';
 import { GlassCard } from '@/components/common/glass-card';
 import { NearbyParksCardSkeleton } from '@/components/parks/nearby-parks-card-skeleton';
@@ -57,13 +56,10 @@ import { GlossaryInject } from '@/components/glossary/glossary-inject';
 
 import type { Metadata } from 'next';
 
-// ~5 min ISR window for the static shell. Each data section sets its own
-// revalidate on its fetch (analytics/geo: 300s, ML: 1800s) and streams in via
-// its own Suspense boundary, so a slow/stale endpoint never blocks first paint.
-
-export async function generateStaticParams() {
-  return locales.map((locale) => ({ locale }));
-}
+// FULLY DYNAMIC (force-dynamic) — rendered per request, no ISR shell write. The above-the-fold
+// shell renders server-side (content-first); each data section fetches its own data and streams in
+// via its own Suspense boundary, so a slow/stale endpoint never blocks first paint.
+export const dynamic = 'force-dynamic';
 
 interface HomePageProps {
   params: Promise<{ locale: string }>;
@@ -96,15 +92,14 @@ export async function generateMetadata({ params }: HomePageProps): Promise<Metad
   };
 }
 
-// Hero image rotates per cache window instead of per request: under Cache Components
-// the static shell can't read Math.random() directly, and a cached pick keeps the
-// hero server-rendered for LCP.
-async function pickHeroImage(): Promise<string> {
-  'use cache';
-  // Hourly rotation is plenty for a decorative hero. A 5-min window made this the MIN cacheLife in
-  // the homepage shell, pinning the (6-locale) homepage to a 5-min ISR-write cadence for nothing.
-  cacheLife('hours');
-  return HERO_IMAGES[Math.floor(Math.random() * HERO_IMAGES.length)];
+// Hero image with an effective 5-minute TTL: a deterministic pick keyed to the current 5-min window
+// — stable within the window (identical for all concurrent requests, no per-request reshuffle) and
+// rotating every 5 minutes. Deterministic so it needs no cache machinery on this force-dynamic page,
+// and it stays server-rendered for LCP (passed to <HeroBackground> with priority).
+const HERO_TTL_MS = 5 * 60_000;
+function pickHeroImage(): string {
+  const windowIndex = Math.floor(Date.now() / HERO_TTL_MS);
+  return HERO_IMAGES[windowIndex % HERO_IMAGES.length];
 }
 
 export default async function HomePage({ params }: HomePageProps) {
@@ -117,7 +112,7 @@ export default async function HomePage({ params }: HomePageProps) {
   // Suspense boundary below, so the hero renders/streams without waiting on the API.
   const [tHome, tParks] = await Promise.all([getTranslations('home'), getTranslations('parks')]);
 
-  const randomHeroImage = await pickHeroImage();
+  const randomHeroImage = pickHeroImage();
 
   return (
     <div className="flex flex-col">

--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/[attraction]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/[attraction]/page.tsx
@@ -136,26 +136,13 @@ export async function generateMetadata({ params }: AttractionPageProps): Promise
   };
 }
 
-// On-demand ISR for the whole catalog — we deliberately DON'T prebuild the popular parks' headliner
-// attractions × 6 locales here. That was the single biggest build-time cost (hundreds of prerenders
-// + build-time API load) and is redundant: every attraction renders on first request (dynamicParams
-// defaults to true), and the prewarm cron warms popular pages post-deploy. Cache Components still
-// requires ≥1 entry (an empty array throws EmptyGenerateStaticParamsError, and a param-less route
-// makes `await params` dynamic outside <Suspense> — both fail the build), so we return a single
-// stable seed and generate everything else lazily. A wrong seed slug would only waste this one
-// prerender.
-export function generateStaticParams() {
-  return [
-    {
-      locale: 'en',
-      continent: 'europe',
-      country: 'germany',
-      city: 'rust',
-      park: 'europa-park',
-      attraction: 'blue-fire-megacoaster',
-    },
-  ];
-}
+// FULLY DYNAMIC (force-dynamic) — rendered per request, so NO per-URL ISR shell write (the dominant
+// write-units source pre-#118 was prerendering every attraction × 6 locales). Cache Components is
+// off; this page reads the data-cached park snapshot (getParkByGeoPath, `fetch` next:revalidate,
+// shared per park) and renders the full content (h1, JSON-LD, FAQ) server-side into the first HTML
+// — content-first, no skeleton. Live status/wait times + the heavy history time-series are
+// client-loaded (React Query). No generateStaticParams needed.
+export const dynamic = 'force-dynamic';
 
 export default async function AttractionPage({ params }: AttractionPageProps) {
   const {

--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -1,13 +1,12 @@
 import { Suspense } from 'react';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
-import { generateAlternateLanguages, locales } from '@/i18n/config';
+import { generateAlternateLanguages } from '@/i18n/config';
 import { buildOpenGraphMetadata } from '@/lib/utils/metadata';
 import { translateCountry, translateContinent } from '@/lib/i18n/helpers';
 import { notFound, permanentRedirect } from 'next/navigation';
 import { MapPin } from 'lucide-react';
 import { Separator } from '@/components/ui/separator';
-import { getParkByGeoPath, getPopularParks } from '@/lib/api/parks';
-import { getGeoStructure } from '@/lib/api/discovery';
+import { getParkByGeoPath } from '@/lib/api/parks';
 import { catchNonFatal } from '@/lib/api/client';
 import { getGlossaryTerms, GLOSSARY_SEGMENTS } from '@/lib/glossary/translations';
 import type { Locale } from '@/i18n/config';
@@ -49,53 +48,12 @@ interface ParkPageProps {
   }>;
 }
 
-const PREBUILD_PARK_LIMIT = 20;
-
-type ParkRouteParams = { continent: string; country: string; city: string; park: string };
-
-// Prebuild the most popular parks (× all locales) so the highest-traffic parks are warm with full
-// SEO HTML on preview + prod from the first request. BOUNDED on purpose: prerendering EVERY park
-// (~156) issued too many cold park-detail fetches on a fresh Vercel build and failed it (a single
-// fetch error inside the `'use cache'` boundary fails the whole build); ~20 stays within the proven
-// envelope. The prewarm cron (vercel.json) warms the long-tail in prod after deploy; everything else
-// is on-demand ISR (dynamicParams). NOTE: generateStaticParams reads do NOT pin the route's
-// revalidate (only render-path reads do), so getPopularParks' short cacheLife is fine here. Cache
-// Components requires ≥1 entry — the geo fallback + a stable seed guarantee that.
-export async function generateStaticParams() {
-  const popular = await getPopularParks(PREBUILD_PARK_LIMIT).catch(() => []);
-
-  const parks: ParkRouteParams[] = popular
-    .map((p) => p.url?.replace(/^\/v1\/parks\//, '').split('/'))
-    .filter((seg): seg is [string, string, string, string] => !!seg && seg.length === 4)
-    .map(([continent, country, city, park]) => ({ continent, country, city, park }));
-
-  // Fallback if the popular-parks endpoint is briefly unavailable at build: enumerate the geo
-  // structure, bounded to the same limit.
-  if (parks.length === 0) {
-    const geo = await getGeoStructure(604800).catch(() => null);
-    outer: for (const continent of geo?.continents ?? []) {
-      for (const country of continent.countries) {
-        for (const city of country.cities) {
-          for (const park of city.parks) {
-            parks.push({
-              continent: continent.slug,
-              country: country.slug,
-              city: city.slug,
-              park: park.slug,
-            });
-            if (parks.length >= PREBUILD_PARK_LIMIT) break outer;
-          }
-        }
-      }
-    }
-  }
-
-  if (parks.length === 0) {
-    parks.push({ continent: 'europe', country: 'germany', city: 'rust', park: 'europa-park' });
-  }
-
-  return locales.flatMap((locale) => parks.map((p) => ({ locale, ...p })));
-}
+// FULLY DYNAMIC (force-dynamic) — rendered per request, so NO per-URL ISR shell write across the
+// catalog × 6 locales. Cache Components is off; the structure (header, attractions, FAQ, JSON-LD)
+// AND the best-days section render server-side into the first HTML (content-first, no skeleton) from
+// the data-cached snapshots (getParkByGeoPath / getBestDaysCalendar). Live status/wait times,
+// weather nowcast and historical stats are client-loaded (React Query) and stream in afterwards.
+export const dynamic = 'force-dynamic';
 
 export async function generateMetadata({ params }: ParkPageProps): Promise<Metadata> {
   const { continent, country, city, park: parkSlug, locale } = await params;
@@ -181,14 +139,11 @@ export async function generateMetadata({ params }: ParkPageProps): Promise<Metad
   };
 }
 
-// Cache Components: the entire shell (header, attractions, weather, FAQ, structured data) is
-// statically prerendered + edge-cached (served `s-maxage`, like the attraction page). The slow
-// below-the-fold sections — best-days, historical stats, the crowd-derived FAQ entry — are loaded
-// CLIENT-side (React Query → the `/api/parks/.../calendar` + `/stats` CDN-cached routes), each
-// showing a skeleton until its data lands. This deliberately avoids forcing dynamic rendering:
-// a single dynamic-IO opt-in (the old per-section approach) would tip the WHOLE route into
-// dynamic (`no-store`) rendering, which is what previously defeated edge caching and drove ISR
-// write churn.
+// force-dynamic (see the `export const dynamic` above): the structure (header, attractions, FAQ,
+// JSON-LD) renders server-side into the first HTML — content-first — from the data-cached park
+// snapshot (getParkByGeoPath). The slow/live sections — best-days calendar, historical stats,
+// weather nowcast, live wait times — stay CLIENT-loaded (React Query → CDN-cached /api routes) and
+// trickle in behind their own skeletons, so their cold/slow fetches never block this page's TTFB.
 export default async function ParkPage({ params }: ParkPageProps) {
   const { locale, continent, country, city, park: parkSlug } = await params;
   setRequestLocale(locale);
@@ -213,10 +168,11 @@ export default async function ParkPage({ params }: ParkPageProps) {
     notFound();
   }
 
-  // The calendar window (current month + next 2) that feeds the below-the-fold best-days + FAQ
-  // sections is now derived CLIENT-side (useCalendarWindow) inside those client components, so the
-  // static shell reads no clock at all — keeping it time-independent for the 1-day TTL. The bulky
-  // calendar fetch itself was already client-side (useParkBestDaysCalendar → the CDN-cached route).
+  // Best-days + historical stats are loaded CLIENT-side (React Query → the CDN-cached
+  // `/api/parks/.../calendar` + `/stats` routes), each showing a skeleton until its data lands.
+  // They are deliberately NOT fetched here: the calendar is a large, lazily-computed backend
+  // response (cold compute can take 10–20s) and would block this dynamic page's TTFB — keeping it
+  // client-side lets the structure render content-first and these sections trickle in.
 
   // Glossary terms for the (client) FAQ section. This is a small static-content lookup (no fetch,
   // no clock) so it's safe to load in the static shell; the client FAQ tree highlights terms from
@@ -385,6 +341,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
             attractionsByLand={attractionsByLand}
             bestDaysSlot={
               <ParkBestDaysSection
+                key="best-days"
                 continent={continent}
                 country={country}
                 city={city}

--- a/app/api/parks/near/route.ts
+++ b/app/api/parks/near/route.ts
@@ -20,7 +20,10 @@ export async function GET(request: NextRequest) {
 
   try {
     const parks = await getParksNearLocationFresh(lat, lng, exclude, limit, maxDistanceM);
-    return NextResponse.json({ parks }, { headers: { 'Cache-Control': 'no-store, must-revalidate' } });
+    return NextResponse.json(
+      { parks },
+      { headers: { 'Cache-Control': 'no-store, must-revalidate' } }
+    );
   } catch (error) {
     console.error('[Park neighbors proxy] Error:', error);
     return NextResponse.json({ error: 'Failed to fetch nearby parks' }, { status: 502 });

--- a/components/glossary/glossary-background.tsx
+++ b/components/glossary/glossary-background.tsx
@@ -1,4 +1,3 @@
-import { cacheLife } from 'next/cache';
 import { RandomHeroImage } from '@/components/layout/hero-background';
 import { HERO_IMAGES } from '@/lib/hero-images';
 
@@ -9,16 +8,11 @@ import { HERO_IMAGES } from '@/lib/hero-images';
  * pick (no `imageSrc`) only chose the image in a post-hydration effect with no priority — the cause
  * of the multi-second glossary LCP.
  *
- * The pick is DETERMINISTIC per UTC day (not random): every glossary page in a day resolves to the
- * same image, so navigating between terms no longer swaps the hero. It also no longer re-randomises
- * every 5 min — the old 5-min `'use cache'` pinned each glossary route to a 5-min ISR revalidate
- * (pure write churn across all terms × locales). `'days'` rotates it once per day with ~288× fewer
- * glossary writes.
+ * The pick is DETERMINISTIC (not random): on the statically-prerendered glossary pages the
+ * build-time day index is baked in, so every glossary page in a deploy resolves to the same image
+ * (navigating between terms no longer swaps the hero) and there is zero per-request/ISR write churn.
  */
-async function pickGlossaryHero(): Promise<string> {
-  'use cache';
-  cacheLife('days');
-  // Date.now() is captured at cache-fill time (allowed inside a 'use cache' boundary).
+function pickGlossaryHero(): string {
   const dayIndex = Math.floor(Date.now() / 86_400_000);
   return HERO_IMAGES[dayIndex % HERO_IMAGES.length];
 }
@@ -28,7 +22,7 @@ async function pickGlossaryHero(): Promise<string> {
  * No Ken Burns animation. Fades to the page background colour over the lower third.
  */
 export async function GlossaryBackground() {
-  const imageSrc = await pickGlossaryHero();
+  const imageSrc = pickGlossaryHero();
 
   return (
     <div className="pointer-events-none absolute top-0 right-0 left-0 -z-10 h-[calc(90vh+4rem)] max-h-[1100px] overflow-hidden select-none">

--- a/components/parks/live-attraction-data.tsx
+++ b/components/parks/live-attraction-data.tsx
@@ -19,6 +19,7 @@ import { WaitTimeInfoCard } from '@/components/parks/wait-time-info-card';
 import { LocalTime } from '@/components/ui/local-time';
 import { GlossaryTermLink } from '@/components/glossary/glossary-term-link';
 import { useTranslations } from 'next-intl';
+import { useMounted } from '@/lib/hooks/use-mounted';
 import { cn } from '@/lib/utils';
 import type {
   ParkWithAttractions,
@@ -94,6 +95,9 @@ export function LiveAttractionData({
 }: LiveAttractionDataProps) {
   const t = useTranslations('attractions');
   const tCommon = useTranslations('common');
+  // Gate the live-refetch indicator on mount so SSR and first client render agree (the page is
+  // force-dynamic; the refetch-on-mount flips `isFetching` true and would otherwise mismatch).
+  const mounted = useMounted();
 
   const { park, attraction, isFetching, isError, error } = useLiveAttractionData({
     continent,
@@ -170,7 +174,7 @@ export function LiveAttractionData({
         </Card>
       )}
 
-      {isFetching && !isError && (
+      {mounted && isFetching && !isError && (
         <div className="text-muted-foreground mb-4 flex items-center gap-2 text-xs">
           <Loader2 className="h-3 w-3 animate-spin" />
           <span>{tCommon('updating')}</span>

--- a/components/parks/live-park-data.tsx
+++ b/components/parks/live-park-data.tsx
@@ -8,6 +8,7 @@ import { Separator } from '@/components/ui/separator';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslations } from 'next-intl';
+import { useMounted } from '@/lib/hooks/use-mounted';
 import { groupAttractionsByLand } from '@/lib/utils/park-utils';
 import type {
   ParkWithAttractions,
@@ -48,6 +49,10 @@ export function LiveParkData({
   bestDaysSlot,
 }: LiveParkDataProps) {
   const t = useTranslations('common');
+  // Gate the live-refetch indicator on mount: the server render (and first client render) must agree
+  // (both render the empty fixed-height slot), or the refetch-on-mount flipping `isFetching` true
+  // would cause a hydration mismatch on this force-dynamic page.
+  const mounted = useMounted();
 
   const {
     data: park,
@@ -124,7 +129,7 @@ export function LiveParkData({
           always present, so the indicator appearing/disappearing on every 5-min poll (and on the
           immediate refetch-on-mount) no longer shifts the status + tabs below it (CLS). */}
       <div className="mb-4 h-4">
-        {isFetching && !isError && (
+        {mounted && isFetching && !isError && (
           <div className="text-muted-foreground flex items-center gap-2 text-xs">
             <Loader2 className="h-3 w-3 animate-spin" />
             <span>{t('updating')}</span>

--- a/docs/troubleshooting/isr-write-explosion.md
+++ b/docs/troubleshooting/isr-write-explosion.md
@@ -1,0 +1,106 @@
+# ISR Write Explosion — Root Cause & Fix (Jun 2026)
+
+## Symptom
+
+Vercel ISR **Write Units** exploded from ~0 (≤ Jun 1) to 220–410K/day (Jun 3–7),
+83K units/12h. Writes ≫ reads on every park/attraction route. Persisted even with
+**no deploy for 24h**. Only **16** time-based revalidations in 12h → writes are NOT
+TTL churn.
+
+## Root cause
+
+`0f57934` (#118, **Jun 2**) _"make park & attraction pages static (ISR)"_ flipped the
+park + attraction pages from `ƒ Dynamic` (per-request, **zero ISR writes**) to
+`◐ Partial Prerender` (static shell persisted to the ISR durable store) by adding
+`generateStaticParams` + `revalidate`. This turned on an ISR **write per unique URL ×
+6 locales** across the whole catalog.
+
+Follow-up perf PRs (#129/#134/#142/#145/#146) only reduced write _frequency_ (7d TTL)
+and _size_ (lean shells). The write driver is neither — it's the **number of unique
+cold renders** (catalog × 6 locales) + **Vercel ISR eviction** (working set ≫ cache →
+re-MISS → re-write).
+
+## Proof (local `next build && next start`, `NEXT_PRIVATE_DEBUG_CACHE=1`)
+
+One **cold** attraction request writes **2 entries**:
+
+1. `FileSystemCache: set /<locale>/.../<attraction>` — the page **shell** (per-locale).
+2. `DefaultCacheHandler: set [...["continent","country","city","park"]]` — the
+   `getParkByGeoPath` **`use cache`** data entry (per-park, **shared across all 6
+   locales AND all that park's attractions**, 7d revalidate).
+
+- **Warm repeat hit** = cache HIT, **0 writes** (6.7ms vs 236ms). → caching works;
+  it's a cold-URL-volume problem, not a cache-key bug.
+- **2nd locale** of same park reuses the shared data entry (HIT) and only writes its
+  own shell. → the ×6 multiplier is **shell-only**.
+
+## Why "few requests → 1K write units"
+
+Write **units are size-weighted** and PPR stores **multiple files per render**
+(`.html` + `.rsc` + several `.segment.rsc` + `.meta`). Stored shell sizes:
+
+| Route                                 | HTML      | RSC   | ~per cold render                         |
+| ------------------------------------- | --------- | ----- | ---------------------------------------- |
+| Homepage `/en`                        | 400KB     | —     | heavy + **5min TTL** (constant rewriter) |
+| Park `europa-park`                    | 416KB     | 244KB | **~660KB+**                              |
+| Country `north-america/united-states` | **596KB** | —     | fat hub (see #130)                       |
+| Attraction `blue-fire`                | 196KB     | —     | smaller, but most numerous               |
+
+So a handful of cold renders of fat park/hub pages = many hundreds–1K write units.
+`.next/server/app` = **1.1GB across 2773 prerendered pages** (~400KB avg).
+
+The park-page RSC is fat (244KB) because the full park (all ~95 attractions) is
+serialized as `initialData` for `LiveParkData`.
+
+## Fix shipped (June 2026): off Cache Components → classic static/dynamic
+
+The billing is **per 8 KB written**, and under `cacheComponents: true` you cannot have
+_content-first first paint_ + _0 ISR writes_ for param-dependent pages (the trilemma:
+content in the shell ⇒ prerender ⇒ per-URL write; 0 writes ⇒ dynamic ⇒ Suspense skeleton
+or build error). `'use cache'` requires `cacheComponents`, so the fix was:
+
+1. **`cacheComponents` OFF** (`next.config.ts`). Back to the classic App Router model.
+2. **All `'use cache'` → `fetch` `next: { revalidate, tags }`** (the non-deprecated Data
+   Cache; `unstable_cache` is deprecated). Shared per-URL (e.g. per-park, not per-locale),
+   so the structure snapshot is cached cross-request and the backend isn't hammered.
+   - Exception: `getBestDaysCalendar` keeps `unstable_cache` — its raw calendar is ~2.25 MB,
+     over the 2 MB fetch-cache cap, so it caches the _projected_ ~13 KB result.
+   - `lib/utils/server-time.ts` helpers became plain (`new Date()` is legal without PPR).
+3. **Park + attraction + home → `export const dynamic = 'force-dynamic'`** → rendered per
+   request, **zero ISR shell writes**, full structure server-rendered into the first HTML
+   (content-first, no skeleton). `generateStaticParams` removed.
+4. **Content pages stay SSG** (glossary, glossary/[term], legal, hubs continent/country/city,
+   howto) via `generateStaticParams` — cheap static, never the write problem.
+
+### Verified locally (`next build && next start`, `NEXT_PRIVATE_DEBUG_CACHE=1`)
+
+- Build route table: park / attraction / home = `ƒ Dynamic`; hubs/glossary/legal = `●/○`.
+- Hitting many distinct park/attraction URLs → **0 `FileSystemCache: set`** (no per-URL ISR
+  shell writes). Cold park TTFB ~20–60 ms; structure HTML has `<h1>` + JSON-LD.
+
+### Gotchas hit during the migration
+
+- **best-days must NOT be server-fetched on the park page.** Its calendar is a large,
+  lazily-computed backend response (cold compute **10–20 s**); awaiting it in the page body
+  blocked the whole dynamic render's TTFB. It stays **client-loaded** (skeleton → trickles
+  in) via `useParkBestDaysCalendar` → the CDN-cached `/api/.../calendar` route.
+- **Hydration mismatch** on the live "updating" indicator (`isFetching`): on a force-dynamic
+  page the server render and the client's refetch-on-mount disagree. Fixed by gating the
+  indicator on `useMounted()` in `live-park-data.tsx` + `live-attraction-data.tsx`.
+- Hero image: deterministic per-5-min window (`Math.floor(Date.now()/300000) % HERO_IMAGES`)
+  — observably "cached 5 min" without cache infra, server-rendered for LCP.
+
+### Pre-existing dev warnings (NOT from this migration, separate follow-ups)
+
+- `NavigationProgress` `useInsertionEffect must not schedule updates` (patches `pushState`
+  then `setState` synchronously — from #141).
+- "Each child in a list should have a unique key" near `<LiveParkData>` (TabsWithHash/render
+  structure, unchanged by this work).
+
+## Notes
+
+- Production serves `x-vercel-mitigated: challenge` (Vercel WAF/BotID, HTTP 429) to
+  non-browser clients → `scripts/isr-cache-probe.mjs` can't run against prod; diagnose
+  via local `next start`.
+- Residual writes are now the small, shared **Data Cache** entries (fetch `next:{revalidate}`,
+  ~1 per park/region/day) — orders of magnitude below the per-locale ISR shell storm.

--- a/lib/api/analytics.ts
+++ b/lib/api/analytics.ts
@@ -1,17 +1,14 @@
-import { cacheLife } from 'next/cache';
 import { api } from './client';
 import type { GlobalStats, GeoLiveStatsDto, TickerResponse } from './types';
 
 /**
- * Get global real-time statistics — cached 10 min (Cache Components).
- *
- * Streamed inside a homepage <Suspense> hole (low cardinality — one shared key), so this is a
- * minor ISR-write contributor; the 10-min window still keeps the aggregate fresh enough.
+ * Get global real-time statistics — cached 10 min in the Vercel Data Cache.
+ * Streamed inside a homepage <Suspense> hole (one shared key).
  */
-export async function getGlobalStats(): Promise<GlobalStats> {
-  'use cache';
-  cacheLife({ stale: 600, revalidate: 600, expire: 1800 });
-  return api.get<GlobalStats>('/v1/analytics/realtime');
+export function getGlobalStats(): Promise<GlobalStats> {
+  return api.get<GlobalStats>('/v1/analytics/realtime', {
+    next: { revalidate: 600, tags: ['analytics'] },
+  });
 }
 
 /**
@@ -19,17 +16,17 @@ export async function getGlobalStats(): Promise<GlobalStats> {
  * concurrent visitors collapse onto one backend call per window (shared with the
  * /api/analytics/ticker proxy).
  */
-export async function getTickerData(): Promise<TickerResponse> {
-  'use cache';
-  cacheLife({ stale: 600, revalidate: 600, expire: 1800 });
-  return api.get<TickerResponse>('/v1/analytics/ticker');
+export function getTickerData(): Promise<TickerResponse> {
+  return api.get<TickerResponse>('/v1/analytics/ticker', {
+    next: { revalidate: 600, tags: ['analytics'] },
+  });
 }
 
 /**
  * Get live statistics for geographic regions — cached 10 min.
  */
-export async function getGeoLiveStats(): Promise<GeoLiveStatsDto> {
-  'use cache';
-  cacheLife({ stale: 600, revalidate: 600, expire: 1800 });
-  return api.get<GeoLiveStatsDto>('/v1/analytics/geo-live');
+export function getGeoLiveStats(): Promise<GeoLiveStatsDto> {
+  return api.get<GeoLiveStatsDto>('/v1/analytics/geo-live', {
+    next: { revalidate: 600, tags: ['analytics'] },
+  });
 }

--- a/lib/api/discovery.ts
+++ b/lib/api/discovery.ts
@@ -1,4 +1,3 @@
-import { cacheLife } from 'next/cache';
 import { api } from './client';
 import { CACHE_TTL } from './cache-config';
 import type {
@@ -13,70 +12,56 @@ import type {
 } from './types';
 
 /**
- * Get complete geographic structure. Cached (geo changes rarely); used for static generation.
- * `revalidate` keys a distinct cache lifetime (e.g. the sitemap asks for 24h).
+ * Get complete geographic structure. Cached in the Vercel Data Cache (geo changes rarely);
+ * used for static generation. `revalidate` keys the cache lifetime (e.g. the sitemap asks for 24h).
  */
-export async function getGeoStructure(revalidate: number = CACHE_TTL.geo): Promise<GeoStructure> {
-  'use cache';
-  cacheLife({ stale: revalidate, revalidate, expire: revalidate * 4 });
-  return api.get<GeoStructure>('/v1/discovery/geo');
+export function getGeoStructure(revalidate: number = CACHE_TTL.geo): Promise<GeoStructure> {
+  return api.get<GeoStructure>('/v1/discovery/geo', { next: { revalidate, tags: ['geo'] } });
 }
 
 /**
  * Get all continents.
  */
-export async function getContinents(): Promise<Continent[]> {
-  'use cache';
-  cacheLife({
-    stale: CACHE_TTL.continents,
-    revalidate: CACHE_TTL.continents,
-    expire: CACHE_TTL.continents * 4,
+export function getContinents(): Promise<Continent[]> {
+  return api.get<Continent[]>('/v1/discovery/continents', {
+    next: { revalidate: CACHE_TTL.continents, tags: ['geo'] },
   });
-  return api.get<Continent[]>('/v1/discovery/continents');
 }
 
 /**
  * Get countries in a continent with hydrated park data and breadcrumbs.
  */
-export async function getCountriesWithParks(
-  continentSlug: string
-): Promise<DiscoveryCountryResponse> {
-  'use cache';
-  cacheLife({
-    stale: CACHE_TTL.continents,
-    revalidate: CACHE_TTL.continents,
-    expire: CACHE_TTL.continents * 4,
+export function getCountriesWithParks(continentSlug: string): Promise<DiscoveryCountryResponse> {
+  return api.get<DiscoveryCountryResponse>(`/v1/discovery/continents/${continentSlug}`, {
+    next: { revalidate: CACHE_TTL.continents, tags: ['geo'] },
   });
-  return api.get<DiscoveryCountryResponse>(`/v1/discovery/continents/${continentSlug}`);
 }
 
 /**
  * Get cities in a country with hydrated park data and breadcrumbs.
  */
-export async function getCitiesWithParks(
+export function getCitiesWithParks(
   continentSlug: string,
   countrySlug: string
 ): Promise<DiscoveryCityResponse> {
-  'use cache';
-  cacheLife({
-    stale: CACHE_TTL.continents,
-    revalidate: CACHE_TTL.continents,
-    expire: CACHE_TTL.continents * 4,
-  });
-  return api.get<DiscoveryCityResponse>(`/v1/discovery/continents/${continentSlug}/${countrySlug}`);
+  return api.get<DiscoveryCityResponse>(
+    `/v1/discovery/continents/${continentSlug}/${countrySlug}`,
+    { next: { revalidate: CACHE_TTL.continents, tags: ['geo'] } }
+  );
 }
 
 /**
  * Get all attractions for sitemap generation. Cached 24h. Returns flat array of { url, slug }.
  */
-export async function getSitemapAttractions(): Promise<SitemapAttraction[]> {
-  'use cache';
-  cacheLife({ stale: 86400, revalidate: 86400, expire: 86400 * 2 });
-  return api.get<SitemapAttraction[]>('/v1/sitemap/attractions');
+export function getSitemapAttractions(): Promise<SitemapAttraction[]> {
+  return api.get<SitemapAttraction[]>('/v1/sitemap/attractions', {
+    next: { revalidate: 86400, tags: ['geo'] },
+  });
 }
 
 /**
- * Find parks near a geographic location using coordinate-based proximity.
+ * Find parks near a geographic location using coordinate-based proximity. Cached (proximity +
+ * structure is week-stable; live status is overlaid client-side via LiveNearbyParks).
  *
  * Uses a tiny latitude offset (+0.001°, ~111m) so the query point sits just
  * outside any park's center, ensuring the API always returns a "nearby_parks"
@@ -88,19 +73,13 @@ export async function getSitemapAttractions(): Promise<SitemapAttraction[]> {
  * @param limit - Number of parks to return (default 3)
  * @param maxDistanceM - Maximum distance in meters; parks beyond this are excluded (default 300km)
  */
-export async function getParksNearLocation(
+export function getParksNearLocation(
   lat: number,
   lng: number,
   excludeParkId?: string,
   limit: number = 3,
   maxDistanceM: number = 300_000
 ): Promise<NearbyParkItem[]> {
-  'use cache';
-  // Read in the PARK page's static shell (NearbyParksSection) — its cacheLife is part of the MIN
-  // that pins the park route's revalidate, so a shorter TTL silently caps the park shell. The seed
-  // here is proximity + structure only (status-free); live status is overlaid client-side
-  // (LiveNearbyParks), and geo proximity is week-stable, so 7d matches the park shell's TTL.
-  cacheLife({ stale: 604800, revalidate: 604800, expire: 604800 * 4 });
   return fetchParksNearLocation(lat, lng, excludeParkId, limit, maxDistanceM, false);
 }
 
@@ -148,7 +127,7 @@ async function fetchParksNearLocation(
   try {
     const response = await api.get<NearbyApiResponse>(
       endpoint,
-      fresh ? { cache: 'no-store' } : undefined
+      fresh ? { cache: 'no-store' } : { next: { revalidate: 604800, tags: ['geo'] } }
     );
 
     if (response.type !== 'nearby_parks' || !response.data.parks) {
@@ -169,14 +148,9 @@ async function fetchParksNearLocation(
  * Use getCountriesWithParks when you need full park data per country.
  */
 export async function getCountriesInContinent(continentSlug: string): Promise<Country[]> {
-  'use cache';
-  cacheLife({
-    stale: CACHE_TTL.continents,
-    revalidate: CACHE_TTL.continents,
-    expire: CACHE_TTL.continents * 4,
-  });
   const response = await api.get<{ data?: Country[]; countries?: Country[] }>(
-    `/v1/discovery/continents/${continentSlug}`
+    `/v1/discovery/continents/${continentSlug}`,
+    { next: { revalidate: CACHE_TTL.continents, tags: ['geo'] } }
   );
   // Handle both old array format and new {data} format
   if (Array.isArray(response)) {
@@ -189,13 +163,12 @@ export async function getCountriesInContinent(continentSlug: string): Promise<Co
  * Get country summary with top parks, peak/quiet months — for SEO landing pages.
  * Cached 24h — data is aggregated from ParkDailyStats, changes daily at most.
  */
-export async function getCountrySummary(
+export function getCountrySummary(
   continentSlug: string,
   countrySlug: string
 ): Promise<CountrySummary> {
-  'use cache';
-  cacheLife({ stale: 86400, revalidate: 86400, expire: 86400 * 2 });
   return api.get<CountrySummary>(
-    `/v1/discovery/continents/${continentSlug}/${countrySlug}/summary`
+    `/v1/discovery/continents/${continentSlug}/${countrySlug}/summary`,
+    { next: { revalidate: 86400, tags: ['geo'] } }
   );
 }

--- a/lib/api/ml.ts
+++ b/lib/api/ml.ts
@@ -1,25 +1,23 @@
-import { cacheLife } from 'next/cache';
 import { api } from './client';
 import type { MLDashboardDto, ModelMetricsHistoryResponse } from './types';
 
 /**
  * Get ML model dashboard — accuracy, coverage, model health.
- * Changes only on model retraining; cached 30 min.
+ * Changes only on model retraining; cached 30 min in the Vercel Data Cache.
  */
-export async function getMLDashboard(): Promise<MLDashboardDto> {
-  'use cache';
-  cacheLife({ stale: 1800, revalidate: 1800, expire: 7200 });
-  return api.get<MLDashboardDto>('/v1/ml/dashboard');
+export function getMLDashboard(): Promise<MLDashboardDto> {
+  return api.get<MLDashboardDto>('/v1/ml/dashboard', {
+    next: { revalidate: 1800, tags: ['ml'] },
+  });
 }
 
 /**
  * Get ML model metrics history for sparklines (oldest first, up to `limit`).
  * Cached 30 min — training runs once daily at 06:00 UTC.
  */
-export async function getMLMetricsHistory(limit = 50): Promise<ModelMetricsHistoryResponse> {
-  'use cache';
-  cacheLife({ stale: 1800, revalidate: 1800, expire: 7200 });
+export function getMLMetricsHistory(limit = 50): Promise<ModelMetricsHistoryResponse> {
   return api.get<ModelMetricsHistoryResponse>('/v1/ml/models/metrics-history', {
     params: { limit },
+    next: { revalidate: 1800, tags: ['ml'] },
   });
 }

--- a/lib/api/parks.ts
+++ b/lib/api/parks.ts
@@ -1,30 +1,16 @@
-import { cacheLife } from 'next/cache';
 import { api, ApiError } from './client';
 import type { ParkWithAttractions, AttractionResponse, PopularPark } from './types';
 
-// Shell-level TTL for the park/attraction static prerender. Deliberately DECOUPLED from the
-// API's 5-min live cadence: the wait times + open/closed status baked into the shell are only an
-// SSR seed that LiveParkData / LiveAttractionData replace client-side (React Query, no-store, 5-min
-// poll + refetch on mount/focus — see use-live-park-data.ts). So for any visitor with JS the shell
-// TTL is invisible; it only governs the first-paint seed, no-JS visitors and crawlers. Under Cache
-// Components the effective revalidate of a route shell is the MIN cacheLife of the 'use cache' reads
-// in its static portion, so these values are the floor that drives the dominant per-park /
-// per-attraction × per-locale ISR-write volume.
-//
-// Context: park/attraction pages were dynamic (no ISR writes) until they were switched to static
-// ISR with revalidate:300 — which is what turned ISR writes on across the whole catalog × 6 locales.
-//
-// Both shells revalidate every 7 DAYS. The shell carries only day-stable, SEO-relevant structure
-// (name, attraction list + links, FAQ, JSON-LD, summary stats); every "today/now" value and all
-// live data (status, wait times, weather, history, forecast) is CLIENT-derived (useBrowserNow /
-// React Query no-store polls via getParkByGeoPathFresh), so a 7-day-old shell never shows stale
-// live data to a JS visitor — it only seeds first paint, no-JS visitors and crawlers, which change
-// at most when a ride is added/removed. 7 days cuts the time-based per-park/per-attraction ×
-// per-locale ISR-write FREQUENCY ~7× vs 1 day; on-demand revalidation (a backend webhook →
-// revalidateTag) can later push it toward ∞. Cold renders are avoided by prebuilding all parks
-// (generateStaticParams) + the prewarm cron, so the long TTL has no first-paint downside.
-const PARK_MAX_AGE = 604800; // 7d park shell TTL — live data is client-side
-const ATTRACTION_MAX_AGE = 604800; // 7d attraction shell TTL — live data is client-side
+// Data-cache (`fetch` `next: { revalidate }`) windows for the park/attraction structure fetch.
+// The park & attraction PAGES are `force-dynamic` (rendered per request → no per-URL ISR shell
+// writes — see their page.tsx). These cached fetches only shield the backend: the structure
+// (name, attraction list, FAQ, summary stats) is shared across all 6 locales of a park and revalidated
+// once per window via stale-while-revalidate. Every live value (status, wait times, weather, history,
+// forecast) is CLIENT-derived (React Query no-store polls via getParkByGeoPathFresh), so a day-old
+// structure snapshot never shows stale live data to a JS visitor. 1 day keeps new rides appearing in
+// the SSR/SEO HTML within ~24h while keeping data-cache writes negligible (shared per park).
+const PARK_REVALIDATE = 86400; // 1d — structure snapshot; live data is client-side
+const ATTRACTION_REVALIDATE = 86400; // 1d
 
 /**
  * Trim for the LIVE (no-store) client poll: drop only attraction-detail-only fields the park/
@@ -71,24 +57,21 @@ function leanParkForShell(park: ParkWithAttractions): ParkWithAttractions {
 }
 
 /**
- * Get parks by geographic path. Cached via Cache Components (`'use cache'`):
- * the static shell of the park page captures this snapshot; live wait times are
- * refreshed client-side by LiveParkData.
+ * Get parks by geographic path. Cached in the Vercel Data Cache via `fetch` `next: { revalidate }`
+ * (stale-while-revalidate, 1-day window): the per-request `force-dynamic` park/attraction render
+ * reads this shared snapshot (keyed by the backend URL — NOT the locale, so all 6 locales of a park
+ * share one entry) so the backend isn't hit on every render; live wait times are refreshed
+ * client-side by LiveParkData.
  *
- * Returns `null` for a non-existent park (API 404). The 404 MUST be caught inside this
- * `'use cache'` boundary: an error thrown across a `'use cache'` boundary bypasses the caller's
- * `try`/`catch` (and `catchNonFatal`) and surfaces as a 500 instead of letting the caller render
- * `notFound()` — so a missing park would 500 rather than 404. Other errors (maintenance/network)
- * still propagate.
+ * Returns `null` for a non-existent park (API 404). The 404 is caught inside `fetchParkByGeoPath`
+ * (returns `null`) so the caller can render `notFound()`; other errors (maintenance/network) propagate.
  */
-export async function getParkByGeoPath(
+export function getParkByGeoPath(
   continent: string,
   country: string,
   city: string,
   parkSlug: string
 ): Promise<ParkWithAttractions | null> {
-  'use cache';
-  cacheLife({ stale: PARK_MAX_AGE, revalidate: PARK_MAX_AGE, expire: PARK_MAX_AGE * 4 });
   return fetchParkByGeoPath(continent, country, city, parkSlug, false);
 }
 
@@ -120,7 +103,7 @@ async function fetchParkByGeoPath(
   try {
     const park = await api.get<ParkWithAttractions>(
       `/v1/parks/${continent}/${country}/${city}/${parkSlug}`,
-      fresh ? { cache: 'no-store' } : undefined
+      fresh ? { cache: 'no-store' } : { next: { revalidate: PARK_REVALIDATE, tags: ['parks'] } }
     );
     // The ISR shell gets the aggressive trim (drops statistics.history — the biggest size-weighted
     // ISR-write chunk); the live no-store poll keeps the full per-attraction data for the cards.
@@ -133,10 +116,10 @@ async function fetchParkByGeoPath(
 
 /**
  * Get a specific attraction by geographic path with full data including history.
- * Cached via Cache Components; live wait times are refreshed client-side.
+ * Cached in the Vercel Data Cache via `fetch` `next: { revalidate }`; live wait times are refreshed
+ * client-side.
  *
- * Returns `null` on a 404 for the same reason as {@link getParkByGeoPath} (a throw across the
- * `'use cache'` boundary would 500 instead of letting the caller render `notFound()`).
+ * Returns `null` on a 404 so the caller can render `notFound()`.
  */
 export async function getAttractionByGeoPath(
   continent: string,
@@ -145,15 +128,10 @@ export async function getAttractionByGeoPath(
   parkSlug: string,
   attractionSlug: string
 ): Promise<AttractionResponse | null> {
-  'use cache';
-  cacheLife({
-    stale: ATTRACTION_MAX_AGE,
-    revalidate: ATTRACTION_MAX_AGE,
-    expire: ATTRACTION_MAX_AGE * 4,
-  });
   try {
     return await api.get<AttractionResponse>(
-      `/v1/parks/${continent}/${country}/${city}/${parkSlug}/attractions/${attractionSlug}`
+      `/v1/parks/${continent}/${country}/${city}/${parkSlug}/attractions/${attractionSlug}`,
+      { next: { revalidate: ATTRACTION_REVALIDATE, tags: ['attractions'] } }
     );
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) return null;
@@ -197,8 +175,9 @@ export async function getAttractionByGeoPathFresh(
  * generateStaticParams + the homepage/featured seed, so a tighter window was pure write churn.
  * @param limit clamped to 1–100 by the API (default 20)
  */
-export async function getPopularParks(limit = 20): Promise<PopularPark[]> {
-  'use cache';
-  cacheLife({ stale: 1800, revalidate: 1800, expire: 7200 });
-  return api.get<PopularPark[]>('/v1/parks/popular', { params: { limit } });
+export function getPopularParks(limit = 20): Promise<PopularPark[]> {
+  return api.get<PopularPark[]>('/v1/parks/popular', {
+    params: { limit },
+    next: { revalidate: 1800, tags: ['popular-parks'] },
+  });
 }

--- a/lib/api/stats.ts
+++ b/lib/api/stats.ts
@@ -1,4 +1,3 @@
-import { cacheLife } from 'next/cache';
 import { getServerAuthHeaders } from '@/lib/api/client';
 import type { ParkHistoricalStats } from '@/lib/api/types';
 
@@ -33,15 +32,10 @@ export async function getParkHistoricalStats(
   parkSlug: string,
   years = 2
 ): Promise<ParkHistoricalStats | null> {
-  'use cache';
-  // Cached (Cache Components). This is now invoked from the `/api/parks/.../stats` route handler
-  // (the park page loads stats CLIENT-side), so the slow cold-compute never touches the park
-  // page's static prerender. The retry loop below warms a cold-compute backend WITHIN a single
-  // fill, so a successful aggregate is returned on first load — and the data only changes daily.
-  // A 5-min window was therefore pure ISR-write churn (288 writes/day per park key); 1h cuts that
-  // ~12× while still re-attempting a genuine null (too-little-data) park within the hour.
-  cacheLife({ stale: 3600, revalidate: 3600, expire: 14400 });
-
+  // Invoked from the `/api/parks/.../stats` route handler (the park page loads stats CLIENT-side),
+  // which is CDN-cached (Cache-Control s-maxage=3600 — see next.config.ts), so caching happens at
+  // that edge layer. The retry loop below warms a cold-compute backend WITHIN a single request, so
+  // a successful aggregate is returned on first load; the CDN then serves it for the hour.
   const url = `${getApiBaseUrl()}/v1/parks/${continent}/${country}/${city}/${parkSlug}/stats?years=${years}`;
 
   for (let attempt = 0; attempt < RETRY_DELAYS_MS.length; attempt++) {

--- a/lib/api/weather-nowcast.ts
+++ b/lib/api/weather-nowcast.ts
@@ -1,20 +1,15 @@
-import { cacheLife } from 'next/cache';
 import { api, ApiError } from './client';
 import type { WeatherNowcast } from './types';
 
-// Shell-seed TTL for the cached nowcast. The API itself sets Cache-Control: max-age=900 (15 min),
-// but this cached copy only seeds the park-page static shell — `useWeatherNowcast` replaces it
-// client-side on mount via the uncached `getParkWeatherNowcastFresh` poll. Pinning it at 900 made
-// it the MIN cacheLife in the park shell, capping the whole park route's revalidate at 15 min and
-// undercutting the 1h park TTL (see PARK_MAX_AGE). 1h here lets the park shell actually reach its
-// intended floor; the live banner stays fresh via the client poll regardless.
+// Data-cache window for the cached nowcast seed. The live banner is refreshed client-side via the
+// uncached `getParkWeatherNowcastFresh` poll, so this only seeds first paint / no-JS / crawlers.
 const NOWCAST_SEED_TTL = 3600;
 
 /**
  * Get short-term (next ~2h) weather nowcast for a park.
  * Returns null if nowcast is unavailable (404 — missing coordinates or upstream down).
- * Cached 1h (Cache Components) so the park-page static shell can bake in a seed; the live banner
- * is refreshed client-side (see getParkWeatherNowcastFresh / useWeatherNowcast).
+ * Cached 1h in the Vercel Data Cache (`fetch` `next: { revalidate }`); the live banner is refreshed
+ * client-side (see getParkWeatherNowcastFresh / useWeatherNowcast).
  */
 export async function getParkWeatherNowcast(
   continent: string,
@@ -22,11 +17,10 @@ export async function getParkWeatherNowcast(
   city: string,
   parkSlug: string
 ): Promise<WeatherNowcast | null> {
-  'use cache';
-  cacheLife({ stale: NOWCAST_SEED_TTL, revalidate: NOWCAST_SEED_TTL, expire: NOWCAST_SEED_TTL * 2 });
   try {
     return await api.get<WeatherNowcast>(
-      `/v1/parks/${continent}/${country}/${city}/${parkSlug}/weather/nowcast`
+      `/v1/parks/${continent}/${country}/${city}/${parkSlug}/weather/nowcast`,
+      { next: { revalidate: NOWCAST_SEED_TTL, tags: ['weather'] } }
     );
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) {

--- a/lib/glossary/parse-segments.ts
+++ b/lib/glossary/parse-segments.ts
@@ -62,10 +62,7 @@ function buildPatternFragment(pattern: string): string {
   return `\\b${escaped}${trailingBoundary}`;
 }
 
-export function parseGlossarySegments(
-  text: string,
-  terms: GlossaryMatchTerm[]
-): GlossarySegment[] {
+export function parseGlossarySegments(text: string, terms: GlossaryMatchTerm[]): GlossarySegment[] {
   const entries = buildMatchEntries(terms);
   if (entries.length === 0) return [{ type: 'text', content: text }];
 

--- a/lib/hooks/use-region-parks.ts
+++ b/lib/hooks/use-region-parks.ts
@@ -1,5 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import type { DiscoveryCityResponse, ParkStatus, CrowdLevel, ScheduleSummary } from '@/lib/api/types';
+import type {
+  DiscoveryCityResponse,
+  ParkStatus,
+  CrowdLevel,
+  ScheduleSummary,
+} from '@/lib/api/types';
 
 /** Live, per-park fields the hub ParkCards overlay client-side (everything that can change during the day). */
 export interface LiveParkFields {

--- a/lib/utils/redirect-utils.ts
+++ b/lib/utils/redirect-utils.ts
@@ -9,27 +9,17 @@
  */
 
 import { cache } from 'react';
-import { cacheLife } from 'next/cache';
 import { getGeoStructure } from '@/lib/api/discovery';
 
 /**
- * O(1) park-slug → geo-path index for redirect lookups, cached via Cache Components.
- * Returns a plain Record (serializable across the cache boundary). Refreshes daily.
- *
- * This index is read in the PARK page's static shell (findParkPageRedirect), so its cacheLife is
- * part of the MIN that pins the park route's revalidate. The data is week-stable (geo paths / park
- * slugs change very rarely), so 'weeks' lets the park shell reach its intended 7-day TTL instead of
- * being capped at 1 day.
+ * O(1) park-slug → geo-path index for redirect lookups. Memoized per request via React `cache()`;
+ * the underlying `getGeoStructure(604800)` is itself cached cross-request in the Vercel Data Cache
+ * (`fetch` `next: { revalidate }`), so rebuilding this small index per request is cheap and never
+ * hits the backend. Used only for malformed-URL redirect detection, never to serve a valid park.
  */
-async function getParkSlugIndex(): Promise<Record<string, ParkLookupResult>> {
-  'use cache';
-  cacheLife('weeks');
-
+const getParkSlugIndex = cache(async (): Promise<Record<string, ParkLookupResult>> => {
   const index: Record<string, ParkLookupResult> = {};
   try {
-    // 7-day cache: this nested 'use cache' read is part of the park route's MIN revalidate, so a
-    // shorter geo TTL here would cap the 7-day park shell (geo paths are week-stable; only used for
-    // malformed-URL redirect detection, never to serve a valid park).
     const data = await getGeoStructure(604800);
     for (const continent of data.continents) {
       for (const country of continent.countries) {
@@ -49,7 +39,7 @@ async function getParkSlugIndex(): Promise<Record<string, ParkLookupResult>> {
     console.error('[RedirectUtils] Failed to fetch geo structure:', error);
   }
   return index;
-}
+});
 
 export interface ParkLookupResult {
   continent: string;

--- a/lib/utils/server-time.ts
+++ b/lib/utils/server-time.ts
@@ -1,47 +1,26 @@
-import { cacheLife } from 'next/cache';
-
 /**
- * Cache-Components-safe "current time" helpers.
+ * Server-side "current time" helpers.
  *
- * Under `cacheComponents`, reading `new Date()` / `Date.now()` directly in a server
- * render is forbidden (it would bake a non-deterministic value into the static shell).
- * These helpers read the clock inside a `'use cache'` boundary, so the value is captured
- * at cache-fill time and refreshed on the given cadence — correct for display values
- * (copyright year, "today") where a few minutes/hours of staleness is fine. For truly
- * live values (countdowns, "x min ago"), use a Client Component instead.
+ * With Cache Components disabled, server code may read `new Date()` / `Date.now()` directly. On the
+ * `force-dynamic` park/attraction/home pages these resolve per request (always fresh); on the
+ * statically-prerendered pages (Footer year, etc.) they resolve at build time, which is fine for
+ * display values where day/year granularity is enough. For truly live values (countdowns,
+ * "x min ago"), use a Client Component instead.
+ *
+ * They remain `async` so existing `await` call sites and `Promise` return types are unaffected.
  */
 
-/**
- * Current calendar year (for copyright lines). Read in the Footer, which is part of EVERY route's
- * static prerender — so its cacheLife is a global MIN that pins every route's revalidate. At 'days'
- * it silently capped park/attraction at 1-day (defeating the 7-day shell TTL). 'weeks' lifts that
- * floor; the year still self-corrects within a week of Jan 1, which is plenty for a footer.
- */
+/** Current calendar year (for copyright lines). */
 export async function getCurrentYear(): Promise<number> {
-  'use cache';
-  cacheLife('weeks');
   return new Date().getFullYear();
 }
 
-/**
- * Current epoch milliseconds, captured at cache-fill time. Refreshes daily.
- *
- * Consumers only need day-granular precision (calendar month boundaries, "today's" schedule
- * lookup, the yyyy-MM-dd date in structured data). This is read in the park/attraction static
- * shell, so its cacheLife is the MIN that pins the whole route's revalidate: at 'hours' it
- * silently capped park/attraction at a 1h revalidate, defeating the intended 6h TTL (a hidden
- * per-park × per-locale write multiplier). 'days' lifts that floor so the 6h shell TTL actually
- * applies; for truly live values use a Client Component instead.
- */
+/** Current epoch milliseconds. */
 export async function getServerNowMs(): Promise<number> {
-  'use cache';
-  cacheLife('days');
   return Date.now();
 }
 
-/** Today's date as `YYYY-MM-DD` in the given IANA timezone. Refreshes hourly. */
+/** Today's date as `YYYY-MM-DD` in the given IANA timezone. */
 export async function getServerToday(timeZone: string): Promise<string> {
-  'use cache';
-  cacheLife('hours');
   return new Intl.DateTimeFormat('en-CA', { timeZone }).format(new Date());
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,10 +6,12 @@ const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
 const nextConfig: NextConfig = {
   poweredByHeader: false,
-  // Cache Components (Next 16, successor to experimental.ppr): static, edge-cacheable
-  // shells + streamed dynamic holes. Data caching is via `'use cache'` + `cacheLife`
-  // (see lib/api/*), dynamic work sits behind <Suspense>.
-  cacheComponents: true,
+  // Cache Components (PPR) is intentionally OFF. The high-traffic detail pages (park, attraction,
+  // home) are `export const dynamic = 'force-dynamic'` — rendered per request so there is NO per-URL
+  // ISR shell write (the catalog × 6-locale write explosion that PPR caused). Content is server-
+  // rendered (content-first, no skeleton); live data is client-loaded (React Query → CDN-cached /api
+  // routes). Server data fetches are cached in the Vercel Data Cache via `fetch` `next:{revalidate}`
+  // (see lib/api/*). Content pages (glossary, legal, hubs) stay static via generateStaticParams.
   staticPageGenerationTimeout: 180,
   compiler: {
     // Remove React properties that are not needed in production


### PR DESCRIPTION
Kills the ISR write-unit spikes (~220–410K/day since #118). Vercel bills writes per 8KB; static-ISR park/attraction × 6 locales wrote a shell per crawled URL. cacheComponents can't give content-first + 0 writes (trilemma), so move off it:

- cacheComponents: false (next.config.ts)
- park + attraction + home → export const dynamic = 'force-dynamic' (per-request render, 0 ISR shell writes, structure server-rendered)
- all 'use cache' → fetch next:{revalidate,tags} (non-deprecated Data Cache; verified it still caches under force-dynamic). best-days keeps unstable_cache (raw calendar > 2MB fetch-cache cap).
- server-time helpers → plain (no PPR constraint)
- content pages (glossary/legal/hubs) stay SSG
- hero: deterministic 5-min window pick
- fix hydration mismatch: gate live 'updating' indicator on useMounted (live-park-data, live-attraction-data)
- key on best-days slot

Verified locally: park/attraction/home = ƒ; 0 FileSystemCache:set on distinct URLs; same-park double-hit = Data Cache HIT; cold TTFB ~20–70ms; lint clean. Docs: docs/troubleshooting/isr-write-explosion.md