### PR TITLE
fix(park): live status badge in ParkTimeInfo (was showing stale GESCHLOSSEN)

### DIFF
--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -310,6 +310,10 @@ export default async function ParkPage({ params }: ParkPageProps) {
                 nextSchedule={park.nextSchedule}
                 status={park.status}
                 hasOperatingSchedule={park.hasOperatingSchedule}
+                continent={continent}
+                country={country}
+                city={city}
+                parkSlug={parkSlug}
                 className="border-primary/10"
               />
             </Suspense>

--- a/components/parks/park-time-info.tsx
+++ b/components/parks/park-time-info.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { ParkStatusBadge } from '@/components/parks/park-status-badge';
+import { useLiveParkData } from '@/lib/hooks/use-live-park-data';
 import type { ParkStatus } from '@/lib/api/types';
 import { ParkTimeRange } from '@/components/common/park-time';
 import { GlossaryTermLink } from '@/components/glossary/glossary-term-link';
@@ -21,6 +22,14 @@ interface ParkTimeInfoProps {
   nextSchedule?: NextScheduleItem | null;
   status?: ParkStatus | null;
   hasOperatingSchedule?: boolean;
+  /** Geo-routing params — when provided, the card subscribes to the live park query (shared key
+   *  with LiveParkData → no extra fetch) so the status badge + schedule reflect the live state
+   *  instead of the up-to-1-day-stale server snapshot baked into the data-cache. Omitted by the
+   *  demo/mock showcases, which keep the static props. */
+  continent?: string;
+  country?: string;
+  city?: string;
+  parkSlug?: string;
   className?: string;
 }
 
@@ -32,10 +41,14 @@ interface ParkTimeInfoProps {
  */
 export function ParkTimeInfo({
   timezone,
-  schedule,
-  nextSchedule,
-  status,
-  hasOperatingSchedule = true,
+  schedule: scheduleProp,
+  nextSchedule: nextScheduleProp,
+  status: statusProp,
+  hasOperatingSchedule: hasOperatingScheduleProp = true,
+  continent,
+  country,
+  city,
+  parkSlug,
   className,
 }: ParkTimeInfoProps) {
   const t = useTranslations('parks');
@@ -43,6 +56,26 @@ export function ParkTimeInfo({
   const tNearby = useTranslations('nearby');
   const locale = useLocale();
   const currentTime = useBrowserNow(60_000);
+
+  // The park structure (incl. `status` and `schedule`) is baked into the 1-day data-cache snapshot,
+  // so the server-rendered props can be up to a day stale — which previously left this badge showing
+  // GESCHLOSSEN while the park was actually open. Subscribe to the same live park query LiveParkData
+  // polls (shared React Query key → no extra fetch) and prefer its fresh values; fall back to the
+  // props until the live poll lands (and for the demo/mock usages that pass no geo params), so SSR and
+  // the first client render still agree.
+  const hasParams = !!(continent && country && city && parkSlug);
+  const { data: livePark } = useLiveParkData({
+    continent: continent ?? '',
+    country: country ?? '',
+    city: city ?? '',
+    parkSlug: parkSlug ?? '',
+    enabled: hasParams,
+  });
+  const status = (hasParams ? livePark?.status : null) ?? statusProp;
+  const schedule = (hasParams ? livePark?.schedule : null) ?? scheduleProp;
+  const nextSchedule = (hasParams ? livePark?.nextSchedule : null) ?? nextScheduleProp;
+  const hasOperatingSchedule =
+    (hasParams ? livePark?.hasOperatingSchedule : undefined) ?? hasOperatingScheduleProp;
 
   // Pick today's schedule entry CLIENT-side (from the browser clock in the park's timezone) so the
   // static shell never reads the server clock. Before mount we fall back to the first entry — same


### PR DESCRIPTION
## Problem

On the park detail page (e.g. [Phantasialand](https://park.fan/de/parks/europe/germany/bruehl/phantasialand)) the **"Heutige Öffnungszeiten"** card showed a **GESCHLOSSEN** badge while the park was actually open — and right next to it the client-computed *"Schließt in 5 Std 8 Min"* countdown and the live wait-time/crowd cards correctly treated the park as **open**.

## Root cause

Since the park page went `force-dynamic` over a **1-day data-cache snapshot** (#140 / #147), the design intent is that *every* live value is client-derived (the comment in `lib/api/parks.ts` says so explicitly). `WeatherCard` was correctly wired to subscribe to the live park query for fresh weather — but **`ParkTimeInfo` was missed**. It rendered `status` / `schedule` straight from the up-to-1-day-stale server snapshot via props and never subscribed to the live query, so its badge froze at whatever the snapshot last baked in.

## Fix

`ParkTimeInfo` now subscribes to the same `useLiveParkData` query `LiveParkData` polls (shared React Query key → **no extra fetch**) and prefers its fresh `status` / `schedule` / `nextSchedule` / `hasOperatingSchedule`, falling back to the props until the live poll lands — and for the demo/mock showcases that pass no geo params, so SSR and the first client render still agree (no hydration mismatch). This is the exact pattern already used by `WeatherCard`, `LiveNearbyParks` and `LiveParkGrid`.

## Rides — checked, already correct

- **Park-page ride list:** `tabs-with-hash` → `LandSection` → `AttractionCard` receives `parkStatus={park.status}` where `park` is the **live** `currentPark` from `LiveParkData`. ✅
- **Attraction detail page:** status/wait times come from `LiveAttractionData` (live poll). ✅
- **Home / hub / nearby grids:** all seed status-free and overlay live status client-side (`LiveParkGrid`, `LiveNearbyParks`, `LiveActivityGrid`, featured parks). ✅

So the stale-badge regression was isolated to `ParkTimeInfo`.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on changed files

https://claude.ai/code/session_01Q3pqBRVkdbUuNsKtJcBUMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3pqBRVkdbUuNsKtJcBUMF)_