### PR TITLE
fix(i18n): korrigiere kaputte deutsche Schulferien-Warnung

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -513,7 +513,7 @@
       "subtitle": "Basierend auf KI-Crowd-Prognosen für die nächsten 3 Monate",
       "quietestDaysTitle": "Ruhigste Wochentage",
       "upcomingQuietTitle": "Kommende ruhige Tage",
-      "schoolHolidayWarning": "Schulferien sind am {park} typischerweise deutlich voller — prüfe den Crowd-Kalender vor der Buchung.",
+      "schoolHolidayWarning": "Für {park} gilt: In den Schulferien ist es typischerweise deutlich voller — prüfe den Crowd-Kalender vor der Buchung.",
       "noUpcomingQuiet": "In den nächsten 30 Tagen keine besonders ruhigen Tage.",
       "noData": "Noch nicht genug Crowd-Daten verfügbar.",
       "bestWeekendDayTitle": "Bester Wochenendtag",


### PR DESCRIPTION
## Problem

Auf Parkseiten (z.B. [Universal Epic Universe](https://park.fan/de/parks/north-america/united-states/orlando/universal-epic-universe)) wurde die deutsche Schulferien-Warnung fehlerhaft angezeigt:

> ⚠️ Schulferien sind **am das** Universal Epic Universe typischerweise deutlich voller — prüfe den Crowd-Kalender vor der Buchung.

Die Vorlage in `messages/de.json` war doppelt kaputt:

1. **Grammatik:** `am` = `an dem` (Dativ). Da `displayName` den Parknamen bereits **mit Artikel im Akkusativ** liefert (`das Universal Epic Universe`, `den Europa-Park`), entstand `am das Universal Epic Universe` — doppelter Artikel.
2. **Semantik:** „Schulferien sind … voller" — nicht die Ferien sind voller, sondern der Park.

## Fix

Neue Formulierung nutzt die akkusativ-regierende Präposition `für`, passend zur `displayName`-Form (`das …` / `den …` / ohne Artikel):

> Für {park} gilt: In den Schulferien ist es typischerweise deutlich voller — prüfe den Crowd-Kalender vor der Buchung.

Funktioniert grammatisch korrekt für alle Park-Varianten:
- „Für **das** Universal Epic Universe gilt: …"
- „Für **den** Europa-Park gilt: …"
- „Für Disneyland Paris gilt: …" (ohne Artikel)

Nur die deutsche Übersetzung (`messages/de.json`) ist betroffen; EN/NL/FR/ES/IT waren bereits korrekt.

https://claude.ai/code/session_01DBAKyE7yEaFoCghzTcu4ef

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBAKyE7yEaFoCghzTcu4ef)_