### PR TITLE
perf(park): render attraction grid once + fix Web Vitals INP attribution

### DIFF
--- a/components/analytics/web-vitals-reporter.tsx
+++ b/components/analytics/web-vitals-reporter.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useReportWebVitals } from 'next/web-vitals';
+import { useEffect } from 'react';
+import { onINP, onLCP, onCLS, onTTFB, onFCP } from 'web-vitals/attribution';
 import { trackEvent } from '@/lib/analytics/umami';
 
 /**
  * Reports Core Web Vitals **with attribution** to Umami so the slow interaction behind a poor
  * INP can be identified in the field (Google only gives the aggregate). INP is the current
- * problem child (>200ms mobile on the homepage); LCP/CLS are reported too for context.
+ * problem child (>200ms mobile on big park pages); LCP/CLS are reported too for context.
  *
  * TTFB + FCP are also reported: with the streamed homepage shell, TTFB is the server time
  * before the first byte and FCP splits that server wait (timeToFirstByte) from the client
@@ -14,13 +15,16 @@ import { trackEvent } from '@/lib/analytics/umami';
  * or a client problem. CLS attribution (`largestShiftTarget`) surfaces the element that
  * shifts most, so the Suspense skeleton fit can be validated in the field.
  *
- * Uses Next's built-in `useReportWebVitals` (Next bundles `web-vitals` — no extra dependency).
- * `metric.attribution` is populated because `experimental.webVitalsAttribution` is enabled in
- * `next.config.ts`. For INP, `interactionTarget` is the CSS selector of the element and the
- * delay breakdown (input → processing → presentation) tells us which phase to fix.
+ * IMPORTANT: this imports the `web-vitals/attribution` build **directly** rather than going
+ * through Next's `useReportWebVitals`. In Next 16, `useReportWebVitals` imports the plain
+ * (non-attribution) `web-vitals` build and `experimental.webVitalsAttribution` does NOT wire
+ * attribution into it (the flag's env vars are defined but never consumed, and there's no
+ * module alias) — so `metric.attribution` arrived `undefined` and every phase reported as 0.
+ * Importing `web-vitals/attribution` ourselves makes the breakdown bundler-independent.
+ * For INP, `interactionTarget` is the CSS selector of the element and the delay breakdown
+ * (input → processing → presentation) tells us which phase to fix.
  *
- * The callback is module-scoped (stable reference) per the Next docs, so it isn't
- * re-registered on every render.
+ * The callback is module-scoped (stable reference) so it isn't re-created on every render.
  */
 const stripLocale = (p: string) => p.replace(/^\/(en|de|fr|it|nl|es)(?=\/|$)/, '') || '/';
 
@@ -107,6 +111,14 @@ function reportWebVital(metric: {
 }
 
 export function WebVitalsReporter() {
-  useReportWebVitals(reportWebVital);
+  useEffect(() => {
+    // Each onX registers a passive observer and fires reportWebVital with the metric (incl.
+    // attribution). INP/LCP/CLS report their final value on page-hide by default, matching CrUX.
+    onINP(reportWebVital);
+    onLCP(reportWebVital);
+    onCLS(reportWebVital);
+    onTTFB(reportWebVital);
+    onFCP(reportWebVital);
+  }, []);
   return null;
 }

--- a/components/parks/live-park-data.tsx
+++ b/components/parks/live-park-data.tsx
@@ -137,15 +137,20 @@ export function LiveParkData({
         )}
       </div>
 
-      {/* Park Status Component — on mobile receives the tabs between WaitTime and Attractions */}
-      <ParkStatus park={currentPark} variant="detailed" midSlot={tabsWithHash} />
-
-      {bestDaysSlot}
-
-      <Separator className="my-8" />
-
-      {/* Tabs on desktop (hidden on mobile — already shown inside ParkStatus grid) */}
-      <div className="hidden sm:block">{tabsWithHash}</div>
+      {/* Status, ride-list tabs and best-days are laid out in ONE flex column and reordered per
+          breakpoint via `order`, so the heavy <TabsWithHash> (the full attraction grid for big
+          parks) is rendered + hydrated EXACTLY ONCE. It used to be mounted twice — a mobile copy
+          inside ParkStatus and a `hidden sm:block` desktop copy — and `display:none` does not skip
+          hydration, so every park page paid double the hydration/re-render cost (the dominant
+          mobile-INP source on large parks like PortAventura). `gap-8` gives uniform spacing.
+            mobile : status → tabs → best-days
+            desktop: status → best-days → separator → tabs */}
+      <div className="flex flex-col gap-8">
+        <ParkStatus park={currentPark} variant="detailed" className="order-1" />
+        <div className="order-2 sm:order-4">{tabsWithHash}</div>
+        {bestDaysSlot && <div className="order-3 sm:order-2">{bestDaysSlot}</div>}
+        <Separator className="order-3 hidden sm:block" />
+      </div>
     </>
   );
 }

--- a/components/parks/park-status.tsx
+++ b/components/parks/park-status.tsx
@@ -17,11 +17,9 @@ interface ParkStatusProps {
   park: ParkData;
   variant: 'compact' | 'detailed' | 'card' | 'hero';
   className?: string;
-  /** Inserted between the WaitTime card and Attractions card in the detailed grid, mobile only. */
-  midSlot?: React.ReactNode;
 }
 
-export function ParkStatus({ park, variant, className, midSlot }: ParkStatusProps) {
+export function ParkStatus({ park, variant, className }: ParkStatusProps) {
   const analytics = 'analytics' in park ? park.analytics : null;
   const currentLoad = 'currentLoad' in park ? park.currentLoad : null;
   const status = 'status' in park ? park.status : undefined;
@@ -267,11 +265,6 @@ export function ParkStatus({ park, variant, className, midSlot }: ParkStatusProp
             )}
           </div>
         )}
