### PR TITLE
fix(weather): anchor the "now" label to the curve dot; keep bg animations alive on iOS

### DIFF
--- a/components/parks/weather-background.css
+++ b/components/parks/weather-background.css
@@ -5,6 +5,30 @@
   border-radius: inherit;
   z-index: 0;
   --cloud: #ffffff;
+  /* Size container so the cloud drift can be a compositor `transform` animation
+     in container-width units (see weather-drift-transform below). */
+  container-type: size;
+}
+
+/* iOS/WebKit: content BEHIND a backdrop-filter (the glass overlay) is only
+   re-snapshotted when the compositor updates — without their own GPU layers
+   the animated scene appears frozen except while scrolling. Promote every
+   animated layer and the glass itself so the scene keeps animating behind
+   the blur. (The sun keeps its layer via will-change only — its pulse
+   keyframes own the transform.) */
+.weather-bg__canvas,
+.weather-bg__clouds,
+.weather-bg__stars,
+.weather-bg__fog,
+.weather-bg__flash,
+.weather-bg__bolt,
+.weather-bg__sun,
+.weather-bg__glass {
+  will-change: transform;
+}
+.weather-bg__canvas,
+.weather-bg__glass {
+  transform: translateZ(0);
 }
 
 /* --- Sky gradients (day) --- */
@@ -178,6 +202,17 @@
   animation: weather-drift var(--duration) linear infinite;
   animation-delay: var(--delay);
 }
+/* Compositor-driven drift where container units exist (Safari 16+/modern):
+   animating `left` runs on the main thread, and on iOS such changes never
+   reach the backdrop-filter snapshot — the clouds only moved while
+   scrolling. `translateX` in cqw units is handled by the compositor and
+   keeps the whole scene repainting behind the glass. */
+@supports (width: 1cqw) {
+  .weather-bg__cloud {
+    left: 0;
+    animation-name: weather-drift-transform;
+  }
+}
 .weather-bg__cloud::before,
 .weather-bg__cloud::after {
   content: '';
@@ -289,6 +324,16 @@ html.dark .weather-bg__glass {
   }
   to {
     left: 118%;
+  }
+}
+/* Same path as weather-drift, but compositor-driven; scale must ride along
+   because keyframes replace the element's base transform. */
+@keyframes weather-drift-transform {
+  from {
+    transform: translateX(-30cqw) scale(var(--scale));
+  }
+  to {
+    transform: translateX(118cqw) scale(var(--scale));
   }
 }
 @keyframes weather-fog {

--- a/components/parks/weather-hourly-chart.tsx
+++ b/components/parks/weather-hourly-chart.tsx
@@ -386,19 +386,24 @@ export function WeatherHourlyChart({
           className="border-foreground/30 pointer-events-none absolute inset-y-0 border-l border-dashed"
           style={{ left: `${nowPct}%` }}
           aria-hidden="true"
-        >
-          {showNowLabel && (
-            <span className="text-foreground/60 absolute top-0 left-1 text-[9px] leading-none font-medium">
-              {t('nowLabel')}
-            </span>
-          )}
-        </div>
+        />
         {nowTempY != null && (
           <div
             className="ring-background pointer-events-none absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber-400 ring-2"
             style={{ left: `${nowPct}%`, top: `${nowTempY}%` }}
             aria-hidden="true"
           />
+        )}
+        {/* "Now" label — anchored just above the dot on the curve (not glued to the
+            chart's top edge); hidden when it would collide with the max-temp label. */}
+        {showNowLabel && nowTempY != null && (
+          <span
+            className="text-foreground/60 pointer-events-none absolute -translate-x-1/2 -translate-y-full pb-2.5 text-[9px] leading-none font-medium"
+            style={{ left: `${clampX(nowPct)}%`, top: `${nowTempY}%` }}
+            aria-hidden="true"
+          >
+            {t('nowLabel')}
+          </span>
         )}
 
         {/* Min/max temperature labels, anchored to their hours */}


### PR DESCRIPTION
Follow-up to #158 — these two fixes were pushed a few minutes after the PR had already been merged (the branch had been deleted, so the push silently recreated it instead of landing in the PR). Branch was rebased onto current `main`; this PR contains exactly the one missing commit.

## 1. "Jetzt" label glued to the chart's top edge

The now-label in the hourly day view was pinned with `top-0` to the top of the chart. It now hangs just above the amber "now" dot on the temperature curve (centered on the dashed line). The existing collision guard still applies: near the day's max (where the max-temp label sits), the label is hidden — and it's also hidden when no dot exists (missing temps).

## 2. Background animations on mobile only visible while scrolling

Known iOS/WebKit behavior: content **behind** a `backdrop-filter` (the card's glass overlay) is only re-snapshotted while the compositor updates — in practice, only during scrolling. Two changes in `weather-background.css`:

- **Own GPU layers** for all animated layers (precipitation canvas, clouds, stars, fog, lightning, sun) and the glass overlay itself (`will-change: transform` / `translateZ(0)`), so WebKit keeps re-compositing the scene behind the blur.
- **Cloud drift moved to the compositor**: it animated `left` — a main-thread layout animation that never reaches the backdrop snapshot on iOS. It's now a `transform: translateX(…)` animation in container-width units (`cqw`, same −30 % → 118 % path; `.weather-bg` becomes a size container). Browsers without container units keep the old `left` keyframes as fallback.

## Verification

- `tsc --noEmit` ✓, `eslint` ✓, `prettier` ✓
- Please double-check the iOS behavior on a real device via the preview deployment — if it still freezes, the next lever is replacing the backdrop blur with a plain tinted overlay on mobile.

https://claude.ai/code/session_01E6Wk7KpjBn7bzspJW9r8fR

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6Wk7KpjBn7bzspJW9r8fR)_