### PR TITLE
Add hourly day view (temperature curve + rain bars) to the weather card

### DIFF
--- a/app/[locale]/howto/_mock-components.tsx
+++ b/app/[locale]/howto/_mock-components.tsx
@@ -12,7 +12,13 @@ import { WeatherCard } from '@/components/parks/weather-card';
 import { ParkStatus } from '@/components/parks/park-status';
 import { getServerNowMs } from '@/lib/utils/server-time';
 import type { FavoriteAttraction } from '@/lib/api/favorites';
-import type { ScheduleItem, WeatherData, WeatherNowcast, ParkResponse } from '@/lib/api/types';
+import type {
+  ScheduleItem,
+  WeatherData,
+  WeatherHourlyToday,
+  WeatherNowcast,
+  ParkResponse,
+} from '@/lib/api/types';
 import {
   Star,
   Clock,
@@ -251,6 +257,29 @@ export async function MockParkHeader({ locale }: { locale: MockLocale }) {
     },
   };
 
+  // Hourly day view (sunny mock): diurnal curve, dry all day. Dated "today in
+  // Europe/Berlin" — the chart hides itself when the data isn't today's.
+  const berlinDateStr = new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Europe/Berlin',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(nowMs);
+  const hourly: WeatherHourlyToday = {
+    timezone: 'Europe/Berlin',
+    points: Array.from({ length: 24 }, (_, h) => {
+      const tFrac = 0.5 - 0.5 * Math.cos((((h - 5 + 24) % 24) / 24) * 2 * Math.PI);
+      return {
+        time: `${berlinDateStr}T${String(h).padStart(2, '0')}:00`,
+        temperatureC: Math.round((16 + 10 * tFrac) * 10) / 10,
+        precipitationMm: 0,
+        precipitationProbability: 5,
+        weatherCode: 1,
+        isDay: h >= 6 && h <= 21,
+      };
+    }),
+  };
+
   const park = {
     id: 'phantasialand',
     slug: 'phantasialand',
@@ -330,7 +359,14 @@ export async function MockParkHeader({ locale }: { locale: MockLocale }) {
             status="OPERATING"
             className="border-primary/10"
           />
-          <WeatherCard weather={weather} nowcast={nowcast} className="border-primary/10" />
+          <WeatherCard
+            weather={weather}
+            nowcast={nowcast}
+            timezone="Europe/Berlin"
+            hourly={hourly}
+            schedule={[todaySchedule]}
+            className="border-primary/10"
+          />
         </div>
 
         {/* Status grid — occupancy, wait times & attractions */}

--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -330,6 +330,9 @@ export default async function ParkPage({ params }: ParkPageProps) {
                   country={country}
                   city={city}
                   parkSlug={parkSlug}
+                  latitude={park.latitude}
+                  longitude={park.longitude}
+                  timezone={park.timezone}
                   className="border-primary/10"
                 />
               </Suspense>

--- a/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
+++ b/app/[locale]/parks/[continent]/[country]/[city]/[park]/page.tsx
@@ -333,6 +333,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
                   latitude={park.latitude}
                   longitude={park.longitude}
                   timezone={park.timezone}
+                  schedule={park.schedule}
                   className="border-primary/10"
                 />
               </Suspense>

--- a/app/api/weather/hourly/route.ts
+++ b/app/api/weather/hourly/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type { WeatherHourlyPoint, WeatherHourlyToday } from '@/lib/api/types';
+
+/**
+ * Today's hour-by-hour forecast for a park location, proxied from Open-Meteo.
+ *
+ * The park.fan backend only exposes daily weather plus a ~6 h nowcast (no hourly
+ * temperatures), so the detailed day view fetches Open-Meteo — the backend's own
+ * upstream source, already attributed in the weather card — directly. Proxying it
+ * through this route keeps the request first-party (no visitor IPs to a third
+ * party) and lets the Next data cache + CDN collapse all visitors of a park onto
+ * one upstream call per cache window.
+ *
+ * Query params: lat, lon (coordinates), tz (IANA timezone for local hour labels).
+ * Coordinates are rounded to 2 decimals (~1 km) — plenty for weather, and it
+ * canonicalizes the upstream URL for better cache hits.
+ */
+
+interface OpenMeteoHourlyResponse {
+  timezone: string;
+  hourly: {
+    time: string[];
+    temperature_2m: (number | null)[];
+    precipitation: (number | null)[];
+    precipitation_probability: (number | null)[];
+    weather_code: (number | null)[];
+    is_day: (number | null)[];
+  };
+}
+
+const TZ_PATTERN = /^[A-Za-z0-9_+\-/]{1,64}$/;
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const latParam = searchParams.get('lat');
+  const lonParam = searchParams.get('lon');
+  const lat = latParam ? Number(latParam) : NaN;
+  const lon = lonParam ? Number(lonParam) : NaN;
+  const tz = searchParams.get('tz') ?? 'UTC';
+
+  if (
+    !Number.isFinite(lat) ||
+    lat < -90 ||
+    lat > 90 ||
+    !Number.isFinite(lon) ||
+    lon < -180 ||
+    lon > 180
+  ) {
+    return NextResponse.json({ error: 'Invalid lat/lon' }, { status: 400 });
+  }
+  if (!TZ_PATTERN.test(tz)) {
+    return NextResponse.json({ error: 'Invalid tz' }, { status: 400 });
+  }
+
+  const upstream =
+    `https://api.open-meteo.com/v1/forecast` +
+    `?latitude=${lat.toFixed(2)}&longitude=${lon.toFixed(2)}` +
+    `&hourly=temperature_2m,precipitation,precipitation_probability,weather_code,is_day` +
+    `&forecast_days=1&timezone=${encodeURIComponent(tz)}`;
+
+  try {
+    // Open-Meteo refreshes its models roughly hourly; 15 min keeps the curve
+    // fresh enough while one cached response serves every visitor of the park.
+    const res = await fetch(upstream, { next: { revalidate: 900 } });
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Upstream weather request failed' }, { status: 502 });
+    }
+
+    const data = (await res.json()) as OpenMeteoHourlyResponse;
+    const h = data.hourly;
+    if (!h?.time?.length) {
+      return NextResponse.json({ error: 'No hourly data' }, { status: 502 });
+    }
+
+    const points: WeatherHourlyPoint[] = h.time.map((time, i) => ({
+      time,
+      temperatureC: h.temperature_2m?.[i] ?? null,
+      precipitationMm: h.precipitation?.[i] ?? null,
+      precipitationProbability: h.precipitation_probability?.[i] ?? null,
+      weatherCode: h.weather_code?.[i] ?? null,
+      isDay: (h.is_day?.[i] ?? 1) === 1,
+    }));
+
+    const body: WeatherHourlyToday = { timezone: data.timezone, points };
+
+    return NextResponse.json(body, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=900, stale-while-revalidate=900',
+      },
+    });
+  } catch (error) {
+    console.error('[Weather Hourly API] Error:', error);
+    return NextResponse.json({ error: 'Failed to fetch hourly weather' }, { status: 500 });
+  }
+}

--- a/components/blog/blog-weather-widget.tsx
+++ b/components/blog/blog-weather-widget.tsx
@@ -51,6 +51,10 @@ export async function BlogWeatherWidget({ park, slug }: BlogWeatherWidgetProps) 
         country={geo.country}
         city={geo.city}
         parkSlug={geo.parkSlug}
+        latitude={full.latitude}
+        longitude={full.longitude}
+        timezone={full.timezone}
+        schedule={full.schedule}
       />
     </div>
   );

--- a/components/parks/nowcast-update-countdown.tsx
+++ b/components/parks/nowcast-update-countdown.tsx
@@ -61,9 +61,14 @@ export function NowcastUpdateCountdown({
   const mm = String(Math.floor(totalSec / 60)).padStart(2, '0');
   const ss = String(totalSec % 60).padStart(2, '0');
 
+  // Below `sm` the full sentence wraps the card header — show the bare timer there.
   return (
-    <p className={cn('font-mono text-[11px] tabular-nums opacity-60', className)}>
-      {t('updateIn', { countdown: `${mm}:${ss}` })}
+    <p
+      className={cn('font-mono text-[11px] tabular-nums opacity-60', className)}
+      title={t('updateIn', { countdown: `${mm}:${ss}` })}
+    >
+      <span className="sm:hidden">{`${mm}:${ss}`}</span>
+      <span className="hidden sm:inline">{t('updateIn', { countdown: `${mm}:${ss}` })}</span>
     </p>
   );
 }

--- a/components/parks/weather-card-demo.tsx
+++ b/components/parks/weather-card-demo.tsx
@@ -232,22 +232,6 @@ function buildHourlyFor(variant: Variant, now: number): WeatherHourlyToday | nul
   return { timezone: 'Europe/Berlin', points };
 }
 