-
-        {/* Ride list (tabs) on mobile — rendered for EVERY status, incl. closed parks (where the
-            open-parks stats grid above isn't rendered at all). Desktop shows the tabs via a
-            separate `hidden sm:block` block in LiveParkData, so this is mobile-only. */}
-        {midSlot && <div className="sm:hidden">{midSlot}</div>}
       </div>
     );
   }

--- a/next.config.ts
+++ b/next.config.ts
@@ -42,10 +42,10 @@ const nextConfig: NextConfig = {
     ],
     // Optimize CSS to reduce render-blocking
     optimizeCss: true,
-    // Surface attribution on Web Vitals (metric.attribution) so the RUM reporter can pin
-    // the exact element/interaction behind a poor INP/LCP/CLS — e.g. the homepage INP>200ms.
-    // TTFB/FCP attribution splits server wait vs client paint to track the streaming win.
-    webVitalsAttribution: ['INP', 'LCP', 'CLS', 'TTFB', 'FCP'],
+    // NOTE: no `webVitalsAttribution` here. In Next 16 it does not wire attribution into
+    // `useReportWebVitals` (the flag's env vars are defined but never consumed). The RUM
+    // reporter imports `web-vitals/attribution` directly instead — see
+    // components/analytics/web-vitals-reporter.tsx.
   },
   images: {
     formats: ['image/avif', 'image/webp'],

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "tailwind-merge": "^3.6.0",
     "tippy.js": "^6.3.7",
     "tiptap-markdown": "^0.9.0",
+    "web-vitals": "^4.2.4",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       tiptap-markdown:
         specifier: ^0.9.0
         version: 0.9.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      web-vitals:
+        specifier: ^4.2.4
+        version: 4.2.4
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3830,6 +3833,9 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  web-vitals@4.2.4:
+    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
+
   webpack-bundle-analyzer@4.10.1:
     resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
     engines: {node: '>= 10.13.0'}
@@ -5881,7 +5887,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.4.1(jiti@2.7.0))
@@ -5908,7 +5914,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5923,14 +5929,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -5945,7 +5951,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -7873,6 +7879,8 @@ snapshots:
       vfile-message: 4.0.3
 
   w3c-keyname@2.2.8: {}
+
+  web-vitals@4.2.4: {}
 
   webpack-bundle-analyzer@4.10.1:
     dependencies:


### PR DESCRIPTION
## Why

Investigating Search Console "duplicate content" turned into a Core Web Vitals deep-dive. The failing metric is **INP on mobile**, and field data (Umami RUM) pinned it to **large park pages** — PortAventura **1.32 s**, Tokyo Disneyland Goofy's **1.20 s**, Phantasialand **0.89 s**, Europa-Park **0.47 s**. The traffic-weighted aggregate p75 (144 ms, "good") hides this because Search Console rates each URL group separately. INP scales with the number of attractions on the page → it's a hydration / re-render cost problem, not a loading one (which is why the earlier LCP/FCP/TTFB work didn't move it).

## Changes

**1. Render the attraction grid exactly once**

`<TabsWithHash>` (the full per-land ride grid + search + Fuse index) was mounted **twice** on every park page:
- a mobile copy inside `ParkStatus` (`sm:hidden`)
- a desktop copy (`hidden sm:block`)

`display:none` does **not** skip hydration, so every park page paid:
- double hydration of the whole grid (the dominant mobile-INP cost on big parks),
- two Fuse.js index builds,
- duplicate global `keydown`/`hashchange` listeners (extra input delay per keystroke),
- a full re-render of **both** trees on every 5-minute live poll.

Status, tabs and best-days now live in **one flex column**, reordered per breakpoint via `order` (`mobile: status → tabs → best-days`, `desktop: status → best-days → separator → tabs`), so the grid renders + hydrates **once**. The now-unused `ParkStatus` `midSlot` prop was removed. As a side benefit, tab state is no longer duplicated across two instances.

**2. Fix empty Web Vitals INP attribution**

The RUM reporter sent `inputDelay` / `processingDuration` / `presentationDelay` as **all 0** while `value` was 80–416 ms — impossible, since INP is their sum. Root cause: in **Next 16**, `useReportWebVitals` imports the **non-attribution** `web-vitals` build, and `experimental.webVitalsAttribution` is never wired into it (its env flags are defined but never consumed, no module alias). So `metric.attribution` was always `undefined`.

Fix: import `web-vitals/attribution` **directly** (added `web-vitals@^4.2.4`), which is bundler-independent. The reporter's field mapping is unchanged; the dead `webVitalsAttribution` flag was removed from `next.config.ts`. Future INP debugging can now use the phase breakdown in Umami (Events → `web-vital-inp` → Properties).

## Verification

- `tsc --noEmit`: no errors in the changed files.
- `eslint` on the three changed components: clean.
- ⚠️ Layout change (flex `order` restructure) not yet visually verified in a browser — spacing is now a uniform `gap-8`; worth a quick manual check at mobile + desktop breakpoints.

## Follow-ups (not in this PR)

- After this ships, re-check the Umami INP phase breakdown to decide whether to also (a) hydrate only the live badges as islands instead of the whole grid, or (b) decouple the 5-min poll re-render from the full tree.
- Allow ~4 weeks for CrUX/Search Console (28-day rolling p75) to reflect the change.

https://claude.ai/code/session_01J7kU7UJjVEPjPJkksW7ehT

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7kU7UJjVEPjPJkksW7ehT)_