### PR TITLE
Sort in-park rides by distance and make park-page button mobile-friendly

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -124,7 +124,7 @@ export default async function HomePage({ params }: HomePageProps) {
           Letting the logo load eagerly (it's a small SVG) keeps the preload budget for the hero. */}
       <HomepageFAQStructuredData />
       {/* Hero Section – static default; when user is in a park (nearby), shows "Willkommen im [Park]" + park info */}
-      <section className="relative isolate -mt-14 overflow-hidden px-6 pt-14 pb-14 sm:pb-20 md:pt-28 md:pb-24 lg:flex lg:min-h-dvh lg:flex-col lg:justify-center lg:pt-16 lg:pb-24">
+      <section className="relative isolate -mt-14 overflow-hidden px-6 pt-14 pb-6 sm:pb-8 md:pt-28 md:pb-10 lg:flex lg:min-h-dvh lg:flex-col lg:justify-center lg:pt-16 lg:pb-12">
         <HeroBackground imageSrc={randomHeroImage} />
         <div className="relative container mx-auto">
           <div className="flex flex-col">
@@ -201,8 +201,9 @@ export default async function HomePage({ params }: HomePageProps) {
       {/* Location banner: not for snippet/indexing (data-nosnippet); show when user has not granted location */}
       <LocationBanner />
 
-      {/* Nearby / In-Park – primary focus: nearest open park or quick park navigation when in park */}
-      <section className="px-4 py-8">
+      {/* Nearby / In-Park – primary focus: nearest open park or quick park navigation when in park.
+          No top padding so the (full-bleed) in-park banner sits flush under the hero. */}
+      <section className="px-4 pb-8">
         <div className="container mx-auto">
           <NearbyParksCard />
         </div>

--- a/components/common/background-overlay-image.tsx
+++ b/components/common/background-overlay-image.tsx
@@ -8,6 +8,8 @@ interface BackgroundOverlayImageProps {
   imageSrc: string;
   alt: string;
   hoverEffect?: boolean;
+  /** `next/image` sizes hint. Defaults to the card layout; pass "100vw" for full-bleed use. */
+  sizes?: string;
 }
 
 /** Client leaf: manages fade-in state for the background image on load. */
@@ -15,6 +17,7 @@ export function BackgroundOverlayImage({
   imageSrc,
   alt,
   hoverEffect = false,
+  sizes = '(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw',
 }: BackgroundOverlayImageProps) {
   const [isLoaded, setIsLoaded] = useState(false);
 
@@ -28,7 +31,7 @@ export function BackgroundOverlayImage({
         isLoaded ? 'opacity-40' : 'opacity-0',
         hoverEffect && 'group-hover:opacity-70'
       )}
-      sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+      sizes={sizes}
       priority={false}
       onLoad={() => setIsLoaded(true)}
     />

--- a/components/parks/nearby-parks-card.tsx
+++ b/components/parks/nearby-parks-card.tsx
@@ -191,7 +191,10 @@ export function NearbyParksCard({ className }: { className?: string }) {
     }
 
     const park = data.park;
-    const attractions = (data.rides || []).slice(0, 5);
+    // Sort by distance (nearest first) before limiting — API order isn't guaranteed.
+    const attractions = [...(data.rides || [])]
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, 5);
 
     // Park page URL (for "Go to park page" CTA); fallback from first attraction
     const rawParkUrl = (park as { url?: string })?.url;
@@ -222,12 +225,12 @@ export function NearbyParksCard({ className }: { className?: string }) {
             {/* Quick navigation: primary CTA to park page when user is in park */}
             {parkPageUrl && (
               <div className="mb-4">
-                <Link href={parkPageUrl} prefetch={false}>
-                  <Button className="w-full sm:w-auto" size="lg">
-                    <ChevronRight className="mr-2 h-4 w-4" />
+                <Button asChild size="lg" className="w-full justify-center sm:w-auto">
+                  <Link href={parkPageUrl} prefetch={false}>
                     {t('goToParkPage')}
-                  </Button>
-                </Link>
+                    <ChevronRight className="h-4 w-4" />
+                  </Link>
+                </Button>
               </div>
             )}
             {/* Park Info */}

--- a/components/parks/nearby-parks-card.tsx
+++ b/components/parks/nearby-parks-card.tsx
@@ -206,14 +206,20 @@ export function NearbyParksCard({ className }: { className?: string }) {
     const parkMapUrl = parkPageUrl && attractions.length > 0 ? `${parkPageUrl}#map` : parkPageUrl;
 
     return (
-      <section className={cn('bg-park-primary/5 relative py-6', className)}>
-        {/* Background image: breaks out to the full viewport width (the card sits inside a
-            centered container) and is confined to the header band, faded to the section
-            background so it never bleeds through the attractions list — keeping the list
-            readable in light mode. `left-1/2 -translate-x-1/2 w-screen` is the full-bleed
-            trick; body has `overflow-x: clip` so this adds no horizontal scrollbar. */}
+      <section
+        className={cn(
+          // Full-bleed banner: the card lives inside a centered container, so break the whole
+          // section out to the viewport width (body has `overflow-x: clip` → no h-scrollbar).
+          // The content below is re-contained, so its left/right padding stays symmetric.
+          'bg-park-primary/5 relative left-1/2 w-screen -translate-x-1/2 overflow-hidden py-6',
+          className
+        )}
+      >
+        {/* Background image: confined to the header band and faded to the section background
+            so it never bleeds through the attractions list — keeping the list readable in
+            light mode. */}
         {park.backgroundImage && (
-          <div className="pointer-events-none absolute top-0 left-1/2 z-0 h-56 w-screen -translate-x-1/2 overflow-hidden sm:h-64">
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-0 h-56 overflow-hidden sm:h-64">
             <BackgroundOverlayImage
               imageSrc={park.backgroundImage}
               alt={stripNewPrefix(park.name)}
@@ -223,7 +229,7 @@ export function NearbyParksCard({ className }: { className?: string }) {
           </div>
         )}
 
-        <div className="relative z-10">
+        <div className="relative z-10 container mx-auto px-4">
           <h2 className="mb-6 flex items-center gap-2 text-xl font-bold">
             <MapPin className="text-park-primary h-5 w-5" />
             {t('youAreInPark', { parkName: stripNewPrefix(park.name) })}

--- a/components/parks/nearby-parks-card.tsx
+++ b/components/parks/nearby-parks-card.tsx
@@ -206,15 +206,18 @@ export function NearbyParksCard({ className }: { className?: string }) {
     const parkMapUrl = parkPageUrl && attractions.length > 0 ? `${parkPageUrl}#map` : parkPageUrl;
 
     return (
-      <section className={cn('bg-park-primary/5 relative overflow-hidden py-6', className)}>
-        {/* Background image: confined to the header band and faded to the section background
-            so it never bleeds through the attractions list (kept it readable in light mode,
-            where the previous full-height overlay showed the image between the frosted rows). */}
+      <section className={cn('bg-park-primary/5 relative py-6', className)}>
+        {/* Background image: breaks out to the full viewport width (the card sits inside a
+            centered container) and is confined to the header band, faded to the section
+            background so it never bleeds through the attractions list — keeping the list
+            readable in light mode. `left-1/2 -translate-x-1/2 w-screen` is the full-bleed
+            trick; body has `overflow-x: clip` so this adds no horizontal scrollbar. */}
         {park.backgroundImage && (
-          <div className="pointer-events-none absolute inset-x-0 top-0 z-0 h-56 overflow-hidden sm:h-64">
+          <div className="pointer-events-none absolute top-0 left-1/2 z-0 h-56 w-screen -translate-x-1/2 overflow-hidden sm:h-64">
             <BackgroundOverlayImage
               imageSrc={park.backgroundImage}
               alt={stripNewPrefix(park.name)}
+              sizes="100vw"
             />
             <div className="from-background/10 via-background/50 to-background absolute inset-0 bg-gradient-to-b" />
           </div>

--- a/components/parks/nearby-parks-card.tsx
+++ b/components/parks/nearby-parks-card.tsx
@@ -6,7 +6,7 @@ import { MapPin, Navigation, Clock, TrendingUp, ChevronRight } from 'lucide-reac
 import { Link } from '@/i18n/navigation';
 import { ParkCard } from '@/components/parks/park-card';
 import { NearbyParksCardSkeleton } from '@/components/parks/nearby-parks-card-skeleton';
-import { BackgroundOverlay } from '@/components/common/background-overlay';
+import { BackgroundOverlayImage } from '@/components/common/background-overlay-image';
 import { FavoriteStar } from '@/components/common/favorite-star';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -207,13 +207,17 @@ export function NearbyParksCard({ className }: { className?: string }) {
 
     return (
       <section className={cn('bg-park-primary/5 relative overflow-hidden py-6', className)}>
-        {/* Background Image */}
+        {/* Background image: confined to the header band and faded to the section background
+            so it never bleeds through the attractions list (kept it readable in light mode,
+            where the previous full-height overlay showed the image between the frosted rows). */}
         {park.backgroundImage && (
-          <BackgroundOverlay
-            imageSrc={park.backgroundImage}
-            alt={stripNewPrefix(park.name)}
-            intensity="medium"
-          />
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-0 h-56 overflow-hidden sm:h-64">
+            <BackgroundOverlayImage
+              imageSrc={park.backgroundImage}
+              alt={stripNewPrefix(park.name)}
+            />
+            <div className="from-background/10 via-background/50 to-background absolute inset-0 bg-gradient-to-b" />
+          </div>
         )}
 
         <div className="relative z-10">

--- a/components/parks/park-status.tsx
+++ b/components/parks/park-status.tsx
@@ -127,7 +127,10 @@ export function ParkStatus({ park, variant, className, midSlot }: ParkStatusProp
                         </span>
                       </div>
                       <Progress
-                        value={occupancy.current}
+                        // occupancy.current is relative to the 90th-percentile baseline and can
+                        // exceed 100 (e.g. 204% on an extreme day); clamp so the bar fills instead
+                        // of overflowing its track (translateX would push it out for >100).
+                        value={Math.min(100, Math.max(0, occupancy.current))}
                         className="h-2"
                         aria-label={t('occupancy')}
                       />

--- a/docs/api/nearby-in-park-shows-headliners.md
+++ b/docs/api/nearby-in-park-shows-headliners.md
@@ -1,0 +1,116 @@
+# Backend-Anweisung: Shows & Headliner in die `nearby` / `in_park`-Antwort aufnehmen
+
+> Ziel: Das Frontend soll auf der Startseite (Ansicht „Du bist im {Park}") neben
+> den nächsten Attraktionen (`rides`) auch die **nächste Show** und die
+> **Headliner** mit Entfernung anzeigen — **ohne** dafür einen zusätzlichen
+> Park-Detail-Call zu machen. Beides soll direkt aus dem bestehenden
+> `GET /v1/discovery/nearby`-Response (`type: "in_park"`) kommen.
+
+## Aktueller Stand (Backend)
+
+- Endpoint: `GET /v1/discovery/nearby` → `LocationController` (`src/location/location.controller.ts`),
+  Logik in `src/location/location.service.ts`.
+- `in_park`-Antwort heute:
+
+```jsonc
+{
+  "type": "in_park",
+  "userLocation": { "latitude": 50.8, "longitude": 6.87 },
+  "data": {
+    "park": { "id", "name", "slug", "distance", "status", "analytics", ... },
+    "rides": [
+      { "id", "name", "slug", "distance", "waitTime", "status", "analytics", "url" }
+    ]
+  }
+}
+```
+
+- `rides` werden aus der `attractions`-Tabelle geladen und bekommen die Distanz
+  zum User per Haversine (User-Koordinaten ↔ Attraktions-Koordinaten).
+- Shows liegen in `src/shows` (Entity + Service) und tragen `latitude/longitude`
+  sowie `showtimes`. Headliner werden heute nur am Park-Detail als
+  `ropeDropHeadliners` (`ParkWithAttractions`) geliefert.
+
+## Gewünschte Erweiterung
+
+Die `in_park`-`data` um **zwei additive Felder** ergänzen (keine Breaking
+Changes — bestehende Felder bleiben unverändert):
+
+```jsonc
+"data": {
+  "park":  { ... },
+  "rides": [ ... ],
+  "shows": [ /* NEU */ ],
+  "headliners": [ /* NEU */ ]
+}
+```
+
+### 1. `shows: ShowWithDistanceDto[]`
+
+Analog zu `rides`: alle Shows des Parks, mit Distanz zum User, nach Distanz
+aufsteigend sortiert.
+
+| Feld                  | Typ                          | Hinweis                                                            |
+| --------------------- | ---------------------------- | ----------------------------------------------------------------- |
+| `id`                  | `string`                     |                                                                   |
+| `name`                | `string`                     |                                                                   |
+| `slug`                | `string`                     |                                                                   |
+| `distance`            | `number`                     | Meter, Haversine User ↔ Show-Koordinaten                          |
+| `status`              | `string`                     | `OPERATING` / `CLOSED` / …                                        |
+| `showtimes`           | `{ startTime: string }[]`    | **heutige** Showtimes, ISO 8601 **mit Offset** (z. B. `+02:00`)   |
+| `url`                 | `string`                     | API-URL, z. B. `/v1/parks/<…>/shows/<slug>`                       |
+| `isSeasonal`          | `boolean` (optional)         | wie bei Park-Detail                                                |
+| `seasonMonths`        | `number[] \| null` (opt.)    | Monate 1–12; `null` = saisonal, Monate unbekannt                  |
+| `isCurrentlyInSeason` | `boolean \| null` (opt.)     |                                                                   |
+
+Umsetzung: Im `in_park`-Zweig des `LocationService` zusätzlich die Shows des
+erkannten Parks laden (Show-Repository, `parkId = park.id`), Distanz wie bei den
+Rides berechnen, heutige `showtimes` mitgeben, nach `distance` sortieren.
+Off-Season-Shows können enthalten bleiben (Flags mitliefern) — das Frontend
+entscheidet über die Darstellung.
+
+> Das Frontend berechnet die „nächste Show" selbst aus `showtimes[].startTime`
+> (nächster Eintrag in der Zukunft). Wichtig ist nur, dass die **heutigen**
+> Showtimes mit korrektem Zeitzonen-Offset geliefert werden.
+
+### 2. `headliners: HeadlinerWithDistanceDto[]`
+
+Die Headliner des Parks (dieselben, die am Park-Detail als
+`ropeDropHeadliners` bestimmt werden) — mit Distanz zum User, nach Distanz
+aufsteigend sortiert.
+
+| Feld         | Typ                       | Hinweis                                         |
+| ------------ | ------------------------- | ----------------------------------------------- |
+| `id`         | `string`                  |                                                 |
+| `name`       | `string`                  |                                                 |
+| `slug`       | `string`                  |                                                 |
+| `distance`   | `number`                  | Meter, Haversine User ↔ Attraktions-Koordinaten |
+| `status`     | `string`                  | `OPERATING` / `CLOSED` / …                      |
+| `waitTime`   | `number \| null`          | aktuelle Wartezeit                              |
+| `crowdLevel` | `string \| null` (opt.)   | falls vorhanden                                 |
+| `url`        | `string`                  | API-URL der Attraktion                          |
+| `worth`      | `boolean` (optional)      | aus Rope-Drop-Logik, falls vorhanden            |
+| `minutesSaved` | `number` (optional)     | aus Rope-Drop-Logik, falls vorhanden            |
+
+Umsetzung: Die vorhandene Headliner-/Rope-Drop-Bestimmung wiederverwenden, die
+Treffer mit der bereits geladenen Rides-Distanz anreichern (gleiche
+Attraktions-Koordinaten) und als eigenes Array zurückgeben. Headliner dürfen
+sich mit `rides` überschneiden — das Frontend nutzt zwei getrennte Listen.
+
+## Sonstiges
+
+- **Additiv & rückwärtskompatibel**: Felder nur hinzufügen, nichts umbenennen.
+- **Swagger/OpenAPI**: `ShowWithDistanceDto` und `HeadlinerWithDistanceDto`
+  ergänzen und im `in_park`-Response-DTO referenzieren.
+- **Tests**: `src/location/location.service.spec.ts` um Fälle für `shows`
+  (inkl. heutiger Showtimes / Sortierung) und `headliners` erweitern.
+- **Radius**: Shows/Headliner gehören zum erkannten Park — nicht über den
+  Rides-Radius hinaus filtern, damit auch ein etwas weiter entfernter
+  Showplatz/Headliner im Park enthalten ist.
+
+## Frontend-Vertrag (zur Abstimmung)
+
+Sobald die Felder live sind, konsumiert das Frontend sie 1:1 in
+`types/nearby.ts` (`NearbyAttractionsData` → `shows`, `headliners`) und rendert
+in `components/parks/nearby-parks-card.tsx` über der `rides`-Liste:
+„Nächste Show" und die Headliner-Liste mit Entfernung.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "validate:translations": "node scripts/validate-translations.js",
-    "test:calendar": "node --experimental-strip-types scripts/test-calendar-utils.mjs",
+    "test:calendar": "node --experimental-strip-types --import ./scripts/register-path-alias.mjs scripts/test-calendar-utils.mjs",
     "probe:isr": "node scripts/isr-cache-probe.mjs",
     "crawl:translations": "node scripts/crawl-translations.js",
     "crawl:translations:live": "node scripts/crawl-translations.js --live",

--- a/scripts/path-alias-hooks.mjs
+++ b/scripts/path-alias-hooks.mjs
@@ -1,0 +1,33 @@
+// ESM resolve hook: map the `@/*` tsconfig path alias to the project root so the
+// standalone `node --experimental-strip-types` test scripts can import app modules
+// (e.g. `@/lib/utils`) the same way the Next.js app does. No runtime dependencies.
+import { existsSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const projectRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// Mirrors TypeScript/Next module resolution order (file wins over directory).
+const SUFFIXES = [
+  '.ts',
+  '.tsx',
+  '.mjs',
+  '.cjs',
+  '.js',
+  '.json',
+  '/index.ts',
+  '/index.tsx',
+  '/index.js',
+];
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith('@/')) {
+    const base = join(projectRoot, specifier.slice(2));
+    for (const candidate of [base, ...SUFFIXES.map((s) => base + s)]) {
+      if (existsSync(candidate) && statSync(candidate).isFile()) {
+        return nextResolve(pathToFileURL(candidate).href, context);
+      }
+    }
+  }
+  return nextResolve(specifier, context);
+}

--- a/scripts/register-path-alias.mjs
+++ b/scripts/register-path-alias.mjs
@@ -1,0 +1,5 @@
+// Registers the `@/*` path-alias resolve hook for standalone node test scripts.
+// Used via `node --import ./scripts/register-path-alias.mjs ...`.
+import { register } from 'node:module';
+
+register('./path-alias-hooks.mjs', import.meta.url);


### PR DESCRIPTION
## Summary

Improves the "Du bist im {park}" (in-park) view of the nearby card on the homepage:

- **Sort rides by distance** — the "Attraktionen in deiner Nähe" list is now sorted by distance (nearest first) before being limited to 5. The API order isn't guaranteed, so this is enforced client-side.
- **Mobile-friendly "Zur Park-Seite" button** — the CTA now uses the `Button asChild` pattern wrapping the `Link` instead of nesting a `Button` inside an inline `<a>`. This gives a single, reliable full-width tap target on mobile (`w-full`) and auto width on desktop (`sm:w-auto`), with the chevron placed after the label to indicate forward navigation.

## Changes
- `components/parks/nearby-parks-card.tsx` (`in_park` branch)

## Verification
- `tsc --noEmit` — no new errors in the changed file
- `eslint` — clean

https://claude.ai/code/session_01AfadYonwTq2g8MAhAUZsNm

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfadYonwTq2g8MAhAUZsNm)_