### PR TITLE
fix(park): load weather first, best travel time always last; fix stale-day hourly chart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ Theme park wait times and statistics frontend for **[api.park.fan](https://api.p
 **Technology Stack:** Next.js 16 (App Router), React 19, TypeScript.
 **Routing:** This project uses **`proxy.ts`** for routing and i18n middleware, **not** a standard `middleware.ts`.
 Multilingual (EN/DE/NL/FR/ES/IT), Server Components by default. All detailed documentation lives in **`docs/`** - start at **[docs/README.md](docs/README.md)**.
+**Park page loading priority (REQUIREMENT):** the best-travel-time data (best-days calendar + historical stats) must **always load last** — live status, wait times and all weather queries load first. Enforced via `useLoadLast` (`lib/hooks/use-load-last.ts`); see [system-overview](docs/architecture/system-overview.md#4-park-page-loading-priority-requirement).
 
 ---
 

--- a/app/api/weather/hourly/route.ts
+++ b/app/api/weather/hourly/route.ts
@@ -11,9 +11,19 @@ import type { WeatherHourlyPoint, WeatherHourlyToday } from '@/lib/api/types';
  * party) and lets the Next data cache + CDN collapse all visitors of a park onto
  * one upstream call per cache window.
  *
- * Query params: lat, lon (coordinates), tz (IANA timezone for local hour labels).
+ * Query params: lat, lon (coordinates), tz (IANA timezone for local hour labels),
+ * date (optional YYYY-MM-DD — the park-local "today" the client renders).
  * Coordinates are rounded to 2 decimals (~1 km) — plenty for weather, and it
  * canonicalizes the upstream URL for better cache hits.
+ *
+ * The `date` param pins the upstream request to an explicit day
+ * (`start_date`/`end_date`) instead of `forecast_days=1` ("today at upstream
+ * fetch time"). This makes every cache key — CDN (request URL) and Next data
+ * cache (upstream URL) — roll over with the park-local day, so a
+ * stale-while-revalidate serve can never return YESTERDAY's hours for a
+ * request made today. (The chart hides data that isn't "today", so that stale
+ * serve made the hourly day view randomly disappear for the first visitors of
+ * a day.)
  */
 
 interface OpenMeteoHourlyResponse {
@@ -29,6 +39,7 @@ interface OpenMeteoHourlyResponse {
 }
 
 const TZ_PATTERN = /^[A-Za-z0-9_+\-/]{1,64}$/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -51,12 +62,20 @@ export async function GET(request: NextRequest) {
   if (!TZ_PATTERN.test(tz)) {
     return NextResponse.json({ error: 'Invalid tz' }, { status: 400 });
   }
+  const date = searchParams.get('date');
+  if (date !== null && !DATE_PATTERN.test(date)) {
+    return NextResponse.json({ error: 'Invalid date' }, { status: 400 });
+  }
+
+  // Explicit day when the client sent one (date-stable cache keys, see above);
+  // `forecast_days=1` as back-compat fallback for requests without it.
+  const dayWindow = date ? `&start_date=${date}&end_date=${date}` : `&forecast_days=1`;
 
   const upstream =
     `https://api.open-meteo.com/v1/forecast` +
     `?latitude=${lat.toFixed(2)}&longitude=${lon.toFixed(2)}` +
     `&hourly=temperature_2m,precipitation,precipitation_probability,weather_code,is_day` +
-    `&forecast_days=1&timezone=${encodeURIComponent(tz)}`;
+    `${dayWindow}&timezone=${encodeURIComponent(tz)}`;
 
   try {
     // Open-Meteo refreshes its models roughly hourly; 15 min keeps the curve

--- a/components/parks/park-best-days-section.tsx
+++ b/components/parks/park-best-days-section.tsx
@@ -104,7 +104,11 @@ export function ParkBestDaysSection({
   // Calendar window derived from the browser clock (client-only) so the park shell never reads
   // the server clock — keeping it time-independent for the 1-day TTL.
   const { from, to } = getCalendarWindow(useBrowserNow(null));
-  const { data: calendarData, isLoading: calendarLoading } = useParkBestDaysCalendar({
+  // `isPending` (not `isLoading`): both queries start DISABLED — until mounted/the calendar
+  // window is known, and until useLoadLast releases them (best-travel-time loads last, see
+  // the hooks). A disabled query is pending but not fetching, so `isLoading` would be false
+  // and the section would flash its empty fallback during the defer window.
+  const { data: calendarData, isPending: calendarPending } = useParkBestDaysCalendar({
     continent,
     country,
     city,
@@ -112,7 +116,7 @@ export function ParkBestDaysSection({
     from,
     to,
   });
-  const { data: stats, isLoading: statsLoading } = useParkHistoricalStats({
+  const { data: stats, isPending: statsPending } = useParkHistoricalStats({
     continent,
     country,
     city,
@@ -120,7 +124,7 @@ export function ParkBestDaysSection({
   });
 
   // The compact header card has no skeleton placeholder; render nothing until data arrives.
-  if (!mounted || calendarLoading || statsLoading) {
+  if (!mounted || calendarPending || statsPending) {
     return compact ? null : <ParkBestDaysSectionSkeleton />;
   }
 

--- a/components/parks/park-stats-section.tsx
+++ b/components/parks/park-stats-section.tsx
@@ -34,14 +34,17 @@ export function ParkStatsSection({
   // Browser-only query (disabled during SSR). Show the skeleton until mounted + loaded so the
   // static prerender renders the placeholder rather than an empty section.
   const mounted = useMounted();
-  const { data: stats, isLoading } = useParkHistoricalStats({
+  // `isPending` (not `isLoading`): the query starts DISABLED until useLoadLast releases it
+  // (best-travel-time/stats load last). A disabled query is pending but not fetching, so
+  // `isLoading` would be false and the section would vanish during the defer window.
+  const { data: stats, isPending } = useParkHistoricalStats({
     continent,
     country,
     city,
     parkSlug,
   });
 
-  if (!mounted || isLoading) {
+  if (!mounted || isPending) {
     return <ParkStatsSectionSkeleton />;
   }
 

--- a/components/parks/weather-card.tsx
+++ b/components/parks/weather-card.tsx
@@ -84,14 +84,17 @@ export function WeatherCard({
   // liveNowcast is undefined when the hook is disabled (no params) — fall back to the static prop
   const activeNowcast = hasParams ? liveNowcast : nowcast;
 
-  // Detailed day view for today — only when a nowcast exists (parks with live
-  // weather coverage) and we know where the park is. A static `hourly` prop
+  // Detailed day view for today. The fetch starts IMMEDIATELY (in parallel with the
+  // nowcast, not gated on it) so the chart is ready the moment the nowcast lands —
+  // the old nowcast→hourly waterfall delayed the weather card by a full roundtrip.
+  // Rendering below still requires a nowcast (parks with live weather coverage); for
+  // parks without one the single CDN-cached fetch is cheap. A static `hourly` prop
   // (showcases/demos) takes precedence and disables the fetch.
   const { data: fetchedHourly } = useWeatherHourly({
     latitude,
     longitude,
     timezone,
-    enabled: !!activeNowcast && hourly === undefined,
+    enabled: hourly === undefined,
   });
   const activeHourly = hourly !== undefined ? hourly : fetchedHourly;
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -29,6 +29,24 @@ The park.fan frontend is a **Next.js 16** App Router application with Server Com
 3. **Rendering** → HTML with SEO, JSON-LD, meta tags
 4. **Client** → Hydration, theme, search, favorites
 
+### 4. Park page loading priority (REQUIREMENT)
+
+On the park detail page, the **best-travel-time data ("Beste Reisezeit": best-days
+calendar + historical stats) must ALWAYS load LAST — everything else loads first.**
+
+- These are the largest and slowest park requests (cold backend compute can take
+  10–20 s); they must never compete with the fast, user-visible live data (park
+  status, wait times, weather nowcast, hourly weather) for bandwidth or backend
+  capacity.
+- Enforced centrally by `lib/hooks/use-load-last.ts` (`useLoadLast`), which holds
+  back `useParkBestDaysCalendar` and `useParkHistoricalStats` until every other
+  React Query fetch on the page has settled (plus a safety timeout so the sections
+  can never be starved). **Any new consumer of calendar/stats data on the park page
+  must go through these hooks** so the rule cannot be bypassed (queries with the
+  same key would otherwise start the fetch early).
+- Conversely: weather must load EARLY. The hourly day-view fetch runs in parallel
+  with the nowcast (no waterfall); only its _rendering_ is gated on the nowcast.
+
 ---
 
 ## Routing Structure

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,39 @@ Short log of notable changes; details live in the linked docs.
 
 ---
 
+## Unreleased – Park page load order: weather first, best travel time last
+
+Two loading fixes on the park page, plus a stale-cache fix that made the hourly weather
+day view randomly disappear.
+
+- **Hourly day view sometimes missing (stale-day cache race)**: `/api/weather/hourly`
+  used `forecast_days=1` ("today at upstream fetch time") behind two
+  stale-while-revalidate cache layers (Next data cache `revalidate: 900` + CDN
+  `s-maxage=900`). The Next data cache serves a stale entry (any age) while it
+  revalidates in the background — so the first visitors after midnight could receive
+  YESTERDAY's hours. `WeatherHourlyChart` hides data that isn't "today" in the park
+  timezone, so the chart silently vanished on those pages and reappeared on reload.
+  Fix: the client (`useWeatherHourly`) now sends the park-local date (browser clock,
+  computed at fetch time) as `&date=`, and the route maps it to Open-Meteo
+  `start_date`/`end_date`. Every cache key (CDN request URL + Next data-cache upstream
+  URL) now rolls over with the park-local day, so a stale serve can never deliver the
+  wrong day.
+- **Weather loaded too late (nowcast→hourly waterfall)**: the hourly fetch was gated on
+  the nowcast having arrived. It now starts in parallel on mount; only the _rendering_
+  of the day view still requires a nowcast.
+- **Best travel time ALWAYS loads last (requirement)**: the best-days calendar +
+  historical stats are the page's largest/slowest requests (cold compute 10–20 s) and
+  competed with the live/weather queries. New `useLoadLast` gate
+  (`lib/hooks/use-load-last.ts`) defers `useParkBestDaysCalendar` +
+  `useParkHistoricalStats` until every other React Query fetch on the page has settled
+  (300 ms network-idle grace, 5 s safety timeout so the sections can't be starved).
+  Consumers (`ParkBestDaysSection`, `ParkStatsSection`) now gate their skeletons on
+  `isPending` instead of `isLoading` — a deferred (disabled) query is pending but not
+  fetching, so `isLoading` would have flashed the empty fallback. Requirement
+  documented in [system-overview](architecture/system-overview.md) and `CLAUDE.md`.
+
+---
+
 ## Unreleased – Hourly day view in the weather card
 
 Weather-app style detail view for today inside the park weather card: smoothed temperature

--- a/lib/hooks/use-load-last.ts
+++ b/lib/hooks/use-load-last.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { useIsFetching } from '@tanstack/react-query';
+
+// Query-key prefixes of the deferred trip-planning queries themselves — they
+// must not block their own release.
+const DEFERRED_KEY_PREFIXES = ['park-best-days-calendar', 'park-historical-stats'];
+
+// How long the rest of the page must be network-idle before the deferred
+// queries are released. Mount-time fetches dispatch within the same commit,
+// so a short window is enough to catch them (and dependent queries they
+// enable) before releasing.
+const SETTLE_GRACE_MS = 300;
+
+// Hard cap so the trip-planning sections can never be starved — e.g. by a
+// poll that never goes idle or a hanging request.
+const SAFETY_TIMEOUT_MS = 5000;
+
+/**
+ * Load-priority gate for the park page's heavy trip-planning queries
+ * (best-days calendar + historical stats).
+ *
+ * REQUIREMENT (docs/architecture/system-overview.md → "Park page loading
+ * priority"): the best-travel-time data must ALWAYS load LAST. Live status,
+ * wait times and every weather query (nowcast, hourly day view) load first —
+ * the calendar/stats responses are the largest and slowest park requests
+ * (cold backend compute can take 10–20 s) and must never compete with the
+ * fast, user-visible live data for bandwidth or backend capacity.
+ *
+ * Returns `true` once every OTHER React Query fetch on the page has been idle
+ * for a short grace period, or after a safety timeout. Once released it stays
+ * released (later polls don't re-suspend the sections).
+ */
+export function useLoadLast(): boolean {
+  const [released, setReleased] = useState(false);
+
+  // In-flight queries other than the deferred ones themselves (reactive).
+  const fetchingOthers = useIsFetching({
+    predicate: (query) => !DEFERRED_KEY_PREFIXES.includes(query.queryKey[0] as string),
+  });
+
+  // Release after the page has been network-idle for the grace period. Any
+  // fetch starting inside the window re-arms the timer (cleanup clears it).
+  useEffect(() => {
+    if (released || fetchingOthers > 0) return;
+    const timer = setTimeout(() => setReleased(true), SETTLE_GRACE_MS);
+    return () => clearTimeout(timer);
+  }, [released, fetchingOthers]);
+
+  useEffect(() => {
+    if (released) return;
+    const timer = setTimeout(() => setReleased(true), SAFETY_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [released]);
+
+  return released;
+}

--- a/lib/hooks/use-park-best-days-calendar.ts
+++ b/lib/hooks/use-park-best-days-calendar.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useLoadLast } from '@/lib/hooks/use-load-last';
 import type { IntegratedCalendarResponse } from '@/lib/api/types';
 
 interface UseParkBestDaysCalendarParams {
@@ -23,6 +24,10 @@ interface UseParkBestDaysCalendarParams {
  *   where reading the clock internally (React Query) is forbidden under Cache Components.
  * - 30-min staleTime: this fuels trip-planning aggregates that only shift with the daily
  *   forecast, so a half-hour-old snapshot is fine.
+ * - Deferred via `useLoadLast`: the best-travel-time data must ALWAYS load last on the park
+ *   page — this large, slow (cold compute 10–20 s) response must never compete with the live
+ *   status/weather queries (see docs/architecture/system-overview.md → "Park page loading
+ *   priority").
  */
 export function useParkBestDaysCalendar({
   continent,
@@ -32,6 +37,8 @@ export function useParkBestDaysCalendar({
   from,
   to,
 }: UseParkBestDaysCalendarParams) {
+  const releasedLast = useLoadLast();
+
   return useQuery<IntegratedCalendarResponse>({
     queryKey: ['park-best-days-calendar', continent, country, city, parkSlug, from, to],
     queryFn: async () => {
@@ -47,8 +54,9 @@ export function useParkBestDaysCalendar({
       return (await response.json()) as IntegratedCalendarResponse;
     },
     // Browser-only, and only once the (client-derived) window is known — `from`/`to` are empty
-    // until the browser clock lands, and we must not fire a `?from=&to=` request.
-    enabled: typeof window !== 'undefined' && from !== '' && to !== '',
+    // until the browser clock lands, and we must not fire a `?from=&to=` request. `releasedLast`
+    // holds the fetch back until every other query on the page has settled (loads-last rule).
+    enabled: typeof window !== 'undefined' && from !== '' && to !== '' && releasedLast,
     staleTime: 30 * 60_000,
     gcTime: 60 * 60_000,
     refetchOnWindowFocus: false,

--- a/lib/hooks/use-park-historical-stats.ts
+++ b/lib/hooks/use-park-historical-stats.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useLoadLast } from '@/lib/hooks/use-load-last';
 import type { ParkHistoricalStats } from '@/lib/api/types';
 
 interface UseParkHistoricalStatsParams {
@@ -20,6 +21,9 @@ interface UseParkHistoricalStatsParams {
  *   where reading the clock internally (React Query) is forbidden under Cache Components.
  * - 404 = "no displayable stats for this park" → treated as `null`, no retries.
  * - 1h staleTime mirrors the server cache window (data changes daily, not in real time).
+ * - Deferred via `useLoadLast`: feeds the best-travel-time + stats sections, which must
+ *   ALWAYS load last on the park page — never competing with the live status/weather
+ *   queries (see docs/architecture/system-overview.md → "Park page loading priority").
  */
 export function useParkHistoricalStats({
   continent,
@@ -27,6 +31,8 @@ export function useParkHistoricalStats({
   city,
   parkSlug,
 }: UseParkHistoricalStatsParams) {
+  const releasedLast = useLoadLast();
+
   return useQuery<ParkHistoricalStats | null>({
     queryKey: ['park-historical-stats', continent, country, city, parkSlug],
     queryFn: async () => {
@@ -44,7 +50,9 @@ export function useParkHistoricalStats({
 
       return (await response.json()) as ParkHistoricalStats;
     },
-    enabled: typeof window !== 'undefined',
+    // `releasedLast` holds the fetch back until every other query on the page has settled
+    // (loads-last rule).
+    enabled: typeof window !== 'undefined' && releasedLast,
     staleTime: 60 * 60_000,
     gcTime: 90 * 60_000,
     refetchOnWindowFocus: false,

--- a/lib/hooks/use-weather-hourly.ts
+++ b/lib/hooks/use-weather-hourly.ts
@@ -5,15 +5,33 @@ interface UseWeatherHourlyParams {
   latitude: number | null | undefined;
   longitude: number | null | undefined;
   timezone: string | undefined;
-  /** Gate the fetch (e.g. only when a nowcast exists, so the day view is shown at all). */
+  /** Gate the fetch (e.g. when static `hourly` data is supplied instead). */
   enabled?: boolean;
+}
+
+/** Today's date (YYYY-MM-DD) in the park timezone, from the browser clock. */
+function parkLocalDate(timezone: string): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(Date.now());
 }
 
 /**
  * Today's hour-by-hour forecast (temperature + precipitation) for a park
  * location, via the cached `/api/weather/hourly` Open-Meteo proxy.
- * The server response is cached 15 min, so polling faster is wasted work; the
- * 30-min refetch mainly rolls the chart over to the new day after midnight.
+ *
+ * The explicit `date` param pins every cache layer (CDN + Next data cache) to
+ * the park-local day the CHART will check against ("is this today?"). Without
+ * it, a stale-while-revalidate serve could hand the first visitor of the day
+ * yesterday's response — whose date no longer matches "today", so the day view
+ * silently disappeared on some pages. The date is computed at FETCH time (not
+ * in the query key), so the 30-min refetch rolls the chart over to the new day
+ * after midnight, same as before.
+ *
+ * The server response is cached 15 min, so polling faster is wasted work.
  */
 export function useWeatherHourly({
   latitude,
@@ -26,8 +44,9 @@ export function useWeatherHourly({
   return useQuery<WeatherHourlyToday | null>({
     queryKey: ['weather-hourly', latitude, longitude, timezone],
     queryFn: async () => {
+      const date = parkLocalDate(timezone!);
       const response = await fetch(
-        `/api/weather/hourly?lat=${latitude}&lon=${longitude}&tz=${encodeURIComponent(timezone!)}`,
+        `/api/weather/hourly?lat=${latitude}&lon=${longitude}&tz=${encodeURIComponent(timezone!)}&date=${date}`,
         { cache: 'no-store' }
       );
 


### PR DESCRIPTION
## Problem

1. **Hourly weather day view randomly missing on some park pages** (e.g. Phantasialand in the report, while Bobbejaanland showed it) — even though the nowcast/live badge and rain banner were present.
2. **Weather loaded too late** on the park page.
3. **Requirement:** the best-travel-time data ("Beste Reisezeit") must ALWAYS load last on the park page — everything else first.

## Root cause of the missing chart (the suspected race condition)

`/api/weather/hourly` asked Open-Meteo for `forecast_days=1` — i.e. *"today at upstream fetch time"* — behind **two stale-while-revalidate cache layers** (Next data cache `revalidate: 900` + CDN `s-maxage=900`). The Next data cache serves a stale entry of **any age** while revalidating in the background, so the first visitors of a (cache-)day could receive **yesterday's** hours. `WeatherHourlyChart` deliberately hides data that isn't "today" in the park timezone → the chart silently disappeared and came back on the next reload (after the background revalidation). A classic cache race, which is why it only hit *some* pages *sometimes*.

## Fixes

- **Date-stable caching:** `useWeatherHourly` now sends the park-local date (browser clock, computed at fetch time) as `&date=`; the route maps it to Open-Meteo `start_date`/`end_date`. Every cache key (CDN request URL + Next data-cache upstream URL) now rolls over with the park-local day — a stale serve can never deliver the wrong day. The browser-clock date also matches exactly what the chart validates against, eliminating server/browser clock-skew mismatches around midnight. (Route keeps `forecast_days=1` as fallback for date-less requests.)
- **Weather earlier:** the hourly fetch no longer waits for the nowcast (waterfall removed) — it starts in parallel on mount; only the *rendering* of the day view is still gated on the nowcast.
- **Best travel time always last:** new `useLoadLast` gate (`lib/hooks/use-load-last.ts`) defers `useParkBestDaysCalendar` + `useParkHistoricalStats` (the page's largest/slowest requests, cold compute 10–20 s) until every other React Query fetch on the page has settled — 300 ms network-idle grace window, 5 s safety timeout so the sections can never be starved. Gated inside the hooks themselves so no consumer (best-days section, stats section, FAQ Q7) can bypass the rule via a shared query key.
- **Skeleton fix:** `ParkBestDaysSection` / `ParkStatsSection` gate on `isPending` instead of `isLoading` — a deferred (disabled) query is pending but not fetching, so `isLoading` would have flashed the empty fallback during the defer window.

## Docs

- Requirement documented in `CLAUDE.md` and `docs/architecture/system-overview.md` ("Park page loading priority (REQUIREMENT)").
- `docs/changelog.md` entry.

## Verification

- `tsc --noEmit` ✓, `eslint` ✓, `prettier` ✓, `next build --turbo` ✓
- Open-Meteo verified to accept `start_date`/`end_date` with the same hourly params.

https://claude.ai/code/session_01E6Wk7KpjBn7bzspJW9r8fR

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6Wk7KpjBn7bzspJW9r8fR)_