-/** Today's park hours (Berlin-fixed) for the opening-hours band on the chart. */
-function buildChartSchedule(now: number): ScheduleItem[] {
-  const dateStr = berlinDateStr(now);
-  return [
-    {
-      date: dateStr,
-      scheduleType: 'OPERATING',
-      openingTime: `${dateStr}T09:00:00+02:00`,
-      closingTime: `${dateStr}T20:00:00+02:00`,
-      description: null,
-      purchases: null,
-      holidayName: null,
-    },
-  ];
-}
-
 function buildScheduleForOffset(
   today: Date,
   dayOffset: number,
@@ -314,12 +298,14 @@ export function WeatherCardShowcase({ variant }: WeatherCardShowcaseProps) {
             status="OPERATING"
             schedule={[buildTodaySchedule(today)]}
           />
+          {/* Same schedule object as the ParkTimeInfo next to it, so the chart's
+              opening-hours band matches the displayed times. */}
           <WeatherCard
             weather={buildWeather(today, 'sunny')}
             nowcast={buildNowcastFor('sunny', mountedAt)}
             timezone="Europe/Berlin"
             hourly={buildHourlyFor('sunny', mountedAt)}
-            schedule={buildChartSchedule(mountedAt)}
+            schedule={[buildTodaySchedule(today)]}
           />
         </div>
       </div>

--- a/components/parks/weather-card-demo.tsx
+++ b/components/parks/weather-card-demo.tsx
@@ -4,7 +4,13 @@ import { useState } from 'react';
 import { format, addDays } from 'date-fns';
 import { WeatherCard } from '@/components/parks/weather-card';
 import { ParkTimeInfo } from '@/components/parks/park-time-info';
-import type { WeatherData, WeatherDay, WeatherNowcast, ScheduleItem } from '@/lib/api/types';
+import type {
+  WeatherData,
+  WeatherDay,
+  WeatherHourlyToday,
+  WeatherNowcast,
+  ScheduleItem,
+} from '@/lib/api/types';
 import { FORECAST_TEMPLATE, VARIANT_CURRENT, type Variant } from './weather-card-demo-data';
 
 function buildWeather(today: Date, variant: Variant): WeatherData {
@@ -177,6 +183,71 @@ function buildNowcastFor(variant: Variant, now: number): WeatherNowcast | null {
   }
 }
 
+/** "Today" in the demo park's timezone — the hourly chart hides itself otherwise. */
+function berlinDateStr(now: number): string {
+  return new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Europe/Berlin',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now);
+}
+
+interface HourlyVariantConfig {
+  tMin: number;
+  tMax: number;
+  dryCode: number;
+  rain: { from: number; to: number; peakMm: number; code: number } | null;
+}
+
+const HOURLY_VARIANTS: Partial<Record<Variant, HourlyVariantConfig>> = {
+  sunny: { tMin: 10, tMax: 19, dryCode: 1, rain: null },
+  rainy: { tMin: 7, tMax: 11, dryCode: 3, rain: { from: 11, to: 18, peakMm: 1.2, code: 63 } },
+  stormy: { tMin: 5, tMax: 9, dryCode: 3, rain: { from: 13, to: 20, peakMm: 3.2, code: 95 } },
+};
+
+/** Deterministic hourly day data so the showcase renders the day-view chart offline. */
+function buildHourlyFor(variant: Variant, now: number): WeatherHourlyToday | null {
+  const cfg = HOURLY_VARIANTS[variant];
+  if (!cfg) return null;
+  const dateStr = berlinDateStr(now);
+  const points = Array.from({ length: 24 }, (_, h) => {
+    // Diurnal curve: coolest around 05:00, warmest around 17:00.
+    const tFrac = 0.5 - 0.5 * Math.cos((((h - 5 + 24) % 24) / 24) * 2 * Math.PI);
+    const rain = cfg.rain;
+    const rainFrac =
+      rain && h >= rain.from && h <= rain.to
+        ? Math.sin(((h - rain.from) / (rain.to - rain.from)) * Math.PI)
+        : 0;
+    const mm = rain ? Math.round(rain.peakMm * rainFrac * 10) / 10 : 0;
+    return {
+      time: `${dateStr}T${String(h).padStart(2, '0')}:00`,
+      temperatureC: Math.round((cfg.tMin + (cfg.tMax - cfg.tMin) * tFrac) * 10) / 10,
+      precipitationMm: mm,
+      precipitationProbability: mm > 0 ? Math.round(60 + 35 * rainFrac) : 15,
+      weatherCode: mm > 0 ? cfg.rain!.code : cfg.dryCode,
+      isDay: h >= 6 && h <= 21,
+    };
+  });
+  return { timezone: 'Europe/Berlin', points };
+}
+
+/** Today's park hours (Berlin-fixed) for the opening-hours band on the chart. */
+function buildChartSchedule(now: number): ScheduleItem[] {
+  const dateStr = berlinDateStr(now);
+  return [
+    {
+      date: dateStr,
+      scheduleType: 'OPERATING',
+      openingTime: `${dateStr}T09:00:00+02:00`,
+      closingTime: `${dateStr}T20:00:00+02:00`,
+      description: null,
+      purchases: null,
+      holidayName: null,
+    },
+  ];
+}
+
 function buildScheduleForOffset(
   today: Date,
   dayOffset: number,
@@ -246,6 +317,9 @@ export function WeatherCardShowcase({ variant }: WeatherCardShowcaseProps) {
           <WeatherCard
             weather={buildWeather(today, 'sunny')}
             nowcast={buildNowcastFor('sunny', mountedAt)}
+            timezone="Europe/Berlin"
+            hourly={buildHourlyFor('sunny', mountedAt)}
+            schedule={buildChartSchedule(mountedAt)}
           />
         </div>
       </div>
@@ -258,10 +332,14 @@ export function WeatherCardShowcase({ variant }: WeatherCardShowcaseProps) {
       <WeatherCard
         weather={buildWeather(today, 'rainy')}
         nowcast={buildNowcastFor('rainy', mountedAt)}
+        timezone="Europe/Berlin"
+        hourly={buildHourlyFor('rainy', mountedAt)}
       />
       <WeatherCard
         weather={buildWeather(today, 'stormy')}
         nowcast={buildNowcastFor('stormy', mountedAt)}
+        timezone="Europe/Berlin"
+        hourly={buildHourlyFor('stormy', mountedAt)}
       />
       <WeatherCard weather={buildWeather(today, 'snowy')} />
       <WeatherCard weather={buildWeather(today, 'fog')} />

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -295,7 +295,7 @@ export function WeatherCard({
             <WeatherForecastStrip forecast={forecast || (activeWeather.forecast ?? [])} />
           )}
 
-          <p className="text-muted-foreground/50 !-mt-1 -mr-4 -mb-3 flex items-center justify-end gap-1 text-[12px] leading-none font-medium">
+          <p className="text-muted-foreground/50 !-mt-1 -mb-3 flex items-center justify-end gap-1 text-[12px] leading-none font-medium">
             <Cloud className="h-3 w-3 shrink-0" aria-hidden="true" />
             <a
               href="https://open-meteo.com/"

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -1,7 +1,16 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { Cloud, ExternalLink, Snowflake, Eye, CloudFog } from 'lucide-react';
+import {
+  Cloud,
+  ExternalLink,
+  Snowflake,
+  Eye,
+  CloudFog,
+  Droplets,
+  Thermometer,
+  Wind as WindIcon,
+} from 'lucide-react';
 import { CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import { WeatherForecastStrip } from './weather-forecast-strip';
@@ -15,7 +24,13 @@ import { getWeatherConfig } from '@/lib/utils/weather-utils';
 import { useWeatherNowcast } from '@/lib/hooks/use-weather-nowcast';
 import { useWeatherHourly } from '@/lib/hooks/use-weather-hourly';
 import { useLiveParkData } from '@/lib/hooks/use-live-park-data';
-import type { WeatherData, WeatherDay, WeatherNowcast } from '@/lib/api/types';
+import type {
+  ScheduleItem,
+  WeatherData,
+  WeatherDay,
+  WeatherHourlyToday,
+  WeatherNowcast,
+} from '@/lib/api/types';
 
 interface WeatherCardProps {
   weather: WeatherData;
@@ -32,6 +47,10 @@ interface WeatherCardProps {
   latitude?: number | null;
   longitude?: number | null;
   timezone?: string;
+  /** Park schedule — today's opening hours are marked in the hourly day view. */
+  schedule?: ScheduleItem[] | null;
+  /** Static hourly data (showcases/demos) — when set, the live fetch is skipped. */
+  hourly?: WeatherHourlyToday | null;
   className?: string;
 }
 
@@ -46,6 +65,8 @@ export function WeatherCard({
   latitude,
   longitude,
   timezone,
+  schedule,
+  hourly,
   className,
 }: WeatherCardProps) {
   const t = useTranslations('parks.weather');
@@ -64,13 +85,15 @@ export function WeatherCard({
   const activeNowcast = hasParams ? liveNowcast : nowcast;
 
   // Detailed day view for today — only when a nowcast exists (parks with live
-  // weather coverage) and we know where the park is.
-  const { data: hourly } = useWeatherHourly({
+  // weather coverage) and we know where the park is. A static `hourly` prop
+  // (showcases/demos) takes precedence and disables the fetch.
+  const { data: fetchedHourly } = useWeatherHourly({
     latitude,
     longitude,
     timezone,
-    enabled: !!activeNowcast,
+    enabled: !!activeNowcast && hourly === undefined,
   });
+  const activeHourly = hourly !== undefined ? hourly : fetchedHourly;
 
   // The base forecast (current + 7-day strip) is baked into the 1-day ISR shell, so it would be up
   // to a day stale. Subscribe to the same live park query LiveParkData polls (shared key → no extra
@@ -173,8 +196,10 @@ export function WeatherCard({
                   <Temp celsius={tempMinC} /> – <Temp celsius={tempMaxC} />
                 </p>
                 {feelsLikeC != null && (
-                  <p className="text-muted-foreground text-xs">
-                    {t('feelsLike')} <Temp celsius={feelsLikeC} />
+                  <p className="text-muted-foreground flex items-center gap-1 text-xs whitespace-nowrap">
+                    <Thermometer className="h-3 w-3 shrink-0 sm:hidden" aria-hidden="true" />
+                    <span className="hidden sm:inline">{t('feelsLike')}</span>
+                    <Temp celsius={feelsLikeC} />
                   </p>
                 )}
                 <p className="text-muted-foreground mt-0.5 text-sm font-medium">{t(label)}</p>
@@ -183,32 +208,51 @@ export function WeatherCard({
 
             {activeNowcast ? (
               <div className="flex items-center gap-3">
+                {/* Text labels collapse to their icons below `sm` — the value column
+                    sits next to the temperature block and wraps otherwise. */}
                 <div className="text-muted-foreground space-y-0.5 text-right text-xs">
-                  <div>
-                    <span className="opacity-70">{t('precipLabel')}: </span>
+                  <div
+                    className="flex items-center justify-end gap-1 whitespace-nowrap"
+                    title={t('precipLabel')}
+                  >
+                    <Droplets className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden="true" />
+                    <span className="hidden opacity-70 sm:inline">{t('precipLabel')}: </span>
                     <Precip mm={precipMm} />
                   </div>
                   {gustsKmh != null && (
-                    <div>
-                      <span className="opacity-70">{t('gustsLabel')}: </span>
+                    <div
+                      className="flex items-center justify-end gap-1 whitespace-nowrap"
+                      title={t('gustsLabel')}
+                    >
+                      <WindIcon className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden="true" />
+                      <span className="hidden opacity-70 sm:inline">{t('gustsLabel')}: </span>
                       <Wind kmh={gustsKmh} />
                     </div>
                   )}
                   {visM != null && (
-                    <div className="flex items-center justify-end gap-1">
+                    <div
+                      className="flex items-center justify-end gap-1 whitespace-nowrap"
+                      title={isFog ? t('fog') : t('visibilityLabel')}
+                    >
                       {isFog ? (
                         <CloudFog className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
                       ) : (
                         <Eye className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden="true" />
                       )}
-                      <span className="opacity-70">{isFog ? t('fog') : t('visibilityLabel')}:</span>{' '}
+                      <span className="hidden opacity-70 sm:inline">
+                        {isFog ? t('fog') : t('visibilityLabel')}:
+                      </span>{' '}
                       <Distance meters={visM} />
                     </div>
                   )}
                   {showSnow && (
-                    <div className="flex items-center justify-end gap-1">
+                    <div
+                      className="flex items-center justify-end gap-1 whitespace-nowrap"
+                      title={t('snowLabel')}
+                    >
                       <Snowflake className="h-3.5 w-3.5 shrink-0 text-sky-300" aria-hidden="true" />
-                      <span className="opacity-70">{t('snowLabel')}:</span> {snowCm!.toFixed(1)} cm
+                      <span className="hidden opacity-70 sm:inline">{t('snowLabel')}:</span>{' '}
+                      {snowCm!.toFixed(1)} cm
                     </div>
                   )}
                 </div>
@@ -219,20 +263,32 @@ export function WeatherCard({
               </div>
             ) : (
               <div className="text-muted-foreground space-y-0.5 text-right text-xs">
-                <div>
-                  <span className="opacity-70">{t('precipLabel')}: </span>
+                <div
+                  className="flex items-center justify-end gap-1 whitespace-nowrap"
+                  title={t('precipLabel')}
+                >
+                  <Droplets className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden="true" />
+                  <span className="hidden opacity-70 sm:inline">{t('precipLabel')}: </span>
                   <Precip mm={precipMm} />
                 </div>
-                <div>
-                  <span className="opacity-70">{t('windLabel')}: </span>
+                <div
+                  className="flex items-center justify-end gap-1 whitespace-nowrap"
+                  title={t('windLabel')}
+                >
+                  <WindIcon className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden="true" />
+                  <span className="hidden opacity-70 sm:inline">{t('windLabel')}: </span>
                   <Wind kmh={windKmh} />
                 </div>
               </div>
             )}
           </div>
 
-          {activeNowcast && timezone && hourly && hourly.points.length > 0 && (
-            <WeatherHourlyChart points={hourly.points} timezone={timezone} />
+          {activeNowcast && timezone && activeHourly && activeHourly.points.length > 0 && (
+            <WeatherHourlyChart
+              points={activeHourly.points}
+              timezone={timezone}
+              schedule={schedule ?? undefined}
+            />
           )}
 
           {(forecast || (activeWeather.forecast && activeWeather.forecast.length > 0)) && (

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -288,6 +288,7 @@ export function WeatherCard({
               points={activeHourly.points}
               timezone={timezone}
               schedule={schedule ?? undefined}
+              nowcast={activeNowcast}
             />
           )}
 

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -5,6 +5,7 @@ import { Cloud, ExternalLink, Snowflake, Eye, CloudFog } from 'lucide-react';
 import { CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import { WeatherForecastStrip } from './weather-forecast-strip';
+import { WeatherHourlyChart } from './weather-hourly-chart';
 import { NowcastUpdateCountdown } from './nowcast-update-countdown';
 import { WeatherBackground } from './weather-background';
 import { WindCompass } from './wind-compass';
@@ -12,6 +13,7 @@ import { TemperatureUnitToggle } from '@/components/common/temperature-unit-togg
 import { Temp, Wind, Precip, Distance } from '@/components/common/unit-display';
 import { getWeatherConfig } from '@/lib/utils/weather-utils';
 import { useWeatherNowcast } from '@/lib/hooks/use-weather-nowcast';
+import { useWeatherHourly } from '@/lib/hooks/use-weather-hourly';
 import { useLiveParkData } from '@/lib/hooks/use-live-park-data';
 import type { WeatherData, WeatherDay, WeatherNowcast } from '@/lib/api/types';
 
@@ -25,6 +27,11 @@ interface WeatherCardProps {
   country?: string;
   city?: string;
   parkSlug?: string;
+  /** Park coordinates + timezone — when provided (and a nowcast exists), enables
+      the detailed hour-by-hour day view for today. */
+  latitude?: number | null;
+  longitude?: number | null;
+  timezone?: string;
   className?: string;
 }
 
@@ -36,6 +43,9 @@ export function WeatherCard({
   country,
   city,
   parkSlug,
+  latitude,
+  longitude,
+  timezone,
   className,
 }: WeatherCardProps) {
   const t = useTranslations('parks.weather');
@@ -52,6 +62,15 @@ export function WeatherCard({
   });
   // liveNowcast is undefined when the hook is disabled (no params) — fall back to the static prop
   const activeNowcast = hasParams ? liveNowcast : nowcast;
+
+  // Detailed day view for today — only when a nowcast exists (parks with live
+  // weather coverage) and we know where the park is.
+  const { data: hourly } = useWeatherHourly({
+    latitude,
+    longitude,
+    timezone,
+    enabled: !!activeNowcast,
+  });
 
   // The base forecast (current + 7-day strip) is baked into the 1-day ISR shell, so it would be up
   // to a day stale. Subscribe to the same live park query LiveParkData polls (shared key → no extra
@@ -211,6 +230,10 @@ export function WeatherCard({
               </div>
             )}
           </div>
+
+          {activeNowcast && timezone && hourly && hourly.points.length > 0 && (
+            <WeatherHourlyChart points={hourly.points} timezone={timezone} />
+          )}
 
           {(forecast || (activeWeather.forecast && activeWeather.forecast.length > 0)) && (
             <WeatherForecastStrip forecast={forecast || (activeWeather.forecast ?? [])} />

--- a/components/parks/weather-hourly-chart.tsx
+++ b/components/parks/weather-hourly-chart.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+import { useEffect, useId, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+import { Clock, Droplets, Umbrella } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Temp, Precip } from '@/components/common/unit-display';
+import { getWeatherConfig } from '@/lib/utils/weather-utils';
+import type { WeatherHourlyPoint } from '@/lib/api/types';
+
+interface WeatherHourlyChartProps {
+  /** Today's hourly points (naive park-local times, ascending). */
+  points: WeatherHourlyPoint[];
+  /** Park timezone — point times are naive park-local, so "now" is compared in that zone. */
+  timezone: string;
+  className?: string;
+}
+
+// Chart geometry in viewBox units (0–100 on both axes, preserveAspectRatio="none").
+const TEMP_TOP = 14; // y of the warmest hour
+const TEMP_BOTTOM = 62; // y of the coldest hour
+// Bottom share of the chart reserved for the rain bars.
+const RAIN_AREA_PCT = 30;
+// mm/h that fills the rain area ("moderate" rain); heavier slots scale the chart up.
+const RAIN_SCALE_TOP_MM = 2.5;
+
+/** Format an instant (ms) as a naive park-local ISO ("YYYY-MM-DDTHH:MM"). */
+function toLocalIso(ms: number, timezone: string): string {
+  return new Intl.DateTimeFormat('sv-SE', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+    .format(ms)
+    .replace(' ', 'T');
+}
+
+/** Catmull-Rom spline through the points, emitted as cubic beziers. */
+function smoothPath(pts: { x: number; y: number }[]): string {
+  if (pts.length < 2) return '';
+  const r = (n: number) => Math.round(n * 100) / 100;
+  let d = `M ${r(pts[0].x)} ${r(pts[0].y)}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[i + 2] ?? p2;
+    const c1x = p1.x + (p2.x - p0.x) / 6;
+    const c1y = p1.y + (p2.y - p0.y) / 6;
+    const c2x = p2.x - (p3.x - p1.x) / 6;
+    const c2y = p2.y - (p3.y - p1.y) / 6;
+    d += ` C ${r(c1x)} ${r(c1y)}, ${r(c2x)} ${r(c2y)}, ${r(p2.x)} ${r(p2.y)}`;
+  }
+  return d;
+}
+
+/**
+ * Detailed day view for today: hourly temperature curve with rain bars
+ * underneath, a "now" marker, and per-hour tooltips — the classic weather-app
+ * hourly chart. Renders nothing once the data no longer belongs to today
+ * (e.g. right after midnight, until the next refetch rolls it over).
+ */
+export function WeatherHourlyChart({ points, timezone, className }: WeatherHourlyChartProps) {
+  const locale = useLocale();
+  const t = useTranslations('parks.weather');
+  const tNowcast = useTranslations('parks.weatherNowcast');
+  const gradientId = useId();
+
+  // Re-render every minute so the "now" marker tracks the actual time.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const n = points.length;
+  if (n < 2) return null;
+
+  const nowLocal = toLocalIso(nowMs, timezone);
+  // Only a *today* view makes sense; hide the chart when the data is for another day.
+  if (points[0].time.slice(0, 10) !== nowLocal.slice(0, 10)) return null;
+
+  const temps = points.map((p) => p.temperatureC);
+  const valid = temps.filter((v): v is number => v != null);
+  if (valid.length < 2) return null;
+  const minTemp = Math.min(...valid);
+  const maxTemp = Math.max(...valid);
+  // Keep a flat curve from collapsing to a line glued to the top of the band.
+  const span = Math.max(maxTemp - minTemp, 2);
+
+  const xFor = (i: number) => ((i + 0.5) / n) * 100;
+  const yFor = (tempC: number) =>
+    TEMP_BOTTOM - ((tempC - minTemp) / span) * (TEMP_BOTTOM - TEMP_TOP);
+
+  const linePts = points
+    .map((p, i) => (p.temperatureC != null ? { x: xFor(i), y: yFor(p.temperatureC) } : null))
+    .filter((p): p is { x: number; y: number } => p !== null);
+  const lineD = smoothPath(linePts);
+  const areaD = `${lineD} L ${linePts[linePts.length - 1].x.toFixed(2)} 100 L ${linePts[0].x.toFixed(2)} 100 Z`;
+
+  // Rain bars: scale against a fixed "moderate rain fills the area" top, but
+  // stretch the scale when an heavier peak would clip.
+  const peakMm = Math.max(...points.map((p) => p.precipitationMm ?? 0));
+  const rainScale = Math.max(RAIN_SCALE_TOP_MM, peakMm);
+
+  // "Now" position as a fraction of the day, in park-local time.
+  const nowMinutes =
+    parseInt(nowLocal.slice(11, 13), 10) * 60 + parseInt(nowLocal.slice(14, 16), 10);
+  const nowPct = (nowMinutes / 1440) * 100;
+
+  // Temperature at "now", interpolated between the neighbouring hour points.
+  const u = nowMinutes / 60 - 0.5;
+  const i0 = Math.min(Math.max(Math.floor(u), 0), n - 2);
+  const frac = Math.min(Math.max(u - i0, 0), 1);
+  const t0 = points[i0].temperatureC;
+  const t1 = points[i0 + 1].temperatureC;
+  const nowTempY = t0 != null && t1 != null ? yFor(t0 + (t1 - t0) * frac) : null;
+
+  // Min/max label anchors (clamped so the labels stay inside the card).
+  const maxIdx = temps.indexOf(maxTemp);
+  const minIdx = temps.indexOf(minTemp);
+  const clampX = (x: number) => Math.min(Math.max(x, 7), 93);
+  // The max label and the "now" marker both live near the top — when the day's
+  // peak is around the current hour they collide, so drop the "Now" text then.
+  const showNowLabel = Math.abs(clampX(xFor(maxIdx)) - nowPct) > 10;
+
+  const fmtTime = (localIso: string) =>
+    new Date(`${localIso}Z`).toLocaleTimeString(locale, {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZone: 'UTC',
+    });
+  const fmtHour = (localIso: string) =>
+    new Date(`${localIso}Z`).toLocaleTimeString(locale, {
+      hour: 'numeric',
+      timeZone: 'UTC',
+    });
+
+  return (
+    <div className={cn('min-w-0', className)}>
+      <p className="text-muted-foreground mb-1.5 flex items-center gap-1.5 text-xs font-medium">
+        <Clock className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden="true" />
+        {t('hourlyTitle')}
+      </p>
+
+      <div className="relative h-24">
+        {/* Temperature curve */}
+        <svg
+          className="pointer-events-none absolute inset-0 h-full w-full text-amber-400"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="currentColor" stopOpacity="0.28" />
+              <stop offset="80%" stopColor="currentColor" stopOpacity="0.02" />
+            </linearGradient>
+          </defs>
+          <path d={areaD} fill={`url(#${gradientId})`} />
+          <path
+            d={lineD}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+
+        {/* Rain bars + per-hour tooltip hit areas */}
+        <div className="absolute inset-0 flex">
+          {points.map((p) => {
+            const mm = p.precipitationMm ?? 0;
+            const barPct =
+              mm > 0 ? Math.min(RAIN_AREA_PCT, Math.max(8, (mm / rainScale) * RAIN_AREA_PCT)) : 0;
+            const prob = p.precipitationProbability;
+            const { icon: HourIcon, label, color } = getWeatherConfig(p.weatherCode ?? 0, p.isDay);
+            const ariaLabel = `${fmtTime(p.time)} · ${
+              p.temperatureC != null ? `${Math.round(p.temperatureC)}°C · ` : ''
+            }${mm.toFixed(1)} mm${prob != null ? ` · ${prob}% ${tNowcast('precipProbability')}` : ''}`;
+            return (
+              <Tooltip key={p.time}>
+                <TooltipTrigger asChild>
+                  <div className="relative min-w-0 flex-1" aria-label={ariaLabel}>
+                    {barPct > 0 && (
+                      <div
+                        className="absolute inset-x-[15%] bottom-0 rounded-t-[2px] bg-sky-400/85"
+                        style={{ height: `${barPct}%` }}
+                      />
+                    )}
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <div className="flex flex-col gap-1 tabular-nums">
+                    <span className="flex items-center gap-1.5">
+                      <Clock className="size-3 shrink-0 opacity-70" aria-hidden="true" />
+                      {fmtTime(p.time)}
+                    </span>
+                    <span className="flex items-center gap-1.5">
+                      <HourIcon className={cn('size-3 shrink-0', color)} aria-hidden="true" />
+                      {p.temperatureC != null && (
+                        <>
+                          <Temp celsius={p.temperatureC} />
+                          {' · '}
+                        </>
+                      )}
+                      {t(label)}
+                    </span>
+                    {mm > 0 && (
+                      <span className="flex items-center gap-1.5">
+                        <Droplets className="size-3 shrink-0 opacity-70" aria-hidden="true" />
+                        <Precip mm={mm} />
+                      </span>
+                    )}
+                    {prob != null && prob > 0 && (
+                      <span className="flex items-center gap-1.5">
+                        <Umbrella className="size-3 shrink-0 opacity-70" aria-hidden="true" />
+                        {prob}% {tNowcast('precipProbability')}
+                      </span>
+                    )}
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </div>
+
+        {/* Mute hours that have already passed */}
+        <div
+          className="bg-background/45 pointer-events-none absolute inset-y-0 left-0"
+          style={{ width: `${nowPct}%` }}
+          aria-hidden="true"
+        />
+
+        {/* "Now" marker */}
+        <div
+          className="border-foreground/30 pointer-events-none absolute inset-y-0 border-l border-dashed"
+          style={{ left: `${nowPct}%` }}
+          aria-hidden="true"
+        >
+          {showNowLabel && (
+            <span className="text-foreground/60 absolute top-0 left-1 text-[9px] leading-none font-medium">
+              {t('nowLabel')}
+            </span>
+          )}
+        </div>
+        {nowTempY != null && (
+          <div
+            className="ring-background pointer-events-none absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber-400 ring-2"
+            style={{ left: `${nowPct}%`, top: `${nowTempY}%` }}
+            aria-hidden="true"
+          />
+        )}
+
+        {/* Min/max temperature labels, anchored to their hours */}
+        <span
+          className="pointer-events-none absolute -translate-x-1/2 -translate-y-full pb-0.5 text-[10px] font-semibold tabular-nums"
+          style={{ left: `${clampX(xFor(maxIdx))}%`, top: `${yFor(maxTemp)}%` }}
+        >
+          <Temp celsius={maxTemp} />
+        </span>
+        <span
+          className="text-muted-foreground pointer-events-none absolute -translate-x-1/2 pt-0.5 text-[10px] font-medium tabular-nums"
+          style={{ left: `${clampX(xFor(minIdx))}%`, top: `${yFor(minTemp)}%` }}
+        >
+          <Temp celsius={minTemp} />
+        </span>
+      </div>
+
+      {/* Axis: weather icon + hour label every 3 hours, aligned with the columns */}
+      <div className="mt-1 flex">
+        {points.map((p, i) => {
+          if (i % 3 !== 0) return <div key={p.time} className="min-w-0 flex-1" />;
+          const { icon: HourIcon, color } = getWeatherConfig(p.weatherCode ?? 0, p.isDay);
+          return (
+            <div key={p.time} className="flex min-w-0 flex-1 flex-col items-center gap-0.5">
+              <HourIcon className={cn('h-3.5 w-3.5 shrink-0', color)} aria-hidden="true" />
+              <span className="text-muted-foreground text-[9px] leading-none tabular-nums">
+                {fmtHour(p.time)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/parks/weather-hourly-chart.tsx
+++ b/components/parks/weather-hourly-chart.tsx
@@ -2,12 +2,12 @@
 
 import { useEffect, useId, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
-import { Clock, Droplets, Umbrella } from 'lucide-react';
+import { Clock, CloudHail, CloudLightning, Droplets, Umbrella, Wind } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Temp, Precip } from '@/components/common/unit-display';
 import { getWeatherConfig } from '@/lib/utils/weather-utils';
-import type { ScheduleItem, WeatherHourlyPoint } from '@/lib/api/types';
+import type { ScheduleItem, WeatherHourlyPoint, WeatherNowcast } from '@/lib/api/types';
 
 interface WeatherHourlyChartProps {
   /** Today's hourly points (naive park-local times, ascending). */
@@ -16,11 +16,37 @@ interface WeatherHourlyChartProps {
   timezone: string;
   /** Park schedule — today's opening hours are marked as a band on the chart. */
   schedule?: ScheduleItem[];
+  /** Live nowcast — severe-weather windows (storm/hail/thunderstorm) are drawn on the chart. */
+  nowcast?: WeatherNowcast | null;
   className?: string;
 }
 
+// Severe-weather windows drawn as tinted vertical bands — same kinds, priority
+// order, colors and icons as the WeatherNowcastBanner.
+type WarningKind = 'storm' | 'hail' | 'thunderstorm';
+
+const WARNING_STYLES: Record<WarningKind, { icon: typeof Wind; band: string; iconColor: string }> =
+  {
+    storm: {
+      icon: Wind,
+      band: 'bg-red-500/15 border-red-500/50',
+      iconColor: 'text-red-600 dark:text-red-400',
+    },
+    hail: {
+      icon: CloudHail,
+      band: 'bg-orange-500/15 border-orange-500/50',
+      iconColor: 'text-orange-600 dark:text-orange-400',
+    },
+    thunderstorm: {
+      icon: CloudLightning,
+      band: 'bg-yellow-500/15 border-yellow-500/50',
+      iconColor: 'text-yellow-600 dark:text-yellow-400',
+    },
+  };
+
 // Chart geometry in viewBox units (0–100 on both axes, preserveAspectRatio="none").
-const TEMP_TOP = 14; // y of the warmest hour
+// TEMP_TOP leaves headroom for the max-temp label so it doesn't touch the box edge.
+const TEMP_TOP = 22; // y of the warmest hour
 const TEMP_BOTTOM = 62; // y of the coldest hour
 // Bottom share of the chart reserved for the rain bars.
 const RAIN_AREA_PCT = 30;
@@ -71,6 +97,7 @@ export function WeatherHourlyChart({
   points,
   timezone,
   schedule,
+  nowcast,
   className,
 }: WeatherHourlyChartProps) {
   const locale = useLocale();
@@ -166,6 +193,37 @@ export function WeatherHourlyChart({
     }
   }
 
+  // Severe-weather windows (UTC instants) mapped onto today's axis. All present
+  // kinds are drawn, not just the banner's highest-priority one.
+  const warnings: {
+    kind: WarningKind;
+    fromPct: number;
+    toPct: number;
+    startLocal: string;
+    endLocal: string | null;
+  }[] = [];
+  if (nowcast) {
+    const events: [WarningKind, string | null | undefined, string | null | undefined][] = [
+      ['storm', nowcast.stormStartsAt, nowcast.stormEndsAt],
+      ['hail', nowcast.hailStartsAt, nowcast.hailEndsAt],
+      ['thunderstorm', nowcast.thunderstormStartsAt, nowcast.thunderstormEndsAt],
+    ];
+    const today = nowLocal.slice(0, 10);
+    for (const [kind, startsAt, endsAt] of events) {
+      if (!startsAt) continue;
+      const startLocal = toLocalIso(Date.parse(startsAt), timezone);
+      const endLocal = endsAt ? toLocalIso(Date.parse(endsAt), timezone) : null;
+      if (startLocal.slice(0, 10) > today) continue; // starts on a later day
+      if (endLocal && endLocal.slice(0, 10) < today) continue; // ended on an earlier day
+      const fromPct = startLocal.slice(0, 10) < today ? 0 : xForMinutes(localMinutes(startLocal));
+      // Unknown or after-midnight end → run to the edge of the chart.
+      const toPct =
+        endLocal && endLocal.slice(0, 10) === today ? xForMinutes(localMinutes(endLocal)) : 100;
+      if (toPct <= fromPct) continue;
+      warnings.push({ kind, fromPct, toPct, startLocal, endLocal });
+    }
+  }
+
   const fmtTime = (localIso: string) =>
     new Date(`${localIso}Z`).toLocaleTimeString(locale, {
       hour: '2-digit',
@@ -180,7 +238,7 @@ export function WeatherHourlyChart({
 
   return (
     <div className={cn('min-w-0', className)}>
-      <div className="relative h-24">
+      <div className="relative h-28">
         {/* Park opening hours band */}
         {openPct != null && closePct != null && (
           <div
@@ -189,6 +247,39 @@ export function WeatherHourlyChart({
             aria-hidden="true"
           />
         )}
+
+        {/* Severe-weather windows (storm / hail / thunderstorm) */}
+        {warnings.map(({ kind, fromPct, toPct, startLocal, endLocal }, i) => {
+          const { icon: WarnIcon, band, iconColor } = WARNING_STYLES[kind];
+          const range = `${fmtTime(startLocal)}${endLocal ? ` – ${fmtTime(endLocal)}` : ''}`;
+          return (
+            <div
+              key={kind}
+              className={cn('pointer-events-none absolute inset-y-0 border-x', band)}
+              style={{ left: `${fromPct}%`, width: `${toPct - fromPct}%` }}
+            >
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {/* Stacked per warning so overlapping windows don't bury each
+                      other's icon. */}
+                  <span
+                    className="pointer-events-auto absolute left-1/2 z-10 -translate-x-1/2"
+                    style={{ top: `${4 + i * 18}px` }}
+                    aria-label={`${tNowcast(`${kind}.heading`)} ${range}`}
+                  >
+                    <WarnIcon className={cn('size-3.5', iconColor)} aria-hidden="true" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <span className="flex items-center gap-1.5 tabular-nums">
+                    <WarnIcon className={cn('size-3 shrink-0', iconColor)} aria-hidden="true" />
+                    {tNowcast(`${kind}.heading`)} · {range}
+                  </span>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          );
+        })}
 
         {/* Temperature curve — drawn twice via clip paths so the elapsed part of
             the day renders dimmed (an overlay wash would tint dark mode wrong). */}

--- a/components/parks/weather-hourly-chart.tsx
+++ b/components/parks/weather-hourly-chart.tsx
@@ -180,11 +180,6 @@ export function WeatherHourlyChart({
 
   return (
     <div className={cn('min-w-0', className)}>
-      <p className="text-muted-foreground mb-1.5 flex items-center gap-1.5 text-xs font-medium">
-        <Clock className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden="true" />
-        {t('hourlyTitle')}
-      </p>
-
       <div className="relative h-24">
         {/* Park opening hours band */}
         {openPct != null && closePct != null && (

--- a/components/parks/weather-hourly-chart.tsx
+++ b/components/parks/weather-hourly-chart.tsx
@@ -7,13 +7,15 @@ import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Temp, Precip } from '@/components/common/unit-display';
 import { getWeatherConfig } from '@/lib/utils/weather-utils';
-import type { WeatherHourlyPoint } from '@/lib/api/types';
+import type { ScheduleItem, WeatherHourlyPoint } from '@/lib/api/types';
 
 interface WeatherHourlyChartProps {
   /** Today's hourly points (naive park-local times, ascending). */
   points: WeatherHourlyPoint[];
   /** Park timezone — point times are naive park-local, so "now" is compared in that zone. */
   timezone: string;
+  /** Park schedule — today's opening hours are marked as a band on the chart. */
+  schedule?: ScheduleItem[];
   className?: string;
 }
 
@@ -65,7 +67,12 @@ function smoothPath(pts: { x: number; y: number }[]): string {
  * hourly chart. Renders nothing once the data no longer belongs to today
  * (e.g. right after midnight, until the next refetch rolls it over).
  */
-export function WeatherHourlyChart({ points, timezone, className }: WeatherHourlyChartProps) {
+export function WeatherHourlyChart({
+  points,
+  timezone,
+  schedule,
+  className,
+}: WeatherHourlyChartProps) {
   const locale = useLocale();
   const t = useTranslations('parks.weather');
   const tNowcast = useTranslations('parks.weatherNowcast');
@@ -129,6 +136,31 @@ export function WeatherHourlyChart({ points, timezone, className }: WeatherHourl
   // peak is around the current hour they collide, so drop the "Now" text then.
   const showNowLabel = Math.abs(clampX(xFor(maxIdx)) - nowPct) > 10;
 
+  // Park opening hours — today's OPERATING window mapped onto the day axis.
+  const localMinutes = (iso: string) =>
+    parseInt(iso.slice(11, 13), 10) * 60 + parseInt(iso.slice(14, 16), 10);
+  const todaySchedule =
+    schedule?.find(
+      (s) =>
+        s.date === nowLocal.slice(0, 10) &&
+        s.scheduleType === 'OPERATING' &&
+        s.openingTime &&
+        s.closingTime
+    ) ?? null;
+  let openPct: number | null = null;
+  let closePct: number | null = null;
+  if (todaySchedule) {
+    const open = toLocalIso(Date.parse(todaySchedule.openingTime!), timezone);
+    const close = toLocalIso(Date.parse(todaySchedule.closingTime!), timezone);
+    if (open.slice(0, 10) === nowLocal.slice(0, 10)) {
+      openPct = (localMinutes(open) / 1440) * 100;
+      // Parks closing after midnight run to the edge of the chart.
+      closePct =
+        close.slice(0, 10) > nowLocal.slice(0, 10) ? 100 : (localMinutes(close) / 1440) * 100;
+      if (closePct <= openPct) closePct = 100;
+    }
+  }
+
   const fmtTime = (localIso: string) =>
     new Date(`${localIso}Z`).toLocaleTimeString(locale, {
       hour: '2-digit',
@@ -149,7 +181,17 @@ export function WeatherHourlyChart({ points, timezone, className }: WeatherHourl
       </p>
 
       <div className="relative h-24">
-        {/* Temperature curve */}
+        {/* Park opening hours band */}
+        {openPct != null && closePct != null && (
+          <div
+            className="border-primary/30 bg-primary/[0.07] pointer-events-none absolute inset-y-0 border-x border-dashed"
+            style={{ left: `${openPct}%`, width: `${closePct - openPct}%` }}
+            aria-hidden="true"
+          />
+        )}
+
+        {/* Temperature curve — drawn twice via clip paths so the elapsed part of
+            the day renders dimmed (an overlay wash would tint dark mode wrong). */}
         <svg
           className="pointer-events-none absolute inset-0 h-full w-full text-amber-400"
           viewBox="0 0 100 100"
@@ -161,24 +203,38 @@ export function WeatherHourlyChart({ points, timezone, className }: WeatherHourl
               <stop offset="0%" stopColor="currentColor" stopOpacity="0.28" />
               <stop offset="80%" stopColor="currentColor" stopOpacity="0.02" />
             </linearGradient>
+            <clipPath id={`${gradientId}-past`}>
+              <rect x="0" y="0" width={nowPct} height="100" />
+            </clipPath>
+            <clipPath id={`${gradientId}-future`}>
+              <rect x={nowPct} y="0" width={100 - nowPct} height="100" />
+            </clipPath>
           </defs>
-          <path d={areaD} fill={`url(#${gradientId})`} />
-          <path
-            d={lineD}
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            vectorEffect="non-scaling-stroke"
-          />
+          {[
+            { clip: 'past', opacity: 0.45 },
+            { clip: 'future', opacity: 1 },
+          ].map(({ clip, opacity }) => (
+            <g key={clip} clipPath={`url(#${gradientId}-${clip})`} opacity={opacity}>
+              <path d={areaD} fill={`url(#${gradientId})`} />
+              <path
+                d={lineD}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            </g>
+          ))}
         </svg>
 
         {/* Rain bars + per-hour tooltip hit areas */}
         <div className="absolute inset-0 flex">
-          {points.map((p) => {
+          {points.map((p, i) => {
             const mm = p.precipitationMm ?? 0;
             const barPct =
               mm > 0 ? Math.min(RAIN_AREA_PCT, Math.max(8, (mm / rainScale) * RAIN_AREA_PCT)) : 0;
+            const isPast = (i + 1) * 60 <= nowMinutes;
             const prob = p.precipitationProbability;
             const { icon: HourIcon, label, color } = getWeatherConfig(p.weatherCode ?? 0, p.isDay);
             const ariaLabel = `${fmtTime(p.time)} · ${
@@ -190,7 +246,10 @@ export function WeatherHourlyChart({ points, timezone, className }: WeatherHourl
                   <div className="relative min-w-0 flex-1" aria-label={ariaLabel}>
                     {barPct > 0 && (
                       <div
-                        className="absolute inset-x-[15%] bottom-0 rounded-t-[2px] bg-sky-400/85"
+                        className={cn(
+                          'absolute inset-x-[15%] bottom-0 rounded-t-[2px] bg-sky-400/85',
+                          isPast && 'opacity-40'
+                        )}
                         style={{ height: `${barPct}%` }}
                       />
                     )}
@@ -230,13 +289,6 @@ export function WeatherHourlyChart({ points, timezone, className }: WeatherHourl
             );
           })}
         </div>
-
-        {/* Mute hours that have already passed */}
-        <div
-          className="bg-background/45 pointer-events-none absolute inset-y-0 left-0"
-          style={{ width: `${nowPct}%` }}
-          aria-hidden="true"
-        />
 
         {/* "Now" marker */}
         <div
@@ -278,10 +330,17 @@ export function WeatherHourlyChart({ points, timezone, className }: WeatherHourl
         {points.map((p, i) => {
           if (i % 3 !== 0) return <div key={p.time} className="min-w-0 flex-1" />;
           const { icon: HourIcon, color } = getWeatherConfig(p.weatherCode ?? 0, p.isDay);
+          const isPast = (i + 1) * 60 <= nowMinutes;
           return (
-            <div key={p.time} className="flex min-w-0 flex-1 flex-col items-center gap-0.5">
+            <div
+              key={p.time}
+              className={cn(
+                'flex min-w-0 flex-1 flex-col items-center gap-0.5',
+                isPast && 'opacity-50'
+              )}
+            >
               <HourIcon className={cn('h-3.5 w-3.5 shrink-0', color)} aria-hidden="true" />
-              <span className="text-muted-foreground text-[9px] leading-none tabular-nums">
+              <span className="text-muted-foreground text-center text-[9px] leading-tight tabular-nums">
                 {fmtHour(p.time)}
               </span>
             </div>

--- a/components/parks/weather-hourly-chart.tsx
+++ b/components/parks/weather-hourly-chart.tsx
@@ -115,10 +115,15 @@ export function WeatherHourlyChart({
   const peakMm = Math.max(...points.map((p) => p.precipitationMm ?? 0));
   const rainScale = Math.max(RAIN_SCALE_TOP_MM, peakMm);
 
-  // "Now" position as a fraction of the day, in park-local time.
+  // Map a park-local time of day onto the x-axis. Hour values (temp points, axis
+  // labels) sit at the CENTER of their hour column, so clock times must use the
+  // same half-slot offset — a plain minutes/1440 mapping lands ~30 min too far left.
+  const xForMinutes = (min: number) => Math.min(Math.max(((min / 60 + 0.5) / n) * 100, 0), 100);
+
+  // "Now" position, in park-local time.
   const nowMinutes =
     parseInt(nowLocal.slice(11, 13), 10) * 60 + parseInt(nowLocal.slice(14, 16), 10);
-  const nowPct = (nowMinutes / 1440) * 100;
+  const nowPct = xForMinutes(nowMinutes);
 
   // Temperature at "now", interpolated between the neighbouring hour points.
   const u = nowMinutes / 60 - 0.5;
@@ -153,10 +158,10 @@ export function WeatherHourlyChart({
     const open = toLocalIso(Date.parse(todaySchedule.openingTime!), timezone);
     const close = toLocalIso(Date.parse(todaySchedule.closingTime!), timezone);
     if (open.slice(0, 10) === nowLocal.slice(0, 10)) {
-      openPct = (localMinutes(open) / 1440) * 100;
+      openPct = xForMinutes(localMinutes(open));
       // Parks closing after midnight run to the edge of the chart.
       closePct =
-        close.slice(0, 10) > nowLocal.slice(0, 10) ? 100 : (localMinutes(close) / 1440) * 100;
+        close.slice(0, 10) > nowLocal.slice(0, 10) ? 100 : xForMinutes(localMinutes(close));
       if (closePct <= openPct) closePct = 100;
     }
   }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,30 @@ Short log of notable changes; details live in the linked docs.
 
 ---
 
+## Unreleased – Hourly day view in the weather card
+
+Weather-app style detail view for today inside the park weather card: smoothed temperature
+curve with min/max labels, rain bars per hour, a "now" marker (past hours dimmed) and
+per-hour tooltips (time, temp, condition, precip, rain probability), plus an axis with
+weather icons every 3 h. Shown only when the park has a live nowcast.
+
+- **Data**: the backend exposes no hourly temperatures (daily weather + ~6 h nowcast only),
+  so `/api/weather/hourly` proxies Open-Meteo — the backend's own upstream source, already
+  attributed in the card. The proxy keeps requests first-party (no visitor IPs to a third
+  party), validates `lat`/`lon`/`tz`, rounds coords to ~1 km and caches 15 min
+  (`revalidate: 900` + `s-maxage=900`), so all visitors of a park share one upstream call.
+  If/when the backend grows an hourly endpoint, only the route handler needs to change.
+- **Types**: `WeatherHourlyPoint` / `WeatherHourlyToday` in `lib/api/types.ts`.
+- **Hook**: `useWeatherHourly` (client-only, 15 min stale, 30 min refetch to roll the chart
+  over to the new day after midnight); enabled only when a nowcast exists.
+- **Component**: `components/parks/weather-hourly-chart.tsx`; hides itself when the data no
+  longer belongs to "today" in the park timezone (midnight gap until the next refetch).
+- **Park page**: passes `latitude`/`longitude`/`timezone` to `WeatherCard` (new optional
+  props — other `WeatherCard` consumers are unaffected).
+- **i18n**: `parks.weather.hourlyTitle` / `parks.weather.nowLabel` in all 6 locales.
+
+---
+
 ## Unreleased – Rope-drop recommendations
 
 Surfaces the API's precomputed rope-drop data (backend PR #67): is it worth arriving at park

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -188,6 +188,28 @@ export interface WeatherNowcast {
 }
 
 // ============================================================================
+// Weather Hourly (today's hour-by-hour forecast, proxied from Open-Meteo)
+// ============================================================================
+
+export interface WeatherHourlyPoint {
+  /** Naive park-local hour ("YYYY-MM-DDTHH:00"), same convention as nowcast steps. */
+  time: string;
+  temperatureC: number | null;
+  /** mm accumulated in this hour slot. */
+  precipitationMm: number | null;
+  /** 0–100%. */
+  precipitationProbability: number | null;
+  weatherCode: number | null;
+  isDay: boolean;
+}
+
+export interface WeatherHourlyToday {
+  /** IANA timezone the point times are local to. */
+  timezone: string;
+  points: WeatherHourlyPoint[];
+}
+
+// ============================================================================
 // Queue Data
 // ============================================================================
 

--- a/lib/hooks/use-weather-hourly.ts
+++ b/lib/hooks/use-weather-hourly.ts
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+import type { WeatherHourlyToday } from '@/lib/api/types';
+
+interface UseWeatherHourlyParams {
+  latitude: number | null | undefined;
+  longitude: number | null | undefined;
+  timezone: string | undefined;
+  /** Gate the fetch (e.g. only when a nowcast exists, so the day view is shown at all). */
+  enabled?: boolean;
+}
+
+/**
+ * Today's hour-by-hour forecast (temperature + precipitation) for a park
+ * location, via the cached `/api/weather/hourly` Open-Meteo proxy.
+ * The server response is cached 15 min, so polling faster is wasted work; the
+ * 30-min refetch mainly rolls the chart over to the new day after midnight.
+ */
+export function useWeatherHourly({
+  latitude,
+  longitude,
+  timezone,
+  enabled = true,
+}: UseWeatherHourlyParams) {
+  const hasCoords = latitude != null && longitude != null && !!timezone;
+
+  return useQuery<WeatherHourlyToday | null>({
+    queryKey: ['weather-hourly', latitude, longitude, timezone],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/weather/hourly?lat=${latitude}&lon=${longitude}&tz=${encodeURIComponent(timezone!)}`,
+        { cache: 'no-store' }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch hourly weather: ${response.statusText}`);
+      }
+
+      return (await response.json()) as WeatherHourlyToday;
+    },
+    // Client-only: under Cache Components, running the query during the static
+    // prerender would read Date.now() internally (React Query).
+    enabled: enabled && hasCoords && typeof window !== 'undefined',
+    staleTime: 15 * 60_000,
+    gcTime: 60 * 60_000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: 30 * 60_000,
+    retry: 1,
+  });
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -306,7 +306,9 @@
       },
       "gustsLabel": "Böen",
       "visibilityLabel": "Sicht",
-      "snowLabel": "Schnee"
+      "snowLabel": "Schnee",
+      "hourlyTitle": "Stündliche Vorhersage",
+      "nowLabel": "Jetzt"
     },
     "weatherNowcast": {
       "updateIn": "Aktualisierung in {countdown}",

--- a/messages/de.json
+++ b/messages/de.json
@@ -307,7 +307,6 @@
       "gustsLabel": "Böen",
       "visibilityLabel": "Sicht",
       "snowLabel": "Schnee",
-      "hourlyTitle": "Stündliche Vorhersage",
       "nowLabel": "Jetzt"
     },
     "weatherNowcast": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -461,7 +461,9 @@
       },
       "gustsLabel": "Gusts",
       "visibilityLabel": "Visibility",
-      "snowLabel": "Snow"
+      "snowLabel": "Snow",
+      "hourlyTitle": "Hourly forecast",
+      "nowLabel": "Now"
     },
     "weatherNowcast": {
       "updateIn": "Update in {countdown}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -462,7 +462,6 @@
       "gustsLabel": "Gusts",
       "visibilityLabel": "Visibility",
       "snowLabel": "Snow",
-      "hourlyTitle": "Hourly forecast",
       "nowLabel": "Now"
     },
     "weatherNowcast": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -461,7 +461,9 @@
       },
       "gustsLabel": "Ráfagas",
       "visibilityLabel": "Visibilidad",
-      "snowLabel": "Nieve"
+      "snowLabel": "Nieve",
+      "hourlyTitle": "Pronóstico por horas",
+      "nowLabel": "Ahora"
     },
     "weatherNowcast": {
       "updateIn": "Actualización en {countdown}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -462,7 +462,6 @@
       "gustsLabel": "Ráfagas",
       "visibilityLabel": "Visibilidad",
       "snowLabel": "Nieve",
-      "hourlyTitle": "Pronóstico por horas",
       "nowLabel": "Ahora"
     },
     "weatherNowcast": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -462,7 +462,6 @@
       "gustsLabel": "Rafales",
       "visibilityLabel": "Visibilité",
       "snowLabel": "Neige",
-      "hourlyTitle": "Prévisions horaires",
       "nowLabel": "Maintenant"
     },
     "weatherNowcast": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -461,7 +461,9 @@
       },
       "gustsLabel": "Rafales",
       "visibilityLabel": "Visibilité",
-      "snowLabel": "Neige"
+      "snowLabel": "Neige",
+      "hourlyTitle": "Prévisions horaires",
+      "nowLabel": "Maintenant"
     },
     "weatherNowcast": {
       "updateIn": "Mise à jour dans {countdown}",

--- a/messages/it.json
+++ b/messages/it.json
@@ -461,7 +461,9 @@
       },
       "gustsLabel": "Raffiche",
       "visibilityLabel": "Visibilità",
-      "snowLabel": "Neve"
+      "snowLabel": "Neve",
+      "hourlyTitle": "Previsioni orarie",
+      "nowLabel": "Ora"
     },
     "weatherNowcast": {
       "updateIn": "Aggiornamento tra {countdown}",

--- a/messages/it.json
+++ b/messages/it.json
@@ -462,7 +462,6 @@
       "gustsLabel": "Raffiche",
       "visibilityLabel": "Visibilità",
       "snowLabel": "Neve",
-      "hourlyTitle": "Previsioni orarie",
       "nowLabel": "Ora"
     },
     "weatherNowcast": {

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -462,7 +462,6 @@
       "gustsLabel": "Windstoten",
       "visibilityLabel": "Zicht",
       "snowLabel": "Sneeuw",
-      "hourlyTitle": "Verwachting per uur",
       "nowLabel": "Nu"
     },
     "weatherNowcast": {

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -461,7 +461,9 @@
       },
       "gustsLabel": "Windstoten",
       "visibilityLabel": "Zicht",
-      "snowLabel": "Sneeuw"
+      "snowLabel": "Sneeuw",
+      "hourlyTitle": "Verwachting per uur",
+      "nowLabel": "Nu"
     },
     "weatherNowcast": {
       "updateIn": "Update over {countdown}",


### PR DESCRIPTION
## Summary

Weather-app style **hourly day view for today** inside the park weather card, shown when the park has a live nowcast:

- Smoothed **temperature curve** (SVG, Catmull-Rom) with min/max labels and gradient fill
- **Rain bars** per hour (scaled so "moderate rain" fills the band; light rain stays visible via a height floor)
- **"Now" marker** with interpolated dot on the curve; past hours are dimmed; label auto-hides when it would collide with the max-temp label
- **Per-hour tooltips**: time, temperature (°C/°F via the dual-unit toggle), condition, precipitation, rain probability
- Axis with weather icon + hour label every 3 h
- Chart hides itself after midnight (park timezone) until the next refetch rolls the data over to the new day

## Why a new Open-Meteo proxy route

The backend only exposes daily weather plus a ~6 h nowcast **without hourly temperatures**, so a day view can't be built from the existing endpoints. The new `/api/weather/hourly` route proxies **Open-Meteo** — the backend's own upstream source, already attributed in the card:

- Keeps requests first-party (no visitor IPs leak to a third party)
- Validates `lat`/`lon`/`tz`, rounds coordinates to ~1 km, missing params → 400
- Cached 15 min (`revalidate: 900` + `s-maxage=900`) so all visitors of a park share one upstream call
- If the backend later grows an hourly endpoint, only this route handler needs to change

## Changes

- `app/api/weather/hourly/route.ts` — cached Open-Meteo proxy
- `components/parks/weather-hourly-chart.tsx` — the day-view chart
- `lib/hooks/use-weather-hourly.ts` — client query (enabled only when a nowcast exists)
- `lib/api/types.ts` — `WeatherHourlyPoint` / `WeatherHourlyToday`
- `components/parks/weather-card.tsx` — new optional `latitude`/`longitude`/`timezone` props + chart slot (other `WeatherCard` consumers unaffected)
- Park page passes coords/timezone; `parks.weather.hourlyTitle` / `nowLabel` in all 6 locales; changelog entry

## Verification

Verified in the running dev server with Playwright (desktop 1280px + mobile 375px, Phantasialand): chart renders with curve, bars, now-marker, tooltips and axis; hourly route returns 24 points; invalid/missing params → 400; when the hourly fetch fails the card renders unchanged without the section. Note: a pre-existing `RangeError: Incorrect locale information provided` page error exists on the park page independent of this change.

https://claude.ai/code/session_01TV3SCgDyXKsFvt1NnKvNhp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TV3SCgDyXKsFvt1NnKvNhp)